### PR TITLE
Basic docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# ramenctl contribution guide
+
+We accept contributions via GitHub pull requests. This document outlines
+some of the conventions related to development workflow to make it
+easier to get your contribution accepted.
+
+## Getting Started
+
+1. Fork this repository on GitHub
+1. Run the tests
+1. Play with the *ramenctl* tool
+1. Open issues, create pull requests
+
+## Contribution Flow
+
+This is a rough outline of what a contributor's workflow looks like:
+
+1. Create a branch from where you want to base your work (usually main).
+1. Make your changes, keeping every commit focused on one logical
+   change.
+1. Make sure your commit messages are in the proper format (see below).
+1. Push your changes to the branch in your fork of the repository.
+1. Make sure all tests pass, and add any new tests as appropriate.
+1. Create a pull request in the original repository.
+
+## Commit message
+
+We follow a rough convention for commit messages that is designed to
+answer two questions: what changed and why. The subject line should
+feature the what and the body of the commit should describe the why.
+
+```
+commands/test: Initial implementation
+
+A minimal implementation of `ramenctl test` working on with ramen
+testing environment. We use the ramen/e2e[1] module to deploy a workload
+and perform a complete DR flow. This can be used to verify that a
+cluster is working properly.
+
+[1] https://github.com/RamenDR/ramen/tree/main/e2e
+```
+
+The first line is the subject and should be no longer than 70
+characters, the second line is always blank, and other lines should be
+wrapped at 80 characters.  This allows the message to be easier to read
+on GitHub as well as in various git tools.
+
+## Certificate of Origin
+
+By contributing to this project you agree to the Developer Certificate
+of Origin (DCO). This document was created by the Linux Kernel community
+and is a simple statement that you, as a contributor, have the legal
+right to make the contribution. See the [DCO](DCO) file for details.
+
+Contributors sign-off that they adhere to these requirements by adding a
+Signed-off-by line to commit messages. For example:
+
+```
+This is my commit message
+
+Signed-off-by: My Name <myname@example.org>
+```
+
+You can append this automatically to the commit message using:
+
+```console
+git commit -s
+```
+
+If you have already made a commit and forgot to include the sign-off,
+you can amend your last commit to add the sign-off using:
+
+```console
+git commit --amend -s
+```
+
+## Coding Style
+
+The *ramenctl* project is written in Go programming language and follows
+the style guidelines dictated by the go fmt as well as go vet tools.

--- a/DCO
+++ b/DCO
@@ -1,0 +1,36 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ramenctl
-Go module and command line tool for managing  troubleshooting Ramen
+
+Command line tool and Go module for managing and troubleshooting Ramen.
+
+## Overview
+
+Working with a complicated Kubernetes cluster is not easy.  In a typical
+disaster recovery environment we have at least 3 connected Kubernetes
+clusters with many components. The *ramenctl* project aims to make it
+easier to manage and troubleshoot this challenging environment.
+
+## Features
+
+The project will provides:
+
+- The *ramenctl* command line tool.
+- The *ramenctl* Go module for integrating the commands in other
+  projects.
+
+## Status
+
+The project is in early development.
+
+## Contributing
+
+- For reporting bugs, suggesting improvements, or requesting new
+  features, please open an
+  [issue](https://github.com/RamenDR/ramenctl/issues).
+- For implementing features or fixing bugs, please see the
+  [ramenctl contribution guide](CONTRIBUTING.md)
+
+## License
+
+*ramenctl* is under the [Apache 2.0 license](LICENSE).


### PR DESCRIPTION
- Add more content to README.md
- Add CONTRIBUTING.md
- Add DCO

The documents are derived from kubectl-rook-ceph[1] and ramen[2].

[1] https://github.com/rook/kubectl-rook-ceph
[2] https://github.com/RamenDR/ramen

Fixes: #1