### PR TITLE
Add basic command infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Artifacts
+/ramenctl
+/examples/odf
+/config.yaml
+
+# Editor files
+/.zed

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+.PHONY: ramenctl examples
+
+all: ramenctl examples
+
+ramenctl:
+	go build -o $@ cmd/main.go
+
+examples:
+	go build -o examples/odf examples/odf.go
+
+clean:
+	rm -f ramenctl examples/odf

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/spf13/cobra"
+)
+
+var InitCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Create configuration file for your clusters",
+	Run: func(c *cobra.Command, args []string) {
+		if err := config.CreateSampleConfig(configFile, RootCmd.DisplayName()); err != nil {
+			console.Fatal(err)
+		}
+
+		console.Completed("Created config file %q - please modify for your clusters", configFile)
+	},
+}

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	// configFile is shared by all commands, enabling access to all clusters.
+	configFile string
+
+	// userOutputDir is used by troubleshooting commands for creating a report.
+	userOutputDir string
+)
+
+var RootCmd = &cobra.Command{
+	Use:   "ramenctl",
+	Short: "Manage and troubleshoot Ramen",
+
+	// When used as a subcommand in another tool, don't inherit persistent pre run commands.
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+}
+
+func init() {
+	// These flags are used by all sub commands.
+	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yaml", "configuration file")
+}
+
+func addOutputFlag(c *cobra.Command) {
+	// The actual output directory is known only when running the command.
+	c.PersistentFlags().StringVarP(&userOutputDir, "output", "o", "", "report directory (default report.{timestamp})")
+}
+
+func outputDir() string {
+	if userOutputDir == "" {
+		return time.Now().Format("report.20060102150405")
+	}
+	return userOutputDir
+}

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/test"
+	"github.com/spf13/cobra"
+)
+
+var TestCmd = &cobra.Command{
+	Use:   "test",
+	Short: "Test disaster recovery flow in your clusters",
+}
+
+var TestRunCmd = &cobra.Command{
+	Use:   "run",
+	Short: "Run disaster recovery flow",
+	Run: func(c *cobra.Command, args []string) {
+		if err := test.Run(outputDir()); err != nil {
+			console.Fatal(err)
+		}
+		console.Completed("Test run completed successfully")
+	},
+}
+
+var TestCleanCmd = &cobra.Command{
+	Use:   "clean",
+	Short: "Delete test artifacts",
+	Run: func(c *cobra.Command, args []string) {
+		if err := test.Clean(outputDir()); err != nil {
+			console.Fatal(err)
+		}
+		console.Completed("Test cleanup completed successfully")
+	},
+}
+
+func init() {
+	addOutputFlag(TestCmd)
+	TestCmd.AddCommand(TestRunCmd, TestCleanCmd)
+}

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/validate"
+	"github.com/spf13/cobra"
+)
+
+var ValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Validate disaster recovery configuration",
+}
+
+var ValidateClustersCmd = &cobra.Command{
+	Use:   "clusters",
+	Short: "Validate clusters configuration",
+	Run: func(c *cobra.Command, args []string) {
+		if err := validate.Clusters(outputDir()); err != nil {
+			console.Fatal(err)
+		}
+		console.Completed("Validation completed successfully")
+	},
+}
+
+func init() {
+	addOutputFlag(ValidateCmd)
+	ValidateCmd.AddCommand(ValidateClustersCmd)
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os"
+
+	"github.com/ramendr/ramenctl/cmd/commands"
+)
+
+func main() {
+	// We add the sub commands here so other project can use the same root command with a subset of ramenctl commands.
+	commands.RootCmd.AddCommand(
+		commands.InitCmd,
+		commands.TestCmd,
+		commands.ValidateCmd,
+	)
+
+	err := commands.RootCmd.Execute()
+	if err != nil {
+		// When root command fails cobra already logged this error.
+		os.Exit(1)
+	}
+}

--- a/examples/odf.go
+++ b/examples/odf.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+// Example for integrating a subset of ramenctl commamds as "odf dr" sub command.
+package main
+
+import (
+	"log"
+
+	dr "github.com/ramendr/ramenctl/cmd/commands"
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "odf",
+	Short: "Testing odf cli integration",
+
+	// Not clear why odf is using this flag.
+	TraverseChildren: true,
+
+	// odf uses this to create k8s clients and validate the cluster. For ramenctl this is not relevant since we work on
+	// multiple clusers that may or may not have odf installed.
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		log.Print("odf sub command pre-run")
+	},
+}
+
+var fooCmd = &cobra.Command{
+	Use:   "foo",
+	Short: "Top level odf cli command",
+	Run: func(c *cobra.Command, args []string) {
+		log.Print("odf foo sub command")
+	},
+}
+
+func init() {
+	// This persistent flag is not relevant to the "odf dr" sub command so it should not be inherited by it. There seems
+	// to be no way to avoid this inheritance now, so it will be need to change in odf.
+	rootCmd.PersistentFlags().String("context", "", "kubectl context")
+}
+
+func main() {
+	// Adapt ramenctl root command to the odf.
+	dr.RootCmd.Use = "dr"
+	dr.RootCmd.Short = "Troubleshoot OpenShift DR"
+
+	// Add a subset of ramenctl command as the "odf dr" subcommand.
+	dr.RootCmd.AddCommand(dr.InitCmd, dr.TestCmd, dr.ValidateCmd)
+
+	rootCmd.AddCommand(fooCmd, dr.RootCmd)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		// odf uses its own logging infrastructure.
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,14 @@
+module github.com/ramendr/ramenctl
+
+// Match kubectl-rook-ceph
+go 1.23.0
+
+// Match kubectl-rook-ceph
+toolchain go1.23.4
+
+require github.com/spf13/cobra v1.9.1
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.6 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
+github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+var sampleConfig = `# %s configuration file
+---
+# Sample cluster configurations:
+# Uncomment and edit the following lines to provide the kubeconfig paths
+# for your clusters.
+# clusters:
+#   hub:
+#     kubeconfigpath: /kubeconfigs/hub
+#   c1:
+#     kubeconfigpath: /kubeconfigs/c1
+#   c2:
+#     kubeconfigpath: /kubeconfigs/c2
+
+# List of PVC specifications for workloads.
+# These define storage configurations, such as 'storageClassName' and
+# 'accessModes', and are used to kustomize workloads.
+pvcspecs:
+- name: rbd
+  storageclassname: rook-ceph-block
+  accessmodes: ReadWriteOnce
+- name: cephfs
+  storageclassname: rook-cephfs-fs1
+  accessmodes: ReadWriteMany
+`
+
+func CreateSampleConfig(filename, creator string) error {
+	content := fmt.Sprintf(sampleConfig, creator)
+	if err := createFile(filename, []byte(content)); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("configuration file %q already exists", filename)
+		}
+		return fmt.Errorf("failed to create %q: %w", filename, err)
+	}
+	return nil
+}
+
+func createFile(name string, content []byte) error {
+	f, err := os.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Write(content); err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package console
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// TODO: Measure actual console and update when window size changes
+var width = 80
+
+func Info(format string, args ...any) {
+	fmt.Printf("⭐ "+format+"\n", args...)
+}
+
+func Progress(format string, args ...any) {
+	line := fmt.Sprintf("👀 "+format+" ...", args...)
+	fmt.Print(pad(line), "\r")
+}
+
+func Completed(format string, args ...any) {
+	line := fmt.Sprintf("✅ "+format, args...)
+	fmt.Print(pad(line), "\n")
+}
+
+func Fatal(err error) {
+	fmt.Fprintf(os.Stderr, "❌ %s\n", err)
+	os.Exit(1)
+}
+
+// pad string to console width, leaving room for the line terminator.
+func pad(s string) string {
+	if len(s) < width-1 {
+		return s + strings.Repeat(" ", width-len(s)-1)
+	}
+	return s
+}

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"time"
+
+	"github.com/ramendr/ramenctl/pkg/console"
+)
+
+func Clean(outputDir string) error {
+	hub := "hub"
+	primary := "dr1"
+	secondary := "dr2"
+
+	console.Info("Using report %q", outputDir)
+
+	console.Progress("Cleaning up cluster %q", primary)
+	time.Sleep(2 * time.Second)
+	console.Completed("Cluster %q cleaned", primary)
+
+	console.Progress("Cleaning up cluster %q", secondary)
+	time.Sleep(2 * time.Second)
+	console.Completed("Cluster %q cleaned", secondary)
+
+	console.Progress("Cleaning up cluster %q", hub)
+	time.Sleep(2 * time.Second)
+	console.Completed("Cluster %q cleaned", hub)
+
+	return nil
+}

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"time"
+
+	"github.com/ramendr/ramenctl/pkg/console"
+)
+
+func Run(outputDir string) error {
+	app := "ramenctl-test-app"
+	primary := "dr1"
+	secondary := "dr2"
+
+	console.Info("Using report %q", outputDir)
+
+	console.Progress("Deploying application %q on cluster %q", app, primary)
+	time.Sleep(2 * time.Second)
+	console.Completed("Application %q deployed on cluster %q", app, primary)
+
+	console.Progress("Protecting application %q in cluster %q", app, primary)
+	time.Sleep(5 * time.Second)
+	console.Completed("Application %q protected in cluster %q", app, primary)
+
+	console.Progress("Failing over application %q to cluster %q", app, secondary)
+	time.Sleep(10 * time.Second)
+	console.Completed("Application %q failed over to cluster %q", app, secondary)
+
+	console.Progress("Unprotecting application %q in cluster %q", app, secondary)
+	time.Sleep(5 * time.Second)
+	console.Completed("Application %q unprotected in cluster %q", app, secondary)
+
+	console.Progress("Protecting application %q in cluster %q", app, secondary)
+	time.Sleep(5 * time.Second)
+	console.Completed("Application %q protected in cluster %q", app, secondary)
+
+	console.Progress("Relocating application %q to cluster %q", app, primary)
+	time.Sleep(10 * time.Second)
+	console.Completed("Application %q relocated to cluster %q", app, primary)
+
+	console.Progress("Unprotecting application %q in cluster %q", app, primary)
+	time.Sleep(5 * time.Second)
+	console.Completed("Application %q unprotected in cluster %q", app, primary)
+
+	console.Progress("Undeploying application %q from cluster %q", app, primary)
+	time.Sleep(2 * time.Second)
+	console.Completed("Application %q undeployed from cluster %q", app, primary)
+
+	return nil
+}

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validate
+
+import "github.com/ramendr/ramenctl/pkg/console"
+
+func Clusters(outputDir string) error {
+	console.Info("Using report %q", outputDir)
+	return nil
+}


### PR DESCRIPTION
Add ramenctl module, providing:                                                                                                                           

- cmd/main.go - the ramenctl command
- examples/odf.go - example of integrating in odf cli 
- cmd/commands - cobra command wrappers used by ramenctl. This is a
  separate package to allow easy integration with other tools such as
  odf cli.
- pkg/console - report progress, completion and errors to the console
- pkg/test - test stub implementation
- pkg/config - create sample configuration file
- pkg/validate - validate stub implementation

We follow the structure of the kubectl-rook-ceph project to make it easy
integrate with the odf cli project.

The command does not do much, but we can play with it to evaluate the user
experience.

Example usage:

    % make
    go build -o ramenctl cmd/main.go
    go build -o examples/odf examples/odf.go

    % ./ramenctl init
    ✅ Created config file "config.yaml" - please modify for your clusters

    % cat config.yaml
    # ramenctl configuration file
    --- 
    # Sample cluster configurations:
    # Uncomment and edit the following lines to provide the kubeconfig paths
    # for your clusters.
    # clusters:
    #   hub:
    #     kubeconfigpath: /kubeconfigs/hub
    #   c1: 
    #     kubeconfigpath: /kubeconfigs/c1
    #   c2: 
    #     kubeconfigpath: /kubeconfigs/c2
    ... 

    % ./ramenctl test run
    ⭐ Using report "report.20250227200509"
    ✅ Application "ramenctl-test-app" deployed on cluster "dr1"
    ✅ Application "ramenctl-test-app" protected in cluster "dr1"
    👀 Failing over application "ramenctl-test-app" to cluster "dr2" ...
    ...

    % ./ramenctl test clean
    ⭐ Using report "report.20250227200741"
    ✅ Cluster "dr1" cleaned
    ✅ Cluster "dr2" cleaned
    ✅ Cluster "hub" cleaned
    ✅ Test cleanup completed successfully

Example usage as odf dr sub command:

    % examples/odf dr -h
    Troubleshoot OpenShift DR

    Usage:
      odf dr [command]

    Available Commands:
      init        Create configuration file for your clusters
      test        Test disaster recovery flow in your clusters
      validate    Validate disaster recovery configuration

    Flags:
      -c, --config string   clusterset configuration file (default "config.yaml")
      -h, --help            help for dr

    Global Flags:
          --context string   kubectl context

    Use "odf dr [command] --help" for more information about a command.

    % examples/odf dr validate clusters
    ⭐ Using report "report.20250227201259"
    ✅ Validation completed successfully

Fixes #4 