### PR TITLE
Improve sample config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,22 +9,41 @@ import (
 	"os"
 )
 
-var sampleConfig = `# %s configuration file
----
-# Sample cluster configurations:
-# Uncomment and edit the following lines to provide the kubeconfig paths
-# for your clusters.
-# clusters:
-#   hub:
-#     kubeconfigpath: /kubeconfigs/hub
-#   c1:
-#     kubeconfigpath: /kubeconfigs/c1
-#   c2:
-#     kubeconfigpath: /kubeconfigs/c2
+var sampleConfig = `## %s configuration file
 
-# List of PVC specifications for workloads.
-# These define storage configurations, such as 'storageClassName' and
-# 'accessModes', and are used to kustomize workloads.
+## Clusters configuration.
+# - Modify clusters "kubeconfigpath" and "name" to match your hub and managed
+#   clusters names and path to the kubeconfig file.
+clusters:
+  hub:
+    name: hub
+    kubeconfigpath: hub/config
+  c1:
+    name: primary
+    kubeconfigpath: primary/config
+  c2:
+    name: secondary
+    kubeconfigpath: secondary/config
+
+## Git repository for test command.
+# - Modify "url" to use your own Git repository.
+# - Modify "branch" to test a different branch.
+repo:
+  url: https://github.com/RamenDR/ocm-ramen-samples.git
+  branch: main
+
+## DRPolicy for test command.
+# - Modify to match actual DRPolicy in the hub cluster.
+drpolicy: dr-policy
+
+## ClusterSet for test command".
+# - Modify to match your Open Cluster Management configuration.
+clusterset: default
+
+## PVC specifications for test command.
+# - Modify items "storageclassname" to match the actual storage classes in the
+#   managed clusters.
+# - Add new items for testing more storage types.
 pvcspecs:
 - name: rbd
   storageclassname: rook-ceph-block
@@ -32,6 +51,16 @@ pvcspecs:
 - name: cephfs
   storageclassname: rook-cephfs-fs1
   accessmodes: ReadWriteMany
+
+## Tests cases for test command.
+# - Modify the test for your preferred workload or deployment type.
+# - Add new tests for testing more combinations in parallel.
+# - Available workloads: deploy
+# - Available deployers: appset, subscr, disapp
+tests:
+- workload: deploy
+  deployer: appset
+  pvcspec: rbd
 `
 
 func CreateSampleConfig(filename, creator string) error {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,18 +14,18 @@ import (
 var sampleConfig = `## {{.CommandName}} configuration file
 
 ## Clusters configuration.
-# - Modify clusters "kubeconfigpath" and "name" to match your hub and managed
+# - Modify clusters "kubeconfig" and "name" to match your hub and managed
 #   clusters names and path to the kubeconfig file.
 clusters:
   hub:
     name: hub
-    kubeconfigpath: hub/config
+    kubeconfig: hub/config
   c1:
     name: primary
-    kubeconfigpath: primary/config
+    kubeconfig: primary/config
   c2:
     name: secondary
-    kubeconfigpath: secondary/config
+    kubeconfig: secondary/config
 
 ## Git repository for test command.
 # - Modify "url" to use your own Git repository.
@@ -36,23 +36,23 @@ repo:
 
 ## DRPolicy for test command.
 # - Modify to match actual DRPolicy in the hub cluster.
-drpolicy: dr-policy
+drPolicy: dr-policy
 
 ## ClusterSet for test command".
 # - Modify to match your Open Cluster Management configuration.
-clusterset: default
+clusterSet: default
 
 ## PVC specifications for test command.
 # - Modify items "storageclassname" to match the actual storage classes in the
 #   managed clusters.
 # - Add new items for testing more storage types.
-pvcspecs:
+PVCSpecs:
 - name: rbd
-  storageclassname: rook-ceph-block
-  accessmodes: ReadWriteOnce
+  storageClassName: rook-ceph-block
+  accessModes: ReadWriteOnce
 - name: cephfs
-  storageclassname: rook-cephfs-fs1
-  accessmodes: ReadWriteMany
+  storageClassName: rook-cephfs-fs1
+  accessModes: ReadWriteMany
 
 ## Tests cases for test command.
 # - Modify the test for your preferred workload or deployment type.
@@ -62,7 +62,7 @@ pvcspecs:
 tests:
 - workload: deploy
   deployer: appset
-  pvcspec: rbd
+  pvcSpec: rbd
 `
 
 func CreateSampleConfig(filename, commandName string) error {


### PR DESCRIPTION
- Don't use commented values since it is hard to uncomment yaml objects                                               
- More clear default values
- Add new name property for clusters
- Add titles for configuration sections using ##
- Document which value may need to be modified or added
- Add missing options: repo, dr-policy, clusterset, tests
- Rename creator to commandName
- Use Go template to render the sample config, preparing for creating sample for drenv environment.

## Example sample config

```yaml
## ramenctl configuration file

## Clusters configuration.
# - Modify clusters "kubeconfig" and "name" to match your hub and managed
#   clusters names and path to the kubeconfig file.
clusters:
  hub:
    name: hub
    kubeconfig: hub/config
  c1:
    name: primary
    kubeconfig: primary/config
  c2:
    name: secondary
    kubeconfig: secondary/config

## Git repository for test command.
# - Modify "url" to use your own Git repository.
# - Modify "branch" to test a different branch.
repo:
  url: https://github.com/RamenDR/ocm-ramen-samples.git
  branch: main

## DRPolicy for test command".
# - Modify to match actual DRPolicy in the hub cluster.
drPolicy: dr-policy

## ClusterSet for test command".
# - Modify to match your Open Cluster Management configuration.
clusterSet: default

## PVC specifications for test command".
# - Modify items "storageclassname" to match the actual storage classes in the
#   managed clusters.
# - Add new items for testing more storage types.
PVCSpecs:
- name: rbd
  storageClassName: rook-ceph-block
  accessModes: ReadWriteOnce
- name: cephfs
  storageClassName: rook-cephfs-fs1
  accessModes: ReadWriteMany

## Tests cases for test command".
# - Modify the test for your preferred workload or deployment type.
# - Add new tests for testing more combinations in parallel.
# - Available workloads: deploy
# - Available deployers: appset, subscr, disapp
tests:
- workload: deploy
  deployer: appset
  pvcSpec: rbd
```

Fixes #21 