### PR TITLE
Enhance init command to support ramen envfile

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -9,14 +9,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var envFile string
+
 var InitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create configuration file for your clusters",
 	Run: func(c *cobra.Command, args []string) {
-		if err := config.CreateSampleConfig(configFile, RootCmd.DisplayName()); err != nil {
+		if err := config.CreateSampleConfig(configFile, RootCmd.DisplayName(), envFile); err != nil {
 			console.Fatal(err)
 		}
-
 		console.Completed("Created config file %q - please modify for your clusters", configFile)
 	},
+}
+
+func init() {
+	// Register the --envfile flag
+	InitCmd.Flags().StringVar(&envFile, "envfile", "", "ramen testing environment file")
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ramendr/ramenctl/pkg/config"
+)
+
+func TestReadEnvFile(t *testing.T) {
+	env, err := config.ReadEnvFile("testdata/regional-dr.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read environment file: %v", err)
+	}
+
+	expected := &config.EnvFile{
+		Name: "rdr",
+		Ramen: config.Ramen{
+			Hub:      "hub",
+			Clusters: []string{"dr1", "dr2"},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, env) {
+		t.Fatalf("expected %+v, got %+v", expected, env)
+	}
+}

--- a/pkg/config/envfile.go
+++ b/pkg/config/envfile.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+)
+
+type Ramen struct {
+	Hub      string   `json:"hub" yaml:"hub"`
+	Clusters []string `json:"clusters" yaml:"clusters"`
+}
+
+type EnvFile struct {
+	Name  string `json:"name" yaml:"name"`
+	Ramen Ramen  `json:"ramen" yaml:"ramen"`
+}
+
+// ReadEnvFile reads and parses an environment file into an EnvFile struct.
+func ReadEnvFile(filePath string) (*EnvFile, error) {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read environment file %q: %w", filePath, err)
+	}
+
+	var env EnvFile
+	if err := yaml.Unmarshal(content, &env); err != nil {
+		return nil, fmt.Errorf("failed to parse environment file %q: %w", filePath, err)
+	}
+
+	return &env, nil
+}
+
+func (e *EnvFile) KubeconfigPath(name string) string {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	return filepath.Join(homeDir, ".config", "drenv", e.Name, "kubeconfigs", name)
+}
+
+func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
+	envConfig, err := ReadEnvFile(envFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Sample{
+		CommandName:         commandName,
+		HubName:             envConfig.Ramen.Hub,
+		HubKubeconfig:       envConfig.KubeconfigPath(envConfig.Ramen.Hub),
+		PrimaryName:         envConfig.Ramen.Clusters[0],
+		PrimaryKubeconfig:   envConfig.KubeconfigPath(envConfig.Ramen.Clusters[0]),
+		SecondaryName:       envConfig.Ramen.Clusters[1],
+		SecondaryKubeconfig: envConfig.KubeconfigPath(envConfig.Ramen.Clusters[1]),
+	}, nil
+}

--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -5,14 +5,14 @@
 #   clusters names and path to the kubeconfig file.
 clusters:
   hub:
-    name: hub
-    kubeconfig: hub/config
+    name: {{.HubName}}
+    kubeconfig: {{.HubKubeconfig}}
   c1:
-    name: primary
-    kubeconfig: primary/config
+    name: {{.PrimaryName}}
+    kubeconfig: {{.PrimaryKubeconfig}}
   c2:
-    name: secondary
-    kubeconfig: secondary/config
+    name: {{.SecondaryName}}
+    kubeconfig: {{.SecondaryKubeconfig}}
 
 ## Kubernetes distribution
 # - Modify to specify your clusters kuberenetes distribution (k8s or ocp).

--- a/pkg/config/testdata/regional-dr.yaml
+++ b/pkg/config/testdata/regional-dr.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# Environment for testing Regional-DR.
+---
+name: "rdr"
+ramen:
+  hub: hub
+  clusters: [dr1, dr2]
+  topology: regional-dr
+  features:
+    volsync: true


### PR DESCRIPTION
This PR improves the ramenctl init command by supporting an optional environment file.


Environment File (--envfile) Support:

- Allows users to provide an environment file containing cluster information.
- If specified, the configuration is loaded from the environment file.
- If --envfile is not provided, a sample configuration file is created.

Example:
```
$ ./ramenctl init --envfile /home/oviner/test/regional-dr.yaml -c config50.yaml
⭐ Created new config file "config50.yaml"
✅ Finalized config file "config50.yaml" - please modify as needed            

$ cat config50.yaml 
## ramenctl configuration file

## Clusters configuration.
# - Modify clusters "kubeconfig" and "name" to match your hub and managed
#   clusters names and path to the kubeconfig file.
clusters:
  hub:
    name: hub
    kubeconfig: /home/oviner/.config/drenv/rdr/kubeconfigs/hub
  c1:
    name: dr1
    kubeconfig: /home/oviner/.config/drenv/rdr/kubeconfigs/dr1
  c2:
    name: dr2
    kubeconfig: /home/oviner/.config/drenv/rdr/kubeconfigs/dr2

## Kubernetes distribution
# - Modify "distro" to specify your clusters kuberenetes
#   distribution(k8s or ocp).
distro: k8s

## Git repository for test command.
# - Modify "url" to use your own Git repository.
# - Modify "branch" to test a different branch.
repo:
  url: https://github.com/RamenDR/ocm-ramen-samples.git
  branch: main

## DRPolicy for test command.
# - Modify to match actual DRPolicy in the hub cluster.
drPolicy: dr-policy

## ClusterSet for test command.
# - Modify to match your Open Cluster Management configuration.
clusterSet: default

## PVC specifications for test command.
# - Modify items "storageclassname" to match the actual storage classes in the
#   managed clusters.
# - Add new items for testing more storage types.
PVCSpecs:
- name: rbd
  storageClassName: rook-ceph-block
  accessModes: ReadWriteOnce
- name: cephfs
  storageClassName: rook-cephfs-fs1
  accessModes: ReadWriteMany

## Tests cases for test command.
# - Modify the test for your preferred workload or deployment type.
# - Add new tests for testing more combinations in parallel.
# - Available workloads: deploy
# - Available deployers: appset, subscr, disapp
tests:
- workload: deploy
  deployer: appset
  pvcSpec: rbd
```

Fixes: #22 