### PR TITLE
Fix command name when running as "odf dr"

### DIFF
--- a/examples/odf.go
+++ b/examples/odf.go
@@ -43,6 +43,9 @@ func main() {
 	// Adapt ramenctl root command to the odf.
 	dr.RootCmd.Use = "dr"
 	dr.RootCmd.Short = "Troubleshoot OpenShift DR"
+	dr.RootCmd.Annotations = map[string]string{
+		cobra.CommandDisplayNameAnnotation: "odf dr",
+	}
 
 	// Add a subset of ramenctl command as the "odf dr" subcommand.
 	dr.RootCmd.AddCommand(dr.InitCmd, dr.TestCmd, dr.ValidateCmd)


### PR DESCRIPTION
We used RootCmd.DisaplayName() to return "ramenctl" or "odf dr" as the command name use in the sample configuration file. This requires annotating RootCmd.

Example usage:

    % examples/odf dr init -c odf.yaml
    ✅ Created config file "odf.yaml" - please modify for your clusters

    % head -1 odf.yaml
    ## odf dr configuration file

Fixes #45