### PR TITLE
Add build information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,25 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+# v0.5.1 when building from tag (release)
+# v0.5.1-1-gcf79160 when building without tag (development)
+version := $(shell git describe --tags)
+commit := $(shell git rev-parse HEAD)
+
+build := github.com/ramendr/ramenctl/pkg/build
+
+# % go build -ldflags="-help"
+#  -X 	definition
+#    	add string value definition of the form importpath.name=value
+ldflags := -X '$(build).Version=$(version)' \
+		   -X '$(build).Commit=$(commit)'
+
 .PHONY: ramenctl examples
 
 all: ramenctl examples
 
 ramenctl:
-	go build -o $@ cmd/main.go
+	go build -ldflags="$(ldflags)" -o $@ cmd/main.go
 
 examples:
 	go build -o examples/odf examples/odf.go

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ramendr/ramenctl/pkg/build"
 )
 
 var (
@@ -18,14 +20,18 @@ var (
 )
 
 var RootCmd = &cobra.Command{
-	Use:   "ramenctl",
-	Short: "Manage and troubleshoot Ramen",
+	Use:     "ramenctl",
+	Short:   "Manage and troubleshoot Ramen",
+	Version: build.Version,
 
 	// When used as a subcommand in another tool, don't inherit persistent pre run commands.
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {
+	// Use plain, machine friendly version string.
+	RootCmd.SetVersionTemplate("{{.Version}}\n")
+
 	// These flags are used by all sub commands.
 	RootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "config.yaml", "configuration file")
 }

--- a/examples/odf.go
+++ b/examples/odf.go
@@ -8,6 +8,8 @@ import (
 	"log"
 
 	dr "github.com/ramendr/ramenctl/cmd/commands"
+	drbuild "github.com/ramendr/ramenctl/pkg/build"
+
 	"github.com/spf13/cobra"
 )
 
@@ -43,6 +45,10 @@ func main() {
 	// Adapt ramenctl root command to the odf.
 	dr.RootCmd.Use = "dr"
 	dr.RootCmd.Short = "Troubleshoot OpenShift DR"
+
+	// Set build information for odf dr reports.
+	drbuild.Version = "v1.2.3"
+	drbuild.Commit = "eb92ed81e2715d286bfd8ce173c76d4ecda9e2b4"
 
 	// Add a subset of ramenctl command as the "odf dr" subcommand.
 	dr.RootCmd.AddCommand(dr.InitCmd, dr.TestCmd, dr.ValidateCmd)

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package build
+
+// Values set during build.
+var (
+	Version string
+	Commit  string
+)


### PR DESCRIPTION
Generate version from git description and report it in --version.

Add new build package keeping `build.Version` and `build.Commit`. `build.Version` is used by the root command to enable Cobra builtin --version option.

ramenctl commands report summary will include build.Version and build.Commit.

Example run when building from tag:

    % ramenctl --version
    v0.2.0

Example run for development build:

    % ramenctl --version
    v0.1.0-1-gbcb8824

The --version option is available only if pkg/build.Version is set. When building as "odf dr" the version flag will not be available, but odf cli can set build.Version and build.Commit for odf dr reports. The example was updated to show this usage.

Fixes #46 