### PR TITLE
test: Run all tests in parallel

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -6,24 +6,18 @@ package console
 import (
 	"fmt"
 	"os"
-	"strings"
 )
-
-// TODO: Measure actual console and update when window size changes
-var width = 80
 
 func Info(format string, args ...any) {
 	fmt.Printf("⭐ "+format+"\n", args...)
 }
 
 func Progress(format string, args ...any) {
-	line := fmt.Sprintf("👀 "+format+" ...", args...)
-	fmt.Print(pad(line), "\r")
+	fmt.Printf("🔎 "+format+" ...\n", args...)
 }
 
 func Completed(format string, args ...any) {
-	line := fmt.Sprintf("✅ "+format, args...)
-	fmt.Print(pad(line), "\n")
+	fmt.Printf("✅ "+format+"\n", args...)
 }
 
 func Error(err error) {
@@ -33,12 +27,4 @@ func Error(err error) {
 func Fatal(err error) {
 	Error(err)
 	os.Exit(1)
-}
-
-// pad string to console width, leaving room for the line terminator.
-func pad(s string) string {
-	if len(s) < width-1 {
-		return s + strings.Repeat(" ", width-len(s)-1)
-	}
-	return s
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -12,19 +12,28 @@ func Info(format string, args ...any) {
 	fmt.Printf("⭐ "+format+"\n", args...)
 }
 
-func Progress(format string, args ...any) {
-	fmt.Printf("🔎 "+format+" ...\n", args...)
+// Step logs a new command step.
+func Step(format string, args ...any) {
+	fmt.Printf("\n🔎 "+format+" ...\n", args...)
 }
 
-func Completed(format string, args ...any) {
-	fmt.Printf("✅ "+format+"\n", args...)
+// Pass logs single operation completion.
+func Pass(format string, args ...any) {
+	fmt.Printf("   ✅ "+format+"\n", args...)
 }
 
+// Fail log single operation error.
 func Error(err error) {
-	fmt.Fprintf(os.Stderr, "❌ %s\n", err)
+	fmt.Fprintf(os.Stderr, "   ❌ %s\n", err)
 }
 
+// Completed logs command completion.
+func Completed(format string, args ...any) {
+	fmt.Printf("\n✅ "+format+"\n", args...)
+}
+
+// Fatal logs command failure and exit.
 func Fatal(err error) {
-	Error(err)
+	fmt.Fprintf(os.Stderr, "\n❌ %s\n", err)
 	os.Exit(1)
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -9,9 +9,7 @@ func Clean(configFile string, outputDir string) error {
 		return err
 	}
 
-	// We want to run all tests in parallel, but for now lets run one test.
-	test := newTest(cmd.Config.Tests[0], cmd)
-	if !cmd.CleanTest(test) {
+	if !cmd.CleanTests() {
 		return cmd.Failed()
 	}
 

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -52,7 +52,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 }
 
 func (c *Command) Setup() bool {
-	console.Progress("Setup environment")
+	console.Step("Setup environment")
 	if err := util.EnsureChannel(c.Env.Hub, c.Config, c.Logger); err != nil {
 		err := fmt.Errorf("failed to setup environment: %w", err)
 		console.Error(err)
@@ -60,13 +60,13 @@ func (c *Command) Setup() bool {
 		c.Report.AddSetup(false)
 		return false
 	}
-	console.Completed("Environment setup")
+	console.Pass("Environment setup")
 	c.Report.AddSetup(true)
 	return true
 }
 
 func (c *Command) Cleanup() bool {
-	console.Progress("Clean environment")
+	console.Step("Clean environment")
 	if err := util.EnsureChannelDeleted(c.Env.Hub, c.Config, c.Logger); err != nil {
 		err := fmt.Errorf("failed to clean environment: %w", err)
 		console.Error(err)
@@ -74,18 +74,18 @@ func (c *Command) Cleanup() bool {
 		c.Report.AddCleanup(false)
 		return false
 	}
-	console.Completed("Environment cleaned")
+	console.Pass("Environment cleaned")
 	c.Report.AddCleanup(true)
 	return true
 }
 
 func (c *Command) RunTests() bool {
-	console.Progress("Run tests")
+	console.Step("Run tests")
 	return c.runFlowFunc(c.runFlow)
 }
 
 func (c *Command) CleanTests() bool {
-	console.Progress("Clean tests")
+	console.Step("Clean tests")
 	return c.runFlowFunc(c.cleanFlow)
 }
 

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -77,6 +77,7 @@ func (c *Command) Cleanup() bool {
 }
 
 func (c *Command) RunTest(test *Test) bool {
+	console.Progress("Run tests")
 	defer c.addTest(test)
 	if !test.Deploy() {
 		return false
@@ -100,6 +101,7 @@ func (c *Command) RunTest(test *Test) bool {
 }
 
 func (c *Command) CleanTest(test *Test) bool {
+	console.Progress("Clean tests")
 	defer c.addTest(test)
 	if !test.Unprotect() {
 		return false

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -87,15 +87,6 @@ func (r *Report) AddCleanup(ok bool) {
 	r.addStep(step)
 }
 
-func (r *Report) findStep(name string) *Step {
-	for _, step := range r.Steps {
-		if step.Name == name {
-			return step
-		}
-	}
-	return nil
-}
-
 // AddTest records a completed test. A failed test mark the test step and the report as failed.
 func (r *Report) AddTest(t *Test) {
 	var step *Step
@@ -125,6 +116,15 @@ func (r *Report) AddTest(t *Test) {
 			r.Status = Passed
 		}
 	}
+}
+
+func (r *Report) findStep(name string) *Step {
+	for _, step := range r.Steps {
+		if step.Name == name {
+			return step
+		}
+	}
+	return nil
 }
 
 func (r *Report) addStep(step *Step) {

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -15,9 +15,7 @@ func Run(configFile string, outputDir string) error {
 		return cmd.Failed()
 	}
 
-	// We want to run all tests in parallel, but for now lets run one test.
-	test := newTest(cmd.Config.Tests[0], cmd)
-	if !cmd.RunTest(test) {
+	if !cmd.RunTests() {
 		return cmd.Failed()
 	}
 

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -46,7 +46,6 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 }
 
 func (t *Test) Deploy() bool {
-	console.Progress("Deploy application %q", t.Name())
 	if err := t.Deployer().Deploy(t.Context); err != nil {
 		err := fmt.Errorf("failed to deploy application %q: %w", t.Name(), err)
 		t.Fail(err)
@@ -57,7 +56,6 @@ func (t *Test) Deploy() bool {
 }
 
 func (t *Test) Undeploy() bool {
-	console.Progress("Undeploy application %q", t.Name())
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
 		err := fmt.Errorf("failed to undeploy application %q: %w", t.Name(), err)
 		t.Fail(err)
@@ -68,7 +66,6 @@ func (t *Test) Undeploy() bool {
 }
 
 func (t *Test) Protect() bool {
-	console.Progress("Protect application %q", t.Name())
 	if err := dractions.EnableProtection(t.Context); err != nil {
 		err := fmt.Errorf("failed to protect application %q: %w", t.Name(), err)
 		t.Fail(err)
@@ -79,7 +76,6 @@ func (t *Test) Protect() bool {
 }
 
 func (t *Test) Unprotect() bool {
-	console.Progress("Unprotect application %q", t.Name())
 	if err := dractions.DisableProtection(t.Context); err != nil {
 		err := fmt.Errorf("failed to unprotect application %q: %w", t.Name(), err)
 		t.Fail(err)
@@ -90,7 +86,6 @@ func (t *Test) Unprotect() bool {
 }
 
 func (t *Test) Failover() bool {
-	console.Progress("Failover application %q", t.Name())
 	if err := dractions.Failover(t.Context); err != nil {
 		err := fmt.Errorf("failed to failover application %q: %w", t.Name(), err)
 		t.Fail(err)
@@ -101,7 +96,6 @@ func (t *Test) Failover() bool {
 }
 
 func (t *Test) Relocate() bool {
-	console.Progress("Relocate application %q", t.Name())
 	if err := dractions.Relocate(t.Context); err != nil {
 		err := fmt.Errorf("failed to relocate application %q: %w", t.Name(), err)
 		t.Fail(err)

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -51,7 +51,7 @@ func (t *Test) Deploy() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q deployed", t.Name())
+	console.Pass("Application %q deployed", t.Name())
 	return true
 }
 
@@ -61,7 +61,7 @@ func (t *Test) Undeploy() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q undeployed", t.Name())
+	console.Pass("Application %q undeployed", t.Name())
 	return true
 }
 
@@ -71,7 +71,7 @@ func (t *Test) Protect() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q protected", t.Name())
+	console.Pass("Application %q protected", t.Name())
 	return true
 }
 
@@ -81,7 +81,7 @@ func (t *Test) Unprotect() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q unprotected", t.Name())
+	console.Pass("Application %q unprotected", t.Name())
 	return true
 }
 
@@ -91,7 +91,7 @@ func (t *Test) Failover() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q failed over", t.Name())
+	console.Pass("Application %q failed over", t.Name())
 	return true
 }
 
@@ -101,7 +101,7 @@ func (t *Test) Relocate() bool {
 		t.Fail(err)
 		return false
 	}
-	console.Completed("Application %q relocated", t.Name())
+	console.Pass("Application %q relocated", t.Name())
 	return true
 }
 


### PR DESCRIPTION
Run all tests in parallel similar to ramen/e2e tests.

Improve the output to more more clear when running multiple tests by separating the output to multiple groups of steps.

## Example run

Using 2 tests, expected usage for ramenctl.

```console
% ramenctl test run -o test
⭐ Using report "test"
⭐ Using config "config.yaml"

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "appset-deploy-cephfs" deployed
   ✅ Application "appset-deploy-cephfs" protected
   ✅ Application "appset-deploy-rbd" protected
   ✅ Application "appset-deploy-cephfs" failed over
   ✅ Application "appset-deploy-rbd" failed over
   ✅ Application "appset-deploy-cephfs" relocated
   ✅ Application "appset-deploy-rbd" relocated
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed

✅ passed (2 passed, 0 failed, 0 skipped)
```

## Example clean

Using 2 tests, expected usage for ramenctl.

```console
% ramenctl test clean -o test
⭐ Using report "test"
⭐ Using config "config.yaml"

🔎 Clean tests ...
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed
   ✅ Application "appset-deploy-cephfs" undeployed

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (2 passed, 0 failed, 0 skipped)
```

## Test report

### Run report

```yaml
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
ramenctl:
  commit: b5e7ffde13922f0fe0695f404026cd27bb33c34b
  version: v0.1.0-19-gb5e7ffd
status: passed
steps:
- name: setup
  status: passed
- name: tests
  status: passed
  tests:
  - deployer: appset
    pvcSpec: cephfs
    status: passed
    workload: deploy
  - deployer: appset
    pvcSpec: rbd
    status: passed
    workload: deploy
summary:
  failed: 0
  passed: 2
  skipped: 0
```

### Clean report

```yaml
% cat test/test-clean.yaml
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
ramenctl:
  commit: b5e7ffde13922f0fe0695f404026cd27bb33c34b
  version: v0.1.0-19-gb5e7ffd
status: passed
steps:
- name: tests
  status: passed
  tests:
  - deployer: appset
    pvcSpec: rbd
    status: passed
    workload: deploy
  - deployer: appset
    pvcSpec: cephfs
    status: passed
    workload: deploy
- name: cleanup
  status: passed
summary:
  failed: 0
  passed: 2
  skipped: 0
```

### Test tarball

[test.tar.gz](https://github.com/user-attachments/files/19409854/test.tar.gz)

Fixes #39 
Fixes #54 