### PR TITLE
report: Improve build info

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -16,16 +16,16 @@ type Host struct {
 	Cpus int    `json:"cpus"`
 }
 
-// Ramenctl describes ramenctl.
-type Ramenctl struct {
+// Build describes ramenctl build.
+type Build struct {
 	Version string `json:"version,omitempty"`
 	Commit  string `json:"commit,omitempty"`
 }
 
 // Report created by ramenctl command.
 type Report struct {
-	Host     Host      `json:"host"`
-	Ramenctl *Ramenctl `json:"ramenctl,omitempty"`
+	Host  Host   `json:"host"`
+	Build *Build `json:"build,omitempty"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
@@ -38,7 +38,7 @@ func New() *Report {
 		},
 	}
 	if build.Version != "" || build.Commit != "" {
-		r.Ramenctl = &Ramenctl{
+		r.Build = &Build{
 			Version: build.Version,
 			Commit:  build.Commit,
 		}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -18,27 +18,30 @@ type Host struct {
 
 // Ramenctl describes ramenctl.
 type Ramenctl struct {
-	Version string `json:"version"`
-	Commit  string `json:"commit"`
+	Version string `json:"version,omitempty"`
+	Commit  string `json:"commit,omitempty"`
 }
 
 // Report created by ramenctl command.
 type Report struct {
-	Host     Host     `json:"host"`
-	Ramenctl Ramenctl `json:"ramenctl"`
+	Host     Host      `json:"host"`
+	Ramenctl *Ramenctl `json:"ramenctl,omitempty"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
 func New() *Report {
-	return &Report{
+	r := &Report{
 		Host: Host{
 			OS:   runtime.GOOS,
 			Arch: runtime.GOARCH,
 			Cpus: runtime.NumCPU(),
 		},
-		Ramenctl: Ramenctl{
+	}
+	if build.Version != "" || build.Commit != "" {
+		r.Ramenctl = &Ramenctl{
 			Version: build.Version,
 			Commit:  build.Commit,
-		},
+		}
 	}
+	return r
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -26,15 +26,36 @@ func TestHost(t *testing.T) {
 	}
 }
 
-func TestRamenctlDefault(t *testing.T) {
-	r := report.New()
-	expected := report.Ramenctl{
-		Version: build.Version,
-		Commit:  build.Commit,
-	}
-	if !reflect.DeepEqual(r.Ramenctl, expected) {
-		t.Fatalf("expected host %+v, got %+v", expected, r.Ramenctl)
-	}
+func TestBuildInfo(t *testing.T) {
+	savedVersion := build.Version
+	savedCommit := build.Commit
+	defer func() {
+		build.Version = savedVersion
+		build.Commit = savedCommit
+	}()
+	t.Run("available", func(t *testing.T) {
+		build.Version = "fake-version"
+		build.Commit = "fake-commit"
+		r := report.New()
+		if r.Ramenctl == nil {
+			t.Fatalf("ramenctl omitted")
+		}
+		expected := &report.Ramenctl{
+			Version: build.Version,
+			Commit:  build.Commit,
+		}
+		if !reflect.DeepEqual(r.Ramenctl, expected) {
+			t.Fatalf("expected ramenctl %+v, got %+v", expected, r.Ramenctl)
+		}
+	})
+	t.Run("missing", func(t *testing.T) {
+		build.Version = ""
+		build.Commit = ""
+		r := report.New()
+		if r.Ramenctl != nil {
+			t.Fatalf("ramenctl not omitted: %+v", r.Ramenctl)
+		}
+	})
 }
 
 func TestRoundtrip(t *testing.T) {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -37,23 +37,23 @@ func TestBuildInfo(t *testing.T) {
 		build.Version = "fake-version"
 		build.Commit = "fake-commit"
 		r := report.New()
-		if r.Ramenctl == nil {
-			t.Fatalf("ramenctl omitted")
+		if r.Build == nil {
+			t.Fatalf("build info omitted")
 		}
-		expected := &report.Ramenctl{
+		expected := &report.Build{
 			Version: build.Version,
 			Commit:  build.Commit,
 		}
-		if !reflect.DeepEqual(r.Ramenctl, expected) {
-			t.Fatalf("expected ramenctl %+v, got %+v", expected, r.Ramenctl)
+		if !reflect.DeepEqual(r.Build, expected) {
+			t.Fatalf("expected build info %+v, got %+v", expected, r.Build)
 		}
 	})
 	t.Run("missing", func(t *testing.T) {
 		build.Version = ""
 		build.Commit = ""
 		r := report.New()
-		if r.Ramenctl != nil {
-			t.Fatalf("ramenctl not omitted: %+v", r.Ramenctl)
+		if r.Build != nil {
+			t.Fatalf("build info not omitted: %+v", r.Build)
 		}
 	})
 }


### PR DESCRIPTION
- Omit build info if we have no build info
- Omit Version or Commit if empty
- Rename "ramenctl" to "build"

## Example report

```yaml
build:
  commit: 3273486bc215e59337eedfd88f67962b6505f17b
  version: v0.2.0-2-g3273486
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
status: passed
...
```