### PR TITLE
validate: add validate step for test run and clean

### DIFF
--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -9,6 +9,10 @@ func Clean(configFile string, outputDir string) error {
 		return err
 	}
 
+	if !cmd.Validate() {
+		return cmd.Failed()
+	}
+
 	if !cmd.CleanTests() {
 		return cmd.Failed()
 	}

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -10,6 +10,7 @@ import (
 	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/util"
+	"github.com/ramendr/ramen/e2e/validate"
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
@@ -49,6 +50,18 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 		PVCSpecs:        e2econfig.PVCSpecsMap(cmd.Config),
 		Report:          NewReport(name),
 	}, nil
+}
+
+func (c *Command) Validate() bool {
+	console.Step("Validate config")
+	if err := validate.TestConfig(c.Env, c.Config, c.Logger); err != nil {
+		err := fmt.Errorf("failed to validate config: %w", err)
+		console.Error(err)
+		c.Logger.Error(err)
+		return false
+	}
+	console.Pass("Config validated")
+	return true
 }
 
 func (c *Command) Setup() bool {

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -9,6 +9,10 @@ func Run(configFile string, outputDir string) error {
 		return err
 	}
 
+	if !cmd.Validate() {
+		return cmd.Failed()
+	}
+
 	// NOTE: The environment will be cleaned up by `test clean` command. If a test fail we want to keep the environment
 	// as is for inspection.
 	if !cmd.Setup() {


### PR DESCRIPTION
This change adds validate step which validates configs like drpolicy, clusterset exists and cluster names provided in config matches with configured clusters in drpolicy and clusterset.

**Example run**
```
⭐ Using report "test"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "appset-deploy-rbd" protected
   ✅ Application "appset-deploy-rbd" failed over
   ✅ Application "appset-deploy-rbd" relocated
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed

✅ passed (1 passed, 0 failed, 0 skipped)
```

**Example clean**

```
⭐ Using report "test_clean"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (1 passed, 0 failed, 0 skipped)
```

In logs:
```
INFO	validate/validation.go:154	Validated clusters ["dr1", "dr2"] in DRPolicy "dr-policy"
INFO	validate/validation.go:180	Validated clusters ["dr1", "dr2"] in ClusterSet "default"
```
Fixes #38 