### PR TITLE
test: Less verbose errors in console

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -22,9 +22,9 @@ func Pass(format string, args ...any) {
 	fmt.Printf("   ✅ "+format+"\n", args...)
 }
 
-// Fail log single operation error.
-func Error(err error) {
-	fmt.Fprintf(os.Stderr, "   ❌ %s\n", err)
+// Error logs single operation error.
+func Error(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "   ❌ "+format+"\n", args...)
 }
 
 // Completed logs command completion.

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -47,8 +47,8 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 
 func (t *Test) Deploy() bool {
 	if err := t.Deployer().Deploy(t.Context); err != nil {
-		err := fmt.Errorf("failed to deploy application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to deploy application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q deployed", t.Name())
@@ -57,8 +57,8 @@ func (t *Test) Deploy() bool {
 
 func (t *Test) Undeploy() bool {
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
-		err := fmt.Errorf("failed to undeploy application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to undeploy application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q undeployed", t.Name())
@@ -67,8 +67,8 @@ func (t *Test) Undeploy() bool {
 
 func (t *Test) Protect() bool {
 	if err := dractions.EnableProtection(t.Context); err != nil {
-		err := fmt.Errorf("failed to protect application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to protect application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q protected", t.Name())
@@ -77,8 +77,8 @@ func (t *Test) Protect() bool {
 
 func (t *Test) Unprotect() bool {
 	if err := dractions.DisableProtection(t.Context); err != nil {
-		err := fmt.Errorf("failed to unprotect application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to unprotect application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q unprotected", t.Name())
@@ -87,8 +87,8 @@ func (t *Test) Unprotect() bool {
 
 func (t *Test) Failover() bool {
 	if err := dractions.Failover(t.Context); err != nil {
-		err := fmt.Errorf("failed to failover application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to failover application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q failed over", t.Name())
@@ -97,16 +97,16 @@ func (t *Test) Failover() bool {
 
 func (t *Test) Relocate() bool {
 	if err := dractions.Relocate(t.Context); err != nil {
-		err := fmt.Errorf("failed to relocate application %q: %w", t.Name(), err)
-		t.Fail(err)
+		msg := fmt.Sprintf("failed to relocate application %q", t.Name())
+		t.fail(msg, err)
 		return false
 	}
 	console.Pass("Application %q relocated", t.Name())
 	return true
 }
 
-func (t *Test) Fail(err error) {
-	console.Error(err)
-	t.Logger().Error(err)
+func (t *Test) fail(msg string, err error) {
+	console.Error(msg)
+	t.Logger().Errorf("%s: %s", msg, err)
 	t.Status = Failed
 }


### PR DESCRIPTION
We use to log a very verbose errors to the console like:

    ❌ failed to failover application "appset-deploy-rbd": Get
    "https://192.168.105.33:6443/apis/ramendr.openshift.io/v1alpha1/namespaces/argocd/drplacementcontrols/appset-deploy-rbd":
    dial tcp 192.168.105.33:6443: connect: operation timed out

This is way too long and detailed for the console, and we may log multiple errors like this in some cases. This is not a good user experience.

Change to log only the high level message:

    ❌ failed to failover application "appset-deploy-rbd"

## Example run

I triggered an error by stopping the hub cluster during the run.

    % ramenctl test run -o test
    ⭐ Using report "test"
    ⭐ Using config "config.yaml"

    🔎 Validate config ...
       ✅ Config validated

    🔎 Setup environment ...
       ✅ Environment setup

    🔎 Run tests ...
       ✅ Application "appset-deploy-cephfs" deployed
       ✅ Application "appset-deploy-rbd" deployed
       ✅ Application "disapp-deploy-rbd" deployed
       ✅ Application "subscr-deploy-rbd" deployed
       ✅ Application "subscr-deploy-cephfs" deployed
       ✅ Application "subscr-deploy-rbd" protected
       ✅ Application "disapp-deploy-rbd" protected
       ✅ Application "disapp-deploy-rbd" failed over
       ❌ failed to protect application "appset-deploy-cephfs"
       ❌ failed to protect application "subscr-deploy-cephfs"
       ❌ failed to protect application "appset-deploy-rbd"
       ❌ failed to failover application "subscr-deploy-rbd"
       ❌ failed to relocate application "disapp-deploy-rbd"

    ❌ failed (0 passed, 5 failed, 0 skipped)

## Example error from test/test-run.log

    2025-03-25T22:03:33.432+0200    ERROR   appset-deploy-cephfs    test/test.go:109
    failed to protect application "appset-deploy-cephfs": Get
     "https://192.168.105.33:6443/apis/ramendr.openshift.io/v1alpha1/namespaces/argocd/drplacementcontrols/appset-deploy-cephfs":
    read tcp 192.168.105.1:61565->192.168.105.33:6443: read: operation timed out
    github.com/ramendr/ramenctl/pkg/test.(*Test).Fail
            /Users/nir/src/ramenctl/pkg/test/test.go:109
    github.com/ramendr/ramenctl/pkg/test.(*Test).Protect
            /Users/nir/src/ramenctl/pkg/test/test.go:71
    github.com/ramendr/ramenctl/pkg/test.(*Command).runFlow
            /Users/nir/src/ramenctl/pkg/test/command.go:142
    github.com/ramendr/ramenctl/pkg/test.(*Command).runFlowFunc.func1
            /Users/nir/src/ramenctl/pkg/test/command.go:127

Fixes: #55