### PR TITLE
build: Make test and clean .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ldflags := -X '$(build).Version=$(version)' \
 
 .PHONY: ramenctl examples
 
-all: ramenctl examples
+all: ramenctl examples test clean
 
 ramenctl:
 	CGO_ENABLED=0 go build -ldflags="$(ldflags)" -o $@ cmd/main.go


### PR DESCRIPTION
If you create a directory "test", running `make test` or `make clean` will do nothing:

    % make test
    make: `test' is up to date.

Fixed by making them .PHONY.