### PR TITLE
Support report with nested steps

### DIFF
--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -48,7 +48,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 		Command:         cmd,
 		NamespacePrefix: "test-",
 		PVCSpecs:        e2econfig.PVCSpecsMap(cmd.Config),
-		Report:          NewReport(name),
+		Report:          newReport(name),
 	}, nil
 }
 

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -55,7 +55,7 @@ type Report struct {
 	Status  Status  `json:"status,omitempty"`
 }
 
-func NewReport(commandName string) *Report {
+func newReport(commandName string) *Report {
 	return &Report{
 		Report: report.New(),
 		Name:   commandName,

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -24,11 +24,12 @@ const (
 	CleanupStep  = "cleanup"
 )
 
-// A step is a test command step. The setup and cleanup steps are modeled as step without tests.
+// A step is a test command step.
 type Step struct {
-	Name   string   `json:"name"`
-	Status Status   `json:"status,omitempty"`
-	Items  []Result `json:"items,omitempty"`
+	Name   string  `json:"name"`
+	Status Status  `json:"status,omitempty"`
+	Config *Config `json:"config,omitempty"`
+	Items  []*Step `json:"items,omitempty"`
 }
 
 // Summary summaries a test run or clean.
@@ -44,12 +45,6 @@ type Config struct {
 	Workload string `json:"workload"`
 	Deployer string `json:"deployer"`
 	PVCSpec  string `json:"pvcSpec"`
-}
-
-// Result describes a single test result.
-type Result struct {
-	Config *Config `json:"config"`
-	Status Status  `json:"status,omitempty"`
 }
 
 // Report created by test sub commands.
@@ -127,7 +122,8 @@ func (r *Report) findStep(name string) *Step {
 
 // AddTest records a completed test. A failed test marks the step as failed.
 func (s *Step) AddTest(t *Test) {
-	result := Result{
+	result := &Step{
+		Name:   t.Name(),
 		Config: t.Config,
 		Status: t.Status,
 	}

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -38,12 +38,18 @@ type Summary struct {
 	Skipped int `json:"skipped"`
 }
 
-// Result describes a single test result.
-type Result struct {
+// Test config supporting yaml marshaling, unlike ramen/e2e/types.TestConfig
+// See https://github.com/RamenDR/ramen/issues/1968
+type Config struct {
 	Workload string `json:"workload"`
 	Deployer string `json:"deployer"`
 	PVCSpec  string `json:"pvcSpec"`
-	Status   Status `json:"status,omitempty"`
+}
+
+// Result describes a single test result.
+type Result struct {
+	Config *Config `json:"config"`
+	Status Status  `json:"status,omitempty"`
 }
 
 // Report created by test sub commands.
@@ -122,10 +128,8 @@ func (r *Report) findStep(name string) *Step {
 // AddTest records a completed test. A failed test marks the step as failed.
 func (s *Step) AddTest(t *Test) {
 	result := Result{
-		Workload: t.Config.Workload,
-		Deployer: t.Config.Deployer,
-		PVCSpec:  t.Config.PVCSpec,
-		Status:   t.Status,
+		Config: t.Config,
+		Status: t.Status,
 	}
 
 	s.Items = append(s.Items, result)

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -101,6 +101,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	failedTest := &Test{
+		Context: &Context{name: "appset-deploy-rbd"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -114,6 +115,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	passedTest := &Test{
+		Context: &Context{name: "appset-deploy-cephfs"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -149,20 +151,22 @@ func TestReportRunTestFailed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", r.Steps[1].Items)
 	}
 
-	failedResult := Result{
+	failedResult := &Step{
+		Name:   failedTest.Name(),
 		Config: failedTest.Config,
 		Status: failedTest.Status,
 	}
-	if tests.Items[0] != failedResult {
+	if !reflect.DeepEqual(tests.Items[0], failedResult) {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[0])
 	}
 
-	passedResult := Result{
+	passedResult := &Step{
+		Name:   passedTest.Name(),
 		Config: passedTest.Config,
 		Status: passedTest.Status,
 	}
-	if tests.Items[1] != passedResult {
-		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[1])
+	if !reflect.DeepEqual(tests.Items[1], passedResult) {
+		t.Errorf("expected result %+v, got %+v", passedResult, tests.Items[1])
 	}
 
 	// Counts updated.
@@ -184,6 +188,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	rbdTest := &Test{
+		Context: &Context{name: "appset-deploy-rbd"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -197,6 +202,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
+		Context: &Context{name: "appset-deploy-cephfs"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -233,19 +239,21 @@ func TestReportRunAllPassed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := Result{
+	rbdResult := &Step{
+		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if tests.Items[0] != rbdResult {
+	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := Result{
+	cephfsResult := &Step{
+		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if tests.Items[1] != cephfsResult {
+	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
 	}
 
@@ -262,6 +270,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
+		Context: &Context{name: "appset-deploy-rbd"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -275,6 +284,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
+		Context: &Context{name: "appset-deploy-cephfs"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -306,20 +316,22 @@ func TestReportCleanTestFailed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := Result{
+	rbdResult := &Step{
+		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if tests.Items[0] != rbdResult {
+	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := Result{
+	cephfsResult := &Step{
+		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if tests.Items[1] != cephfsResult {
-		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
+	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
+		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])
 	}
 
 	// Counts updated.
@@ -335,6 +347,7 @@ func TestReportCleanFailed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
+		Context: &Context{name: "appset-deploy-rbd"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -387,6 +400,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
+		Context: &Context{name: "appset-deploy-rbd"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -400,6 +414,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
+		Context: &Context{name: "appset-deploy-cephfs"},
 		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -437,20 +452,22 @@ func TestReportCleanAllPassed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := Result{
+	rbdResult := &Step{
+		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if tests.Items[0] != rbdResult {
+	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := Result{
+	cephfsResult := &Step{
+		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if tests.Items[1] != cephfsResult {
-		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
+	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
+		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])
 	}
 
 	// The cleanup step passed, the step must be passed.

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestReportEmpty(t *testing.T) {
-	r := NewReport("test-run")
+	r := newReport("test-run")
 
 	// Host and ramenctl info is ready.
 	expectedReport := report.New()
@@ -38,7 +38,7 @@ func TestReportEmpty(t *testing.T) {
 }
 
 func TestReportRunSetupFailed(t *testing.T) {
-	r := NewReport("test-run")
+	r := newReport("test-run")
 	step := &Step{Name: SetupStep, Status: Failed}
 	r.AddStep(step)
 
@@ -66,7 +66,7 @@ func TestReportRunSetupFailed(t *testing.T) {
 }
 
 func TestReportRunSetupPassed(t *testing.T) {
-	r := NewReport("test-run")
+	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -93,7 +93,7 @@ func TestReportRunSetupPassed(t *testing.T) {
 }
 
 func TestReportRunTestFailed(t *testing.T) {
-	r := NewReport("test-run")
+	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -180,7 +180,7 @@ func TestReportRunTestFailed(t *testing.T) {
 }
 
 func TestReportRunAllPassed(t *testing.T) {
-	r := NewReport("test-run")
+	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -268,7 +268,7 @@ func TestReportRunAllPassed(t *testing.T) {
 }
 
 func TestReportCleanTestFailed(t *testing.T) {
-	r := NewReport("test-clean")
+	r := newReport("test-clean")
 
 	rbdTest := &Test{
 		Config: types.TestConfig{
@@ -345,7 +345,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 }
 
 func TestReportCleanFailed(t *testing.T) {
-	r := NewReport("test-clean")
+	r := newReport("test-clean")
 
 	rbdTest := &Test{
 		Config: types.TestConfig{
@@ -397,7 +397,7 @@ func TestReportCleanFailed(t *testing.T) {
 }
 
 func TestReportCleanAllPassed(t *testing.T) {
-	r := NewReport("test-clean")
+	r := newReport("test-clean")
 
 	rbdTest := &Test{
 		Config: types.TestConfig{

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -9,7 +9,6 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramenctl/pkg/report"
 )
 
@@ -102,7 +101,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	failedTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
@@ -115,7 +114,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	passedTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
@@ -151,20 +150,16 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	failedResult := Result{
-		Workload: failedTest.Config.Workload,
-		Deployer: failedTest.Config.Deployer,
-		PVCSpec:  failedTest.Config.PVCSpec,
-		Status:   failedTest.Status,
+		Config: failedTest.Config,
+		Status: failedTest.Status,
 	}
 	if tests.Items[0] != failedResult {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[0])
 	}
 
 	passedResult := Result{
-		Workload: passedTest.Config.Workload,
-		Deployer: passedTest.Config.Deployer,
-		PVCSpec:  passedTest.Config.PVCSpec,
-		Status:   passedTest.Status,
+		Config: passedTest.Config,
+		Status: passedTest.Status,
 	}
 	if tests.Items[1] != passedResult {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[1])
@@ -189,7 +184,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	rbdTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
@@ -202,7 +197,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
@@ -239,20 +234,16 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	rbdResult := Result{
-		Workload: rbdTest.Config.Workload,
-		Deployer: rbdTest.Config.Deployer,
-		PVCSpec:  rbdTest.Config.PVCSpec,
-		Status:   rbdTest.Status,
+		Config: rbdTest.Config,
+		Status: rbdTest.Status,
 	}
 	if tests.Items[0] != rbdResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
 	cephfsResult := Result{
-		Workload: cephfsTest.Config.Workload,
-		Deployer: cephfsTest.Config.Deployer,
-		PVCSpec:  cephfsTest.Config.PVCSpec,
-		Status:   cephfsTest.Status,
+		Config: cephfsTest.Config,
+		Status: cephfsTest.Status,
 	}
 	if tests.Items[1] != cephfsResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
@@ -271,7 +262,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
@@ -284,7 +275,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
@@ -316,20 +307,16 @@ func TestReportCleanTestFailed(t *testing.T) {
 	}
 
 	rbdResult := Result{
-		Workload: rbdTest.Config.Workload,
-		Deployer: rbdTest.Config.Deployer,
-		PVCSpec:  rbdTest.Config.PVCSpec,
-		Status:   rbdTest.Status,
+		Config: rbdTest.Config,
+		Status: rbdTest.Status,
 	}
 	if tests.Items[0] != rbdResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
 	cephfsResult := Result{
-		Workload: cephfsTest.Config.Workload,
-		Deployer: cephfsTest.Config.Deployer,
-		PVCSpec:  cephfsTest.Config.PVCSpec,
-		Status:   cephfsTest.Status,
+		Config: cephfsTest.Config,
+		Status: cephfsTest.Status,
 	}
 	if tests.Items[1] != cephfsResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
@@ -348,7 +335,7 @@ func TestReportCleanFailed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
@@ -400,7 +387,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
@@ -413,7 +400,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Config: types.TestConfig{
+		Config: &Config{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
@@ -451,20 +438,16 @@ func TestReportCleanAllPassed(t *testing.T) {
 	}
 
 	rbdResult := Result{
-		Workload: rbdTest.Config.Workload,
-		Deployer: rbdTest.Config.Deployer,
-		PVCSpec:  rbdTest.Config.PVCSpec,
-		Status:   rbdTest.Status,
+		Config: rbdTest.Config,
+		Status: rbdTest.Status,
 	}
 	if tests.Items[0] != rbdResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
 	cephfsResult := Result{
-		Workload: cephfsTest.Config.Workload,
-		Deployer: cephfsTest.Config.Deployer,
-		PVCSpec:  cephfsTest.Config.PVCSpec,
-		Status:   cephfsTest.Status,
+		Config: cephfsTest.Config,
+		Status: cephfsTest.Status,
 	}
 	if tests.Items[1] != cephfsResult {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package test_test
+package test
 
 import (
 	"reflect"
@@ -11,11 +11,10 @@ import (
 
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramenctl/pkg/report"
-	"github.com/ramendr/ramenctl/pkg/test"
 )
 
 func TestReportEmpty(t *testing.T) {
-	r := test.NewReport("test-run")
+	r := NewReport("test-run")
 
 	// Host and ramenctl info is ready.
 	expectedReport := report.New()
@@ -39,20 +38,20 @@ func TestReportEmpty(t *testing.T) {
 }
 
 func TestReportRunSetupFailed(t *testing.T) {
-	r := test.NewReport("test-run")
-	step := &test.Step{Name: test.SetupStep, Status: test.Failed}
+	r := NewReport("test-run")
+	step := &Step{Name: SetupStep, Status: Failed}
 	r.AddStep(step)
 
 	// Setup failed, so entire report should be failed.
-	if r.Status != test.Failed {
-		t.Errorf("expected status %q, got %q", test.Failed, r.Status)
+	if r.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, r.Status)
 	}
 
 	// Setup failed, we should see the failed step.
 	if len(r.Steps) != 1 {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
-	failedSetup := &test.Step{Name: test.SetupStep, Status: test.Failed}
+	failedSetup := &Step{Name: SetupStep, Status: Failed}
 	if !reflect.DeepEqual(r.Steps[0], failedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", r.Steps[0], failedSetup)
 	}
@@ -67,19 +66,19 @@ func TestReportRunSetupFailed(t *testing.T) {
 }
 
 func TestReportRunSetupPassed(t *testing.T) {
-	r := test.NewReport("test-run")
+	r := NewReport("test-run")
 
-	step := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
 	// Setup succeeded, we should see the successful step.
 	if len(r.Steps) != 1 {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
-	passedSetup := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	passedSetup := &Step{Name: SetupStep, Status: Passed}
 	if !reflect.DeepEqual(r.Steps[0], passedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", r.Steps[0], passedSetup)
 	}
@@ -94,38 +93,38 @@ func TestReportRunSetupPassed(t *testing.T) {
 }
 
 func TestReportRunTestFailed(t *testing.T) {
-	r := test.NewReport("test-run")
+	r := NewReport("test-run")
 
-	step := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	failedTest := &test.Test{
+	failedTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
 		},
-		Status: test.Failed,
+		Status: Failed,
 	}
 	r.AddTest(failedTest)
-	if r.Status != test.Failed {
-		t.Errorf("expected status %q, got %q", test.Failed, r.Status)
+	if r.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, r.Status)
 	}
 
-	passedTest := &test.Test{
+	passedTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(passedTest)
-	if r.Status != test.Failed {
-		t.Errorf("expected status %q, got %q", test.Failed, r.Status)
+	if r.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, r.Status)
 	}
 
 	// We should have a passed setup step, and failed tests step.
@@ -133,17 +132,17 @@ func TestReportRunTestFailed(t *testing.T) {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
 	setup := r.Steps[0]
-	passedSetup := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	passedSetup := &Step{Name: SetupStep, Status: Passed}
 	if !reflect.DeepEqual(setup, passedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", setup, passedSetup)
 	}
 	// One test failed, so the tests step must be failed.
 	tests := r.Steps[1]
-	if tests.Name != test.TestsStep {
-		t.Errorf("expected step name %q, got %q", test.TestsStep, tests.Name)
+	if tests.Name != TestsStep {
+		t.Errorf("expected step name %q, got %q", TestsStep, tests.Name)
 	}
-	if tests.Status != test.Failed {
-		t.Errorf("expected step status %q, got %q", test.Failed, tests.Status)
+	if tests.Status != Failed {
+		t.Errorf("expected step status %q, got %q", Failed, tests.Status)
 	}
 
 	// The tests setup must have 2 results.
@@ -151,7 +150,7 @@ func TestReportRunTestFailed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", r.Steps[1].Items)
 	}
 
-	failedResult := test.Result{
+	failedResult := Result{
 		Workload: failedTest.Config.Workload,
 		Deployer: failedTest.Config.Deployer,
 		PVCSpec:  failedTest.Config.PVCSpec,
@@ -161,7 +160,7 @@ func TestReportRunTestFailed(t *testing.T) {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[0])
 	}
 
-	passedResult := test.Result{
+	passedResult := Result{
 		Workload: passedTest.Config.Workload,
 		Deployer: passedTest.Config.Deployer,
 		PVCSpec:  passedTest.Config.PVCSpec,
@@ -181,38 +180,38 @@ func TestReportRunTestFailed(t *testing.T) {
 }
 
 func TestReportRunAllPassed(t *testing.T) {
-	r := test.NewReport("test-run")
+	r := NewReport("test-run")
 
-	step := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	rbdTest := &test.Test{
+	rbdTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(rbdTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	cephfsTest := &test.Test{
+	cephfsTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(cephfsTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
 	// We should have a passed setup and tests steps.
@@ -220,18 +219,18 @@ func TestReportRunAllPassed(t *testing.T) {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
 	setup := r.Steps[0]
-	passedSetup := &test.Step{Name: test.SetupStep, Status: test.Passed}
+	passedSetup := &Step{Name: SetupStep, Status: Passed}
 	if !reflect.DeepEqual(setup, passedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", setup, passedSetup)
 	}
 
 	// All tests passed, so the tests step must be passed.
 	tests := r.Steps[1]
-	if tests.Name != test.TestsStep {
-		t.Errorf("expected step name %q, got %q", test.TestsStep, tests.Name)
+	if tests.Name != TestsStep {
+		t.Errorf("expected step name %q, got %q", TestsStep, tests.Name)
 	}
-	if tests.Status != test.Passed {
-		t.Errorf("expected step status %q, got %q", test.Passed, tests.Status)
+	if tests.Status != Passed {
+		t.Errorf("expected step status %q, got %q", Passed, tests.Status)
 	}
 
 	// The tests setup must have 2 passed results.
@@ -239,7 +238,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := test.Result{
+	rbdResult := Result{
 		Workload: rbdTest.Config.Workload,
 		Deployer: rbdTest.Config.Deployer,
 		PVCSpec:  rbdTest.Config.PVCSpec,
@@ -249,7 +248,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := test.Result{
+	cephfsResult := Result{
 		Workload: cephfsTest.Config.Workload,
 		Deployer: cephfsTest.Config.Deployer,
 		PVCSpec:  cephfsTest.Config.PVCSpec,
@@ -269,32 +268,32 @@ func TestReportRunAllPassed(t *testing.T) {
 }
 
 func TestReportCleanTestFailed(t *testing.T) {
-	r := test.NewReport("test-clean")
+	r := NewReport("test-clean")
 
-	rbdTest := &test.Test{
+	rbdTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(rbdTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	cephfsTest := &test.Test{
+	cephfsTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
 		},
-		Status: test.Failed,
+		Status: Failed,
 	}
 	r.AddTest(cephfsTest)
-	if r.Status != test.Failed {
-		t.Errorf("expected status %q, got %q", test.Failed, r.Status)
+	if r.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, r.Status)
 	}
 
 	// We should have a failed tests step.
@@ -304,11 +303,11 @@ func TestReportCleanTestFailed(t *testing.T) {
 
 	// One test failed, so the tests step must be failed.
 	tests := r.Steps[0]
-	if tests.Name != test.TestsStep {
-		t.Errorf("expected step name %q, got %q", test.TestsStep, tests.Name)
+	if tests.Name != TestsStep {
+		t.Errorf("expected step name %q, got %q", TestsStep, tests.Name)
 	}
-	if tests.Status != test.Failed {
-		t.Errorf("expected step status %q, got %q", test.Failed, tests.Status)
+	if tests.Status != Failed {
+		t.Errorf("expected step status %q, got %q", Failed, tests.Status)
 	}
 
 	// The tests setup must have 2 results.
@@ -316,7 +315,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := test.Result{
+	rbdResult := Result{
 		Workload: rbdTest.Config.Workload,
 		Deployer: rbdTest.Config.Deployer,
 		PVCSpec:  rbdTest.Config.PVCSpec,
@@ -326,7 +325,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := test.Result{
+	cephfsResult := Result{
 		Workload: cephfsTest.Config.Workload,
 		Deployer: cephfsTest.Config.Deployer,
 		PVCSpec:  cephfsTest.Config.PVCSpec,
@@ -346,25 +345,25 @@ func TestReportCleanTestFailed(t *testing.T) {
 }
 
 func TestReportCleanFailed(t *testing.T) {
-	r := test.NewReport("test-clean")
+	r := NewReport("test-clean")
 
-	rbdTest := &test.Test{
+	rbdTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(rbdTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	step := &test.Step{Name: test.CleanupStep, Status: test.Failed}
+	step := &Step{Name: CleanupStep, Status: Failed}
 	r.AddStep(step)
-	if r.Status != test.Failed {
-		t.Errorf("expected status %q, got %q", test.Failed, r.Status)
+	if r.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, r.Status)
 	}
 
 	// We should have a passed tests and failed cleanup steps.
@@ -374,16 +373,16 @@ func TestReportCleanFailed(t *testing.T) {
 
 	// All tests passed, so the tests step must be passed.
 	tests := r.Steps[0]
-	if tests.Name != test.TestsStep {
-		t.Errorf("expected step name %q, got %q", test.TestsStep, tests.Name)
+	if tests.Name != TestsStep {
+		t.Errorf("expected step name %q, got %q", TestsStep, tests.Name)
 	}
-	if tests.Status != test.Passed {
-		t.Errorf("expected step status %q, got %q", test.Passed, tests.Status)
+	if tests.Status != Passed {
+		t.Errorf("expected step status %q, got %q", Passed, tests.Status)
 	}
 
 	// The cleanup step failed, the step must be passed.
 	cleanup := r.Steps[1]
-	failedCleanup := &test.Step{Name: test.CleanupStep, Status: test.Failed}
+	failedCleanup := &Step{Name: CleanupStep, Status: Failed}
 	if !reflect.DeepEqual(cleanup, failedCleanup) {
 		t.Fatalf("expected setup %+v, got %+v", cleanup, failedCleanup)
 	}
@@ -398,38 +397,38 @@ func TestReportCleanFailed(t *testing.T) {
 }
 
 func TestReportCleanAllPassed(t *testing.T) {
-	r := test.NewReport("test-clean")
+	r := NewReport("test-clean")
 
-	rbdTest := &test.Test{
+	rbdTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "rbd",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(rbdTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	cephfsTest := &test.Test{
+	cephfsTest := &Test{
 		Config: types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
 			PVCSpec:  "cephfs",
 		},
-		Status: test.Passed,
+		Status: Passed,
 	}
 	r.AddTest(cephfsTest)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
-	step := &test.Step{Name: test.CleanupStep, Status: test.Passed}
+	step := &Step{Name: CleanupStep, Status: Passed}
 	r.AddStep(step)
-	if r.Status != test.Passed {
-		t.Errorf("expected status %q, got %q", test.Passed, r.Status)
+	if r.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, r.Status)
 	}
 
 	// We should have a passed tests and cleanup steps.
@@ -439,11 +438,11 @@ func TestReportCleanAllPassed(t *testing.T) {
 
 	// All tests passed, so the tests step must be passed.
 	tests := r.Steps[0]
-	if tests.Name != test.TestsStep {
-		t.Errorf("expected step name %q, got %q", test.TestsStep, tests.Name)
+	if tests.Name != TestsStep {
+		t.Errorf("expected step name %q, got %q", TestsStep, tests.Name)
 	}
-	if tests.Status != test.Passed {
-		t.Errorf("expected step status %q, got %q", test.Passed, tests.Status)
+	if tests.Status != Passed {
+		t.Errorf("expected step status %q, got %q", Passed, tests.Status)
 	}
 
 	// The tests setup must have 2 passed results.
@@ -451,7 +450,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 		t.Errorf("unexpected tests %+v", tests.Items)
 	}
 
-	rbdResult := test.Result{
+	rbdResult := Result{
 		Workload: rbdTest.Config.Workload,
 		Deployer: rbdTest.Config.Deployer,
 		PVCSpec:  rbdTest.Config.PVCSpec,
@@ -461,7 +460,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
-	cephfsResult := test.Result{
+	cephfsResult := Result{
 		Workload: cephfsTest.Config.Workload,
 		Deployer: cephfsTest.Config.Deployer,
 		PVCSpec:  cephfsTest.Config.PVCSpec,
@@ -473,7 +472,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 
 	// The cleanup step passed, the step must be passed.
 	cleanup := r.Steps[1]
-	passedCleanup := &test.Step{Name: test.CleanupStep, Status: test.Passed}
+	passedCleanup := &Step{Name: CleanupStep, Status: Passed}
 	if !reflect.DeepEqual(cleanup, passedCleanup) {
 		t.Fatalf("expected setup %+v, got %+v", cleanup, passedCleanup)
 	}
@@ -487,13 +486,13 @@ func TestReportCleanAllPassed(t *testing.T) {
 	checkRoundtrip(t, r)
 }
 
-func checkRoundtrip(t *testing.T, r1 *test.Report) {
+func checkRoundtrip(t *testing.T, r1 *Report) {
 	// We must be able to marshal and unmarshal the report
 	b, err := yaml.Marshal(r1)
 	if err != nil {
 		t.Fatalf("failed to marshal report: %s", err)
 	}
-	r2 := &test.Report{}
+	r2 := &Report{}
 	if err := yaml.Unmarshal(b, r2); err != nil {
 		t.Fatalf("failed to unmarshal report: %s", err)
 	}

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -17,8 +17,8 @@ import (
 // Test perform DR opetaions for testing DR flow.
 type Test struct {
 	types.Context
-	Config types.TestConfig
 	Status Status
+	Config *Config
 }
 
 // newTest creates a test from test configuration and command context.
@@ -40,8 +40,12 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 
 	return &Test{
 		Context: newContext(workload, deployer, cmd),
-		Config:  tc,
 		Status:  Passed,
+		Config: &Config{
+			Workload: tc.Workload,
+			Deployer: tc.Deployer,
+			PVCSpec:  tc.PVCSpec,
+		},
 	}
 }
 


### PR DESCRIPTION
Change report structure to support nested steps. This will allow
grouping validation and setup steps in to single prepare step and adding
test steps (deploy, protect, ...) and timing info to the report.

To keep the structure consistent we include now the test name. This
makes it easier to relate to the test output and easier to follow.

## Example run

```console
🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "appset-deploy-cephfs" deployed
   ✅ Application "appset-deploy-rbd" protected
   ✅ Application "appset-deploy-cephfs" protected
   ✅ Application "appset-deploy-cephfs" failed over
   ✅ Application "appset-deploy-rbd" failed over
   ✅ Application "appset-deploy-cephfs" relocated
   ✅ Application "appset-deploy-rbd" relocated
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed
```

## Example report

```yaml
steps:
- name: validate
  status: passed
- name: setup
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: cephfs
      workload: deploy
    name: appset-deploy-cephfs
    status: passed
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    name: appset-deploy-rbd
    status: passed
  name: tests
  status: passed
```

## Full test report

[test.tar.gz](https://github.com/user-attachments/files/19473885/test.tar.gz)

Part-of: #50
Part-of: #51