### PR TITLE
Auto detect distro 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/ramendr/ramen/e2e v0.0.0-20250326144158-a155370cdec2
+	github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	sigs.k8s.io/yaml v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -101,8 +101,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250326144158-a155370cdec2 h1:YLbeHbUKOE6YinYJubVx36JIs4b25BUtfiMXyZSOLs8=
-github.com/ramendr/ramen/e2e v0.0.0-20250326144158-a155370cdec2/go.mod h1:T0E9hZ6IoV0sfz0bC/JzZuLQVk9Hfzkabw7ZnMJgGrw=
+github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68 h1:LuJX/VNfg3FVQBhm5WQt2ymX6jtzXkgfUifpzmKMb1Y=
+github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68/go.mod h1:T0E9hZ6IoV0sfz0bC/JzZuLQVk9Hfzkabw7ZnMJgGrw=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -14,10 +14,6 @@ clusters:
     name: {{.SecondaryName}}
     kubeconfig: {{.SecondaryKubeconfig}}
 
-## Kubernetes distribution
-# - Modify to specify your clusters kuberenetes distribution (k8s or ocp).
-distro: k8s
-
 ## Git repository for test command.
 # - Modify "url" to use your own Git repository.
 # - Modify "branch" to test a different branch.


### PR DESCRIPTION
Updated to latest ramen/e2e to include [feature](https://github.com/RamenDR/ramen/issues/1907) added to detect the distro. 
Removed the distro config from the sample.

tested `ramenctl test run` command on ocp and drenv:
All tests passed and autodetected distro on both env.
ocp:
```
2025-03-27T20:34:44.755+0530	INFO	validate/validation.go:202	Detected kubernetes distribution: "ocp"
2025-03-27T20:34:44.755+0530	INFO	validate/validation.go:203	Using namespaces: {RamenHubNamespace:openshift-operators RamenDRClusterNamespace:openshift-dr-system RamenOpsNamespace:openshift-dr-ops ArgocdNamespace:openshift-gitops}
```
drenv:
```
2025-03-27T20:55:19.320+0530	INFO	validate/validation.go:202	Detected kubernetes distribution: "k8s"
2025-03-27T20:55:19.321+0530	INFO	validate/validation.go:203	Using namespaces: {RamenHubNamespace:ramen-system RamenDRClusterNamespace:ramen-system RamenOpsNamespace:ramen-ops ArgocdNamespace:argocd}
```
