### PR TITLE
config: Remove cluster names from sample config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.4
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68
+	github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68 h1:LuJX/VNfg3FVQBhm5WQt2ymX6jtzXkgfUifpzmKMb1Y=
-github.com/ramendr/ramen/e2e v0.0.0-20250327122433-da983c986e68/go.mod h1:T0E9hZ6IoV0sfz0bC/JzZuLQVk9Hfzkabw7ZnMJgGrw=
+github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386 h1:xhc9BhbcgtrE/K/gplYInnd4DkNltOHFIy5J853KyEw=
+github.com/ramendr/ramen/e2e v0.0.0-20250329065458-d36833ab0386/go.mod h1:T0E9hZ6IoV0sfz0bC/JzZuLQVk9Hfzkabw7ZnMJgGrw=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -62,11 +62,8 @@ func ReadConfig(filename string) (*types.Config, error) {
 
 type Sample struct {
 	CommandName         string
-	HubName             string
 	HubKubeconfig       string
-	PrimaryName         string
 	PrimaryKubeconfig   string
-	SecondaryName       string
 	SecondaryKubeconfig string
 }
 
@@ -97,11 +94,8 @@ func createFile(name string, content []byte) error {
 func defaultSample(commandName string) *Sample {
 	return &Sample{
 		CommandName:         commandName,
-		HubName:             "hub",
 		HubKubeconfig:       "hub/config",
-		PrimaryName:         "primary",
 		PrimaryKubeconfig:   "primary/config",
-		SecondaryName:       "secondary",
 		SecondaryKubeconfig: "secondary/config",
 	}
 }

--- a/pkg/config/envfile.go
+++ b/pkg/config/envfile.go
@@ -51,11 +51,8 @@ func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
 	}
 	return &Sample{
 		CommandName:         commandName,
-		HubName:             envConfig.Ramen.Hub,
 		HubKubeconfig:       envConfig.KubeconfigPath(envConfig.Ramen.Hub),
-		PrimaryName:         envConfig.Ramen.Clusters[0],
 		PrimaryKubeconfig:   envConfig.KubeconfigPath(envConfig.Ramen.Clusters[0]),
-		SecondaryName:       envConfig.Ramen.Clusters[1],
 		SecondaryKubeconfig: envConfig.KubeconfigPath(envConfig.Ramen.Clusters[1]),
 	}, nil
 }

--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -5,13 +5,10 @@
 #   clusters names and path to the kubeconfig file.
 clusters:
   hub:
-    name: {{.HubName}}
     kubeconfig: {{.HubKubeconfig}}
   c1:
-    name: {{.PrimaryName}}
     kubeconfig: {{.PrimaryKubeconfig}}
   c2:
-    name: {{.SecondaryName}}
     kubeconfig: {{.SecondaryKubeconfig}}
 
 ## Git repository for test command.


### PR DESCRIPTION
We dont need users to specify cluster names
anymore since managed cluster names will be
auto detected and hub cluster name will always
be hub.

Also removed cluster name lookup from envfile
since drenv conf will not have cluster names anymore.

These changes are due  to feature added in ramen/e2e:
https://github.com/RamenDR/ramen/issues/1866