### PR TITLE
init: Remove stale note about cluster name

### DIFF
--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -1,8 +1,8 @@
 ## {{.CommandName}} configuration file
 
 ## Clusters configuration.
-# - Modify clusters "kubeconfig" and "name" to match your hub and managed
-#   clusters names and path to the kubeconfig file.
+# - Modify clusters "kubeconfig" to match your hub and managed clusters
+#   kubeconfig files.
 clusters:
   hub:
     kubeconfig: {{.HubKubeconfig}}


### PR DESCRIPTION
We don't allow cluster name configuration now, it is automatically discovered during startup.

This change was missing in #80.