### PR TITLE
Update ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.7
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250403163436-dd4fa747d7f7
+	github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250403163436-dd4fa747d7f7 h1:3dlm10hyAJino8NSOxj5hpBPa9/gNz3VIj5SnG0Xu7Y=
-github.com/ramendr/ramen/e2e v0.0.0-20250403163436-dd4fa747d7f7/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d h1:MVW5GO88K8e6D+gsiEIfIn7WjVS+z3RDEDpEnxLLKRc=
+github.com/ramendr/ramen/e2e v0.0.0-20250404093316-3bc6c2453c1d/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
To consume fixes for OpenShift console compatibility:
- https://github.com/RamenDR/ramen/pull/1989
- https://github.com/RamenDR/ramen/pull/1991

With these fixes we would be able to see and manipulate the test
application in the console. This can be useful for manually cleaning up
if `test clean` was not run.
