### PR TITLE
Fix install script and make it more robust and clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ machine="$(uname -m)"
 if [ "$machine" = "aarch64" ]; then machine="arm64"; fi
 if [ "$machine" = "x86_64" ]; then machine="amd64"; fi
 curl -L -o ramenctl https://github.com/ramendr/ramenctl/releases/download/$tag/ramenctl-$tag-$os-$machine
-sudo install ramentcl /usr/local/bin/
+sudo install ramenctl /usr/local/bin/
 rm ramenctl
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ os="$(uname | tr '[:upper:]' '[:lower:]')"
 machine="$(uname -m)"
 if [ "$machine" = "aarch64" ]; then machine="arm64"; fi
 if [ "$machine" = "x86_64" ]; then machine="amd64"; fi
-curl -L -o ramenctl https://github.com/ramendr/ramenctl/releases/download/$tag/ramenctl-$tag-$os-$machine
+curl --location --fail --silent --show-error --output ramenctl \
+    https://github.com/ramendr/ramenctl/releases/download/$tag/ramenctl-$tag-$os-$machine
 sudo install ramenctl /usr/local/bin/
 rm ramenctl
 ```


### PR DESCRIPTION
- We downloaded the executable, but the install command failed because of typo.
- Make the curl command more robust and clear, failing on errors instead of creating invalid executable.

Tested with my fork:
https://github.com/nirs/ramenctl/tree/v0.3.4-rc2

```console
tag="$(curl -fsSL https://api.github.com/repos/nirs/ramenctl/releases/latest | jq -r .tag_name)"
os="$(uname | tr '[:upper:]' '[:lower:]')"
machine="$(uname -m)"
if [ "$machine" = "aarch64" ]; then machine="arm64"; fi
if [ "$machine" = "x86_64" ]; then machine="amd64"; fi
curl --location --fail --silent --show-error --output ramenctl \
    https://github.com/nirs/ramenctl/releases/download/$tag/ramenctl-$tag-$os-$machine
sudo install ramenctl /usr/local/bin/
rm ramenctl

% /usr/local/bin/ramenctl -v
v0.3.4-rc2
```