### PR TITLE
 init: Optimize storage classes for ODF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ cover.out
 
 # Editor files
 /.zed
+
+# Test results
+/.test

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /ramenctl
 /examples/odf
 /config.yaml
+cover.out
 
 # Editor files
 /.zed

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ build := github.com/ramendr/ramenctl/pkg/build
 ldflags := -X '$(build).Version=$(version)' \
 		   -X '$(build).Commit=$(commit)'
 
-.PHONY: ramenctl examples test clean
+.PHONY: ramenctl examples test clean coverage
 
 all: ramenctl examples
 
@@ -25,7 +25,10 @@ examples:
 	go build -o examples/odf examples/odf.go
 
 test:
-	go test -ldflags="$(ldflags)" -v ./...
+	go test --coverprofile cover.out -ldflags="$(ldflags)" -v ./...
+
+coverage:
+	go tool cover -html=cover.out
 
 clean:
 	rm -f ramenctl examples/odf

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,9 +23,9 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read environment file: %w", err)
 		}
-		sample = sampleFromEnv(commandName, env)
+		sample = SampleFromEnv(commandName, env)
 	} else {
-		sample = defaultSample(commandName)
+		sample = NewSample(commandName)
 	}
 
 	content, err := sample.Bytes()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -101,14 +101,14 @@ func defaultSample(commandName string) *Sample {
 }
 
 func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
-	envConfig, err := ReadEnvFile(envFile)
+	env, err := ReadEnvFile(envFile)
 	if err != nil {
 		return nil, err
 	}
 	return &Sample{
 		CommandName:         commandName,
-		HubKubeconfig:       envConfig.KubeconfigPath(envConfig.Ramen.Hub),
-		PrimaryKubeconfig:   envConfig.KubeconfigPath(envConfig.Ramen.Clusters[0]),
-		SecondaryKubeconfig: envConfig.KubeconfigPath(envConfig.Ramen.Clusters[1]),
+		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
+		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
+		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
 	}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,12 +4,9 @@
 package config
 
 import (
-	"bytes"
-	_ "embed"
 	"errors"
 	"fmt"
 	"os"
-	"text/template"
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -17,9 +14,6 @@ import (
 	"github.com/ramendr/ramen/e2e/workloads"
 	"github.com/ramendr/ramenctl/pkg/console"
 )
-
-//go:embed sample.yaml
-var sampleConfig string
 
 func CreateSampleConfig(filename, commandName, envFile string) error {
 	var sample *Sample
@@ -60,25 +54,6 @@ func ReadConfig(filename string) (*types.Config, error) {
 	return config, nil
 }
 
-type Sample struct {
-	CommandName         string
-	HubKubeconfig       string
-	PrimaryKubeconfig   string
-	SecondaryKubeconfig string
-}
-
-func (s *Sample) Bytes() ([]byte, error) {
-	t, err := template.New("sample").Parse(sampleConfig)
-	if err != nil {
-		return nil, err
-	}
-	var buf bytes.Buffer
-	if err := t.Execute(&buf, s); err != nil {
-		return nil, err
-	}
-	return buf.Bytes(), nil
-}
-
 func createFile(name string, content []byte) error {
 	f, err := os.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_RDWR, 0o600)
 	if err != nil {
@@ -89,26 +64,4 @@ func createFile(name string, content []byte) error {
 		return err
 	}
 	return f.Close()
-}
-
-func defaultSample(commandName string) *Sample {
-	return &Sample{
-		CommandName:         commandName,
-		HubKubeconfig:       "hub/config",
-		PrimaryKubeconfig:   "primary/config",
-		SecondaryKubeconfig: "secondary/config",
-	}
-}
-
-func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
-	env, err := ReadEnvFile(envFile)
-	if err != nil {
-		return nil, err
-	}
-	return &Sample{
-		CommandName:         commandName,
-		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
-		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
-		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
-	}, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -99,3 +99,16 @@ func defaultSample(commandName string) *Sample {
 		SecondaryKubeconfig: "secondary/config",
 	}
 }
+
+func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
+	envConfig, err := ReadEnvFile(envFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Sample{
+		CommandName:         commandName,
+		HubKubeconfig:       envConfig.KubeconfigPath(envConfig.Ramen.Hub),
+		PrimaryKubeconfig:   envConfig.KubeconfigPath(envConfig.Ramen.Clusters[0]),
+		SecondaryKubeconfig: envConfig.KubeconfigPath(envConfig.Ramen.Clusters[1]),
+	}, nil
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,7 +23,7 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 		if err != nil {
 			return fmt.Errorf("failed to read environment file: %w", err)
 		}
-		sample = sampleFromEnv(env, commandName)
+		sample = sampleFromEnv(commandName, env)
 	} else {
 		sample = defaultSample(commandName)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,11 +19,11 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 	var sample *Sample
 	if envFile != "" {
 		console.Info("Using envfile %q", envFile)
-		var err error
-		sample, err = sampleFromEnvFile(envFile, commandName)
+		env, err := ReadEnvFile(envFile)
 		if err != nil {
-			return fmt.Errorf("failed to load environment file: %w", err)
+			return fmt.Errorf("failed to read environment file: %w", err)
 		}
+		sample = sampleFromEnv(env, commandName)
 	} else {
 		sample = defaultSample(commandName)
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,3 +28,36 @@ func TestReadEnvFile(t *testing.T) {
 		t.Fatalf("expected %+v, got %+v", expected, env)
 	}
 }
+
+func TestSample(t *testing.T) {
+	sample := config.NewSample("ramenctl")
+	expected := &config.Sample{
+		CommandName:         "ramenctl",
+		HubKubeconfig:       "hub/config",
+		PrimaryKubeconfig:   "primary/config",
+		SecondaryKubeconfig: "secondary/config",
+	}
+	if !reflect.DeepEqual(expected, sample) {
+		t.Fatalf("expected %+v, got %+v", expected, sample)
+	}
+}
+
+func TestSampleFromEnv(t *testing.T) {
+	env := &config.EnvFile{
+		Name: "rdr",
+		Ramen: config.Ramen{
+			Hub:      "hub",
+			Clusters: []string{"dr1", "dr2"},
+		},
+	}
+	sample := config.SampleFromEnv("ramenctl", env)
+	expected := &config.Sample{
+		CommandName:         "ramenctl",
+		HubKubeconfig:       env.KubeconfigPath("hub"),
+		PrimaryKubeconfig:   env.KubeconfigPath("dr1"),
+		SecondaryKubeconfig: env.KubeconfigPath("dr2"),
+	}
+	if !reflect.DeepEqual(expected, sample) {
+		t.Fatalf("expected %+v, got %+v", expected, sample)
+	}
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -32,10 +32,27 @@ func TestReadEnvFile(t *testing.T) {
 func TestSample(t *testing.T) {
 	sample := config.NewSample("ramenctl")
 	expected := &config.Sample{
-		CommandName:         "ramenctl",
-		HubKubeconfig:       "hub/config",
-		PrimaryKubeconfig:   "primary/config",
-		SecondaryKubeconfig: "secondary/config",
+		CommandName:            "ramenctl",
+		HubKubeconfig:          "hub/config",
+		PrimaryKubeconfig:      "primary/config",
+		SecondaryKubeconfig:    "secondary/config",
+		RBDStorageClassName:    "rook-ceph-block",
+		CephFSStorageClassName: "rook-cephfs-fs1",
+	}
+	if !reflect.DeepEqual(expected, sample) {
+		t.Fatalf("expected %+v, got %+v", expected, sample)
+	}
+}
+
+func TestSampleForODF(t *testing.T) {
+	sample := config.NewSample("odf dr")
+	expected := &config.Sample{
+		CommandName:            "odf dr",
+		HubKubeconfig:          "hub/config",
+		PrimaryKubeconfig:      "primary/config",
+		SecondaryKubeconfig:    "secondary/config",
+		RBDStorageClassName:    "ocs-storagecluster-ceph-rbd",
+		CephFSStorageClassName: "ocs-storagecluster-cephfs",
 	}
 	if !reflect.DeepEqual(expected, sample) {
 		t.Fatalf("expected %+v, got %+v", expected, sample)
@@ -52,10 +69,12 @@ func TestSampleFromEnv(t *testing.T) {
 	}
 	sample := config.SampleFromEnv("ramenctl", env)
 	expected := &config.Sample{
-		CommandName:         "ramenctl",
-		HubKubeconfig:       env.KubeconfigPath("hub"),
-		PrimaryKubeconfig:   env.KubeconfigPath("dr1"),
-		SecondaryKubeconfig: env.KubeconfigPath("dr2"),
+		CommandName:            "ramenctl",
+		HubKubeconfig:          env.KubeconfigPath("hub"),
+		PrimaryKubeconfig:      env.KubeconfigPath("dr1"),
+		SecondaryKubeconfig:    env.KubeconfigPath("dr2"),
+		RBDStorageClassName:    "rook-ceph-block",
+		CephFSStorageClassName: "rook-cephfs-fs1",
 	}
 	if !reflect.DeepEqual(expected, sample) {
 		t.Fatalf("expected %+v, got %+v", expected, sample)

--- a/pkg/config/envfile.go
+++ b/pkg/config/envfile.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"path/filepath"
+
 	"sigs.k8s.io/yaml"
 )
 
@@ -42,17 +43,4 @@ func (e *EnvFile) KubeconfigPath(name string) string {
 		panic(err)
 	}
 	return filepath.Join(homeDir, ".config", "drenv", e.Name, "kubeconfigs", name)
-}
-
-func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
-	envConfig, err := ReadEnvFile(envFile)
-	if err != nil {
-		return nil, err
-	}
-	return &Sample{
-		CommandName:         commandName,
-		HubKubeconfig:       envConfig.KubeconfigPath(envConfig.Ramen.Hub),
-		PrimaryKubeconfig:   envConfig.KubeconfigPath(envConfig.Ramen.Clusters[0]),
-		SecondaryKubeconfig: envConfig.KubeconfigPath(envConfig.Ramen.Clusters[1]),
-	}, nil
 }

--- a/pkg/config/sample.go
+++ b/pkg/config/sample.go
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import (
+	"bytes"
+	_ "embed"
+	"text/template"
+)
+
+//go:embed sample.yaml
+var sampleConfig string
+
+type Sample struct {
+	CommandName         string
+	HubKubeconfig       string
+	PrimaryKubeconfig   string
+	SecondaryKubeconfig string
+}
+
+func (s *Sample) Bytes() ([]byte, error) {
+	t, err := template.New("sample").Parse(sampleConfig)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, s); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func defaultSample(commandName string) *Sample {
+	return &Sample{
+		CommandName:         commandName,
+		HubKubeconfig:       "hub/config",
+		PrimaryKubeconfig:   "primary/config",
+		SecondaryKubeconfig: "secondary/config",
+	}
+}
+
+func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
+	env, err := ReadEnvFile(envFile)
+	if err != nil {
+		return nil, err
+	}
+	return &Sample{
+		CommandName:         commandName,
+		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
+		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
+		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
+	}, nil
+}

--- a/pkg/config/sample.go
+++ b/pkg/config/sample.go
@@ -40,15 +40,11 @@ func defaultSample(commandName string) *Sample {
 	}
 }
 
-func sampleFromEnvFile(envFile, commandName string) (*Sample, error) {
-	env, err := ReadEnvFile(envFile)
-	if err != nil {
-		return nil, err
-	}
+func sampleFromEnv(env *EnvFile, commandName string) *Sample {
 	return &Sample{
 		CommandName:         commandName,
 		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
 		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
 		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
-	}, nil
+	}
 }

--- a/pkg/config/sample.go
+++ b/pkg/config/sample.go
@@ -13,27 +13,46 @@ import (
 var sampleConfig string
 
 type Sample struct {
-	CommandName         string
-	HubKubeconfig       string
-	PrimaryKubeconfig   string
-	SecondaryKubeconfig string
+	CommandName            string
+	HubKubeconfig          string
+	PrimaryKubeconfig      string
+	SecondaryKubeconfig    string
+	RBDStorageClassName    string
+	CephFSStorageClassName string
 }
 
 func NewSample(commandName string) *Sample {
-	return &Sample{
+	sample := &Sample{
 		CommandName:         commandName,
 		HubKubeconfig:       "hub/config",
 		PrimaryKubeconfig:   "primary/config",
 		SecondaryKubeconfig: "secondary/config",
 	}
+
+	// When running as `odf dr init` we optimize for ODF cluster.
+	// TODO: look up available storage classes in the cluster and let the user choose?
+	if commandName == "odf dr" {
+		sample.RBDStorageClassName = "ocs-storagecluster-ceph-rbd"
+		sample.CephFSStorageClassName = "ocs-storagecluster-cephfs"
+	} else {
+		sample.RBDStorageClassName = "rook-ceph-block"
+		sample.CephFSStorageClassName = "rook-cephfs-fs1"
+	}
+
+	return sample
 }
 
 func SampleFromEnv(commandName string, env *EnvFile) *Sample {
+	// Using drenv envfile: use drenv storage classes.
 	return &Sample{
 		CommandName:         commandName,
 		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
 		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
 		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
+
+		// TODO: Get the info from the envfile instead of hard-coding.
+		RBDStorageClassName:    "rook-ceph-block",
+		CephFSStorageClassName: "rook-cephfs-fs1",
 	}
 }
 

--- a/pkg/config/sample.go
+++ b/pkg/config/sample.go
@@ -40,7 +40,7 @@ func defaultSample(commandName string) *Sample {
 	}
 }
 
-func sampleFromEnv(env *EnvFile, commandName string) *Sample {
+func sampleFromEnv(commandName string, env *EnvFile) *Sample {
 	return &Sample{
 		CommandName:         commandName,
 		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),

--- a/pkg/config/sample.go
+++ b/pkg/config/sample.go
@@ -19,6 +19,24 @@ type Sample struct {
 	SecondaryKubeconfig string
 }
 
+func NewSample(commandName string) *Sample {
+	return &Sample{
+		CommandName:         commandName,
+		HubKubeconfig:       "hub/config",
+		PrimaryKubeconfig:   "primary/config",
+		SecondaryKubeconfig: "secondary/config",
+	}
+}
+
+func SampleFromEnv(commandName string, env *EnvFile) *Sample {
+	return &Sample{
+		CommandName:         commandName,
+		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
+		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
+		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
+	}
+}
+
 func (s *Sample) Bytes() ([]byte, error) {
 	t, err := template.New("sample").Parse(sampleConfig)
 	if err != nil {
@@ -29,22 +47,4 @@ func (s *Sample) Bytes() ([]byte, error) {
 		return nil, err
 	}
 	return buf.Bytes(), nil
-}
-
-func defaultSample(commandName string) *Sample {
-	return &Sample{
-		CommandName:         commandName,
-		HubKubeconfig:       "hub/config",
-		PrimaryKubeconfig:   "primary/config",
-		SecondaryKubeconfig: "secondary/config",
-	}
-}
-
-func sampleFromEnv(commandName string, env *EnvFile) *Sample {
-	return &Sample{
-		CommandName:         commandName,
-		HubKubeconfig:       env.KubeconfigPath(env.Ramen.Hub),
-		PrimaryKubeconfig:   env.KubeconfigPath(env.Ramen.Clusters[0]),
-		SecondaryKubeconfig: env.KubeconfigPath(env.Ramen.Clusters[1]),
-	}
 }

--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -32,10 +32,10 @@ clusterSet: default
 # - Add new items for testing more storage types.
 PVCSpecs:
 - name: rbd
-  storageClassName: rook-ceph-block
+  storageClassName: {{.RBDStorageClassName}}
   accessModes: ReadWriteOnce
 - name: cephfs
-  storageClassName: rook-cephfs-fs1
+  storageClassName: {{.CephFSStorageClassName}}
   accessModes: ReadWriteMany
 
 ## Tests cases for test command.


### PR DESCRIPTION
When running as `odf dr` use the default ODF storage class names that                                                                      
are more likely to work instead of drenv storage class name, that will
never work. This minimizes manual configuration, making `odf dr` easier
to use.

When using the --envfile flag we use default drenv storage classes since
envfile is never needed for ODF cluster. Currently the envfile does not 
include the storage class names so we must hard code them in ramenctl.
This makes it possible to use `odf dr init` with a drenv environment,
which can help developer that work mostly with an ODF cluster.

We can consider later smarter way to configure the storage classes like
listing the available storage classes and let the user choose.

To make the change easy and safe the config package was refactored and new
tests added.

Fixes #83 
Fixes #82