### PR TITLE
Add report creation time

### DIFF
--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -5,9 +5,13 @@ package report
 
 import (
 	"runtime"
+	"time"
 
 	"github.com/ramendr/ramenctl/pkg/build"
 )
+
+// Used to provide a custom clock for testing.
+var Now func() time.Time
 
 // Host describes the host ramenctl is running on.
 type Host struct {
@@ -24,8 +28,9 @@ type Build struct {
 
 // Report created by ramenctl command.
 type Report struct {
-	Host  Host   `json:"host"`
-	Build *Build `json:"build,omitempty"`
+	Host    Host      `json:"host"`
+	Build   *Build    `json:"build,omitempty"`
+	Created time.Time `json:"created"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
@@ -36,6 +41,7 @@ func New() *Report {
 			Arch: runtime.GOARCH,
 			Cpus: runtime.NumCPU(),
 		},
+		Created: Now(),
 	}
 	if build.Version != "" || build.Commit != "" {
 		r.Build = &Build{
@@ -44,4 +50,14 @@ func New() *Report {
 		}
 	}
 	return r
+}
+
+// marshalableTime return a time value without monotonic time info. This makes it possible to marshal and unmarshal the
+// time value.
+func marshalableTime() time.Time {
+	return time.Now().Local()
+}
+
+func init() {
+	Now = marshalableTime
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -58,6 +59,14 @@ func TestBuildInfo(t *testing.T) {
 	})
 }
 
+func TestCreatedTime(t *testing.T) {
+	fakeTime(t)
+	r := report.New()
+	if r.Created != report.Now() {
+		t.Fatalf("expected %v, got %v", report.Now(), r.Created)
+	}
+}
+
 func TestRoundtrip(t *testing.T) {
 	r1 := report.New()
 	b, err := yaml.Marshal(r1)
@@ -71,4 +80,16 @@ func TestRoundtrip(t *testing.T) {
 	if !reflect.DeepEqual(r1, r2) {
 		t.Fatalf("expected report %+v, got %+v", r1, r2)
 	}
+}
+
+var fakeNow = report.Now()
+
+func fakeTime(t *testing.T) {
+	savedNow := report.Now
+	report.Now = func() time.Time {
+		return fakeNow
+	}
+	t.Cleanup(func() {
+		report.Now = savedNow
+	})
 }

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -6,6 +6,7 @@ package test
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -13,6 +14,7 @@ import (
 )
 
 func TestReportEmpty(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-run")
 
 	// Host and ramenctl info is ready.
@@ -37,6 +39,7 @@ func TestReportEmpty(t *testing.T) {
 }
 
 func TestReportRunSetupFailed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-run")
 	step := &Step{Name: SetupStep, Status: Failed}
 	r.AddStep(step)
@@ -65,6 +68,7 @@ func TestReportRunSetupFailed(t *testing.T) {
 }
 
 func TestReportRunSetupPassed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
@@ -92,6 +96,7 @@ func TestReportRunSetupPassed(t *testing.T) {
 }
 
 func TestReportRunTestFailed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
@@ -179,6 +184,7 @@ func TestReportRunTestFailed(t *testing.T) {
 }
 
 func TestReportRunAllPassed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-run")
 
 	step := &Step{Name: SetupStep, Status: Passed}
@@ -267,6 +273,7 @@ func TestReportRunAllPassed(t *testing.T) {
 }
 
 func TestReportCleanTestFailed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
@@ -344,6 +351,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 }
 
 func TestReportCleanFailed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
@@ -397,6 +405,7 @@ func TestReportCleanFailed(t *testing.T) {
 }
 
 func TestReportCleanAllPassed(t *testing.T) {
+	fakeTime(t)
 	r := newReport("test-clean")
 
 	rbdTest := &Test{
@@ -499,4 +508,16 @@ func checkRoundtrip(t *testing.T, r1 *Report) {
 	if !reflect.DeepEqual(r1, r2) {
 		t.Fatalf("expected report %+v, got %+v", r1, r2)
 	}
+}
+
+var fakeNow = report.Now()
+
+func fakeTime(t *testing.T) {
+	savedNow := report.Now
+	report.Now = func() time.Time {
+		return fakeNow
+	}
+	t.Cleanup(func() {
+		report.Now = savedNow
+	})
 }


### PR DESCRIPTION
This should be a trivial change but Go made it harder since time.Time includes monotonic time value that break serialization. We fix using .Local() returning local time without monotonic time info.

Another complication is testing - new report.Now() was added to allow the test to freeze report time during the tests.

Example report:

    % head test/test-run.yaml
    build:
      commit: 93ddc8584ad5017842e56f44044c27558f7f5483
      version: v0.3.5
    created: "2025-04-09T18:55:57.087804+03:00"
    host:
      arch: arm64
      cpus: 12
      os: darwin
    name: test-run
    status: passed

Fixes: #64