### PR TITLE
cmd: Remove leftovers after requiring --output

### DIFF
--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -4,8 +4,6 @@
 package commands
 
 import (
-	"time"
-
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/build"
@@ -15,8 +13,8 @@ var (
 	// configFile is shared by all commands, enabling access to all clusters.
 	configFile string
 
-	// userOutputDir is used by troubleshooting commands for creating a report.
-	userOutputDir string
+	// outputDir is used by troubleshooting commands for creating a report.
+	outputDir string
 )
 
 var RootCmd = &cobra.Command{
@@ -37,14 +35,6 @@ func init() {
 }
 
 func addOutputFlag(c *cobra.Command) {
-	// The actual output directory is known only when running the command.
-	c.PersistentFlags().StringVarP(&userOutputDir, "output", "o", "", "report directory (default report.{timestamp})")
+	c.PersistentFlags().StringVarP(&outputDir, "output", "o", "", "output directory")
 	c.MarkPersistentFlagRequired("output")
-}
-
-func outputDir() string {
-	if userOutputDir == "" {
-		return time.Now().Format("report.20060102150405")
-	}
-	return userOutputDir
 }

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -18,7 +18,7 @@ var TestRunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run disaster recovery flow",
 	Run: func(c *cobra.Command, args []string) {
-		if err := test.Run(configFile, outputDir()); err != nil {
+		if err := test.Run(configFile, outputDir); err != nil {
 			console.Fatal(err)
 		}
 	},
@@ -28,7 +28,7 @@ var TestCleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Delete test artifacts",
 	Run: func(c *cobra.Command, args []string) {
-		if err := test.Clean(configFile, outputDir()); err != nil {
+		if err := test.Clean(configFile, outputDir); err != nil {
 			console.Fatal(err)
 		}
 	},

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -18,7 +18,7 @@ var ValidateClustersCmd = &cobra.Command{
 	Use:   "clusters",
 	Short: "Validate clusters configuration",
 	Run: func(c *cobra.Command, args []string) {
-		if err := validate.Clusters(outputDir()); err != nil {
+		if err := validate.Clusters(outputDir); err != nil {
 			console.Fatal(err)
 		}
 		console.Completed("Validation completed successfully")


### PR DESCRIPTION
When we made --output required, we left unused code and incorrect default value:

    Flags:
      -h, --help            help for test
      -o, --output string   report directory (default report.{timestamp})

Remove outputDir() helper and rename userOutputDir to outputDir. The code using this flag access the value via the global variable.

Example help:

    Flags:
      -h, --help            help for test
      -o, --output string   output directory