### PR TITLE
Fix spelling of pvcSpecs

### DIFF
--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -30,7 +30,7 @@ clusterSet: default
 # - Modify items "storageclassname" to match the actual storage classes in the
 #   managed clusters.
 # - Add new items for testing more storage types.
-PVCSpecs:
+pvcSpecs:
 - name: rbd
   storageClassName: {{.RBDStorageClassName}}
   accessModes: ReadWriteOnce


### PR DESCRIPTION
Both PVCSpecs and pvcSpecs works since viper config is case insensitive, but we document pvcSpecs.

Thanks: Annette Clewett