### PR TITLE
test: Report test steps

### DIFF
--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -149,6 +149,7 @@ func (s *Step) AddTest(t *Test) {
 		Name:   t.Name(),
 		Config: t.Config,
 		Status: t.Status,
+		Items:  t.Steps,
 	}
 
 	s.Items = append(s.Items, result)

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -114,6 +114,11 @@ func TestReportRunTestFailed(t *testing.T) {
 			PVCSpec:  "rbd",
 		},
 		Status: Failed,
+		Steps: []*Step{
+			{Name: "deploy", Status: Passed},
+			{Name: "protect", Status: Passed},
+			{Name: "failover", Status: Failed},
+		},
 	}
 	r.AddTest(failedTest)
 	if r.Status != Failed {
@@ -128,6 +133,14 @@ func TestReportRunTestFailed(t *testing.T) {
 			PVCSpec:  "cephfs",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "deploy", Status: Passed},
+			{Name: "protect", Status: Passed},
+			{Name: "failover", Status: Passed},
+			{Name: "relocate", Status: Passed},
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(passedTest)
 	if r.Status != Failed {
@@ -161,6 +174,7 @@ func TestReportRunTestFailed(t *testing.T) {
 		Name:   failedTest.Name(),
 		Config: failedTest.Config,
 		Status: failedTest.Status,
+		Items:  failedTest.Steps,
 	}
 	if !tests.Items[0].Equal(failedResult) {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[0])
@@ -170,6 +184,7 @@ func TestReportRunTestFailed(t *testing.T) {
 		Name:   passedTest.Name(),
 		Config: passedTest.Config,
 		Status: passedTest.Status,
+		Items:  passedTest.Steps,
 	}
 	if !tests.Items[1].Equal(passedResult) {
 		t.Errorf("expected result %+v, got %+v", passedResult, tests.Items[1])
@@ -203,6 +218,14 @@ func TestReportRunAllPassed(t *testing.T) {
 			PVCSpec:  "rbd",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "deploy", Status: Passed},
+			{Name: "protect", Status: Passed},
+			{Name: "failover", Status: Passed},
+			{Name: "relocate", Status: Passed},
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(rbdTest)
 	if r.Status != Passed {
@@ -217,6 +240,14 @@ func TestReportRunAllPassed(t *testing.T) {
 			PVCSpec:  "cephfs",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "deploy", Status: Passed},
+			{Name: "protect", Status: Passed},
+			{Name: "failover", Status: Passed},
+			{Name: "relocate", Status: Passed},
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(cephfsTest)
 	if r.Status != Passed {
@@ -251,6 +282,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
+		Items:  rbdTest.Steps,
 	}
 	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
@@ -260,6 +292,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
+		Items:  cephfsTest.Steps,
 	}
 	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
@@ -286,6 +319,10 @@ func TestReportCleanTestFailed(t *testing.T) {
 			PVCSpec:  "rbd",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(rbdTest)
 	if r.Status != Passed {
@@ -300,6 +337,9 @@ func TestReportCleanTestFailed(t *testing.T) {
 			PVCSpec:  "cephfs",
 		},
 		Status: Failed,
+		Steps: []*Step{
+			{Name: "unprotect", Status: Failed},
+		},
 	}
 	r.AddTest(cephfsTest)
 	if r.Status != Failed {
@@ -329,6 +369,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
+		Items:  rbdTest.Steps,
 	}
 	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
@@ -338,6 +379,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
+		Items:  cephfsTest.Steps,
 	}
 	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])
@@ -364,6 +406,10 @@ func TestReportCleanFailed(t *testing.T) {
 			PVCSpec:  "rbd",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(rbdTest)
 	if r.Status != Passed {
@@ -419,6 +465,10 @@ func TestReportCleanAllPassed(t *testing.T) {
 			PVCSpec:  "rbd",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(rbdTest)
 	if r.Status != Passed {
@@ -433,6 +483,10 @@ func TestReportCleanAllPassed(t *testing.T) {
 			PVCSpec:  "cephfs",
 		},
 		Status: Passed,
+		Steps: []*Step{
+			{Name: "unprotect", Status: Passed},
+			{Name: "undeploy", Status: Passed},
+		},
 	}
 	r.AddTest(cephfsTest)
 	if r.Status != Passed {
@@ -468,6 +522,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 		Name:   rbdTest.Name(),
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
+		Items:  rbdTest.Steps,
 	}
 	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
@@ -477,6 +532,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 		Name:   cephfsTest.Name(),
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
+		Items:  cephfsTest.Steps,
 	}
 	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -52,65 +52,65 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 func (t *Test) Deploy() bool {
 	if err := t.Deployer().Deploy(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to deploy application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q deployed", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q deployed", t.Name())
+	return t.pass(msg)
 }
 
 func (t *Test) Undeploy() bool {
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to undeploy application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q undeployed", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q undeployed", t.Name())
+	return t.pass(msg)
 }
 
 func (t *Test) Protect() bool {
 	if err := dractions.EnableProtection(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to protect application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q protected", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q protected", t.Name())
+	return t.pass(msg)
 }
 
 func (t *Test) Unprotect() bool {
 	if err := dractions.DisableProtection(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to unprotect application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q unprotected", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q unprotected", t.Name())
+	return t.pass(msg)
 }
 
 func (t *Test) Failover() bool {
 	if err := dractions.Failover(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to failover application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q failed over", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q failed over", t.Name())
+	return t.pass(msg)
 }
 
 func (t *Test) Relocate() bool {
 	if err := dractions.Relocate(t.Context); err != nil {
 		msg := fmt.Sprintf("failed to relocate application %q", t.Name())
-		t.fail(msg, err)
-		return false
+		return t.fail(msg, err)
 	}
-	console.Pass("Application %q relocated", t.Name())
-	return true
+	msg := fmt.Sprintf("Application %q relocated", t.Name())
+	return t.pass(msg)
 }
 
-func (t *Test) fail(msg string, err error) {
+func (t *Test) fail(msg string, err error) bool {
 	console.Error(msg)
 	t.Logger().Errorf("%s: %s", msg, err)
 	t.Status = Failed
+	return false
+}
+
+func (t *Test) pass(msg string) bool {
+	console.Pass(msg)
+	return true
 }


### PR DESCRIPTION
When a test fails, we want to know which step failed. In the future we
want to support running single steps (#78) or configurable test flows
(#84). In both case we want an easy way to know what was the tested
flow. We can learn about the tested flow from the logs but it is much
easier and quicker when the information is part of the report.

Example test run:

```console
% cat test/test-run.yaml
build:
  commit: e7f811d652c91383227c115c006b9ad883efc12b
  version: v0.3.5-2-ge7f811d
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
status: passed
steps:
- name: validate
  status: passed
- name: setup
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: passed
    - name: failover
      status: passed
    - name: relocate
      status: passed
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-rbd
    status: passed
  ...

Example test clean:

```console
% cat test/test-clean.yaml
build:
  commit: e7f811d652c91383227c115c006b9ad883efc12b
  version: v0.3.5-2-ge7f811d
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
status: passed
steps:
- name: validate
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-rbd
    status: passed
  ...
```

Fixes: #50