### PR TITLE
ci: Run tests on all platforms and architectures

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,9 +11,8 @@ on:
       - main
 
 jobs:
-
   build-matrix:
-    name: Build binaries
+    name: Build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -33,5 +32,35 @@ jobs:
         with:
           go-version-file: go.mod
           cache: false
+      - name: Download modules
+        run: go mod download
       - name: Build binary
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make
+
+  test-matrix:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        # See https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+        runner:
+          - ubuntu-24.04 # x86_64
+          - ubuntu-24.04-arm # arm64
+          - windows-latest # x86_64
+          - macos-13 # x86_64
+          - macos-15 # arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Create build tag
+        run: git tag latest
+      - name: Setup go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Download modules
+        run: go mod download
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: The RamenDR authors
 # SPDX-License-Identifier: Apache-2.0
 
+GO ?= go
+
 # v0.5.1 when building from tag (release)
 # v0.5.1-1-gcf79160 when building without tag (development)
 version := $(shell git describe --tags)
@@ -19,16 +21,16 @@ ldflags := -X '$(build).Version=$(version)' \
 all: ramenctl examples
 
 ramenctl:
-	CGO_ENABLED=0 go build -ldflags="$(ldflags)" cmd/ramenctl.go
+	CGO_ENABLED=0 $(GO) build -ldflags="$(ldflags)" cmd/ramenctl.go
 
 examples:
-	go build -o examples/odf examples/odf.go
+	$(GO) build -o examples/odf examples/odf.go
 
 test:
-	go test --coverprofile cover.out -ldflags="$(ldflags)" -v ./...
+	$(GO) test --coverprofile cover.out -ldflags="$(ldflags)" -v ./...
 
 coverage:
-	go tool cover -html=cover.out
+	$(GO) tool cover -html=cover.out
 
 clean:
 	rm -f ramenctl examples/odf

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/ramendr/ramenctl
 go 1.23.5
 
 // Recommended version: latest go 1.23 release.
-toolchain go1.23.7
+toolchain go1.23.8
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -52,6 +52,28 @@ func New() *Report {
 	return r
 }
 
+// Equal returns true if repoert is qual to other report.
+func (r *Report) Equal(o *Report) bool {
+	if o == nil {
+		return false
+	}
+	if r.Host != o.Host {
+		return false
+	}
+	if !r.Created.Equal(o.Created) {
+		return false
+	}
+	if r.Build != o.Build {
+		if r.Build == nil || o.Build == nil {
+			return false
+		}
+		if *r.Build != *o.Build {
+			return false
+		}
+	}
+	return true
+}
+
 // marshalableTime return a time value without monotonic time info. This makes it possible to marshal and unmarshal the
 // time value.
 func marshalableTime() time.Time {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -77,7 +77,7 @@ func TestRoundtrip(t *testing.T) {
 	if err := yaml.Unmarshal(b, r2); err != nil {
 		t.Fatalf("failed to unmarshal yaml: %s", err)
 	}
-	if !reflect.DeepEqual(r1, r2) {
+	if !r1.Equal(r2) {
 		t.Fatalf("expected report %+v, got %+v", r1, r2)
 	}
 }

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -5,6 +5,7 @@ package test
 
 import (
 	"fmt"
+	"slices"
 
 	"github.com/ramendr/ramenctl/pkg/report"
 )
@@ -111,6 +112,28 @@ func (r *Report) AddTest(t *Test) {
 	}
 }
 
+// Equal return true if report is equal to other report.
+func (r *Report) Equal(o *Report) bool {
+	if o == nil {
+		return false
+	}
+	if !r.Report.Equal(o.Report) {
+		return false
+	}
+	if r.Name != o.Name {
+		return false
+	}
+	if r.Status != o.Status {
+		return false
+	}
+	if r.Summary != o.Summary {
+		return false
+	}
+	return slices.EqualFunc(r.Steps, o.Steps, func(a *Step, b *Step) bool {
+		return a.Equal(b)
+	})
+}
+
 func (r *Report) findStep(name string) *Step {
 	for _, step := range r.Steps {
 		if step.Name == name {
@@ -138,4 +161,31 @@ func (s *Step) AddTest(t *Test) {
 	case Failed:
 		s.Status = Failed
 	}
+}
+
+// Equal return true if step is equal to other step.
+func (s *Step) Equal(o *Step) bool {
+	if o == nil {
+		return false
+	}
+	if s.Name != o.Name {
+		return false
+	}
+	if s.Status != o.Status {
+		return false
+	}
+	if s.Config != o.Config {
+		if s.Config == nil || o.Config == nil {
+			return false
+		}
+		if *s.Config != *o.Config {
+			return false
+		}
+	}
+	return slices.EqualFunc(s.Items, o.Items, func(a *Step, b *Step) bool {
+		if a == nil {
+			return b == nil
+		}
+		return a.Equal(b)
+	})
 }

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -4,7 +4,6 @@
 package test
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
@@ -19,7 +18,7 @@ func TestReportEmpty(t *testing.T) {
 
 	// Host and ramenctl info is ready.
 	expectedReport := report.New()
-	if !reflect.DeepEqual(r.Report, expectedReport) {
+	if !r.Report.Equal(expectedReport) {
 		t.Errorf("expected report %+v, got %+v", expectedReport, r.Report)
 	}
 
@@ -54,13 +53,14 @@ func TestReportRunSetupFailed(t *testing.T) {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
 	failedSetup := &Step{Name: SetupStep, Status: Failed}
-	if !reflect.DeepEqual(r.Steps[0], failedSetup) {
+	if !r.Steps[0].Equal(failedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", r.Steps[0], failedSetup)
 	}
 
 	// No test run son counts should be zero.
-	if r.Summary.Passed != 0 || r.Summary.Failed != 0 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
+	expectedSummary := Summary{}
+	if r.Summary != expectedSummary {
+		t.Errorf("expected summary %+v,  %+v", expectedSummary, r.Summary)
 	}
 
 	// We can marshal and unmarshal the report
@@ -82,13 +82,14 @@ func TestReportRunSetupPassed(t *testing.T) {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
 	passedSetup := &Step{Name: SetupStep, Status: Passed}
-	if !reflect.DeepEqual(r.Steps[0], passedSetup) {
-		t.Fatalf("expected setup %+v, got %+v", r.Steps[0], passedSetup)
+	if !r.Steps[0].Equal(passedSetup) {
+		t.Fatalf("expected setup %+v, got %+v", passedSetup, r.Steps[0])
 	}
 
 	// No test run son counts should be zero.
-	if r.Summary.Passed != 0 || r.Summary.Failed != 0 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
+	expectedSummary := Summary{}
+	if r.Summary != expectedSummary {
+		t.Errorf("expected summary %+v, got %+v", expectedSummary, r.Summary)
 	}
 
 	// We can marshal and unmarshal the report
@@ -139,8 +140,8 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 	setup := r.Steps[0]
 	passedSetup := &Step{Name: SetupStep, Status: Passed}
-	if !reflect.DeepEqual(setup, passedSetup) {
-		t.Fatalf("expected setup %+v, got %+v", setup, passedSetup)
+	if !setup.Equal(passedSetup) {
+		t.Fatalf("expected setup %+v, got %+v", passedSetup, setup)
 	}
 	// One test failed, so the tests step must be failed.
 	tests := r.Steps[1]
@@ -161,7 +162,7 @@ func TestReportRunTestFailed(t *testing.T) {
 		Config: failedTest.Config,
 		Status: failedTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[0], failedResult) {
+	if !tests.Items[0].Equal(failedResult) {
 		t.Errorf("expected result %+v, got %+v", failedResult, tests.Items[0])
 	}
 
@@ -170,13 +171,14 @@ func TestReportRunTestFailed(t *testing.T) {
 		Config: passedTest.Config,
 		Status: passedTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[1], passedResult) {
+	if !tests.Items[1].Equal(passedResult) {
 		t.Errorf("expected result %+v, got %+v", passedResult, tests.Items[1])
 	}
 
 	// Counts updated.
-	if r.Summary.Passed != 1 || r.Summary.Failed != 1 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
+	expectedSummary := Summary{Passed: 1, Failed: 1}
+	if r.Summary != expectedSummary {
+		t.Errorf("expected summary %+v, got %+v", expectedSummary, r.Summary)
 	}
 
 	// We can marshal and unmarshal the report
@@ -227,8 +229,8 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 	setup := r.Steps[0]
 	passedSetup := &Step{Name: SetupStep, Status: Passed}
-	if !reflect.DeepEqual(setup, passedSetup) {
-		t.Fatalf("expected setup %+v, got %+v", setup, passedSetup)
+	if !setup.Equal(passedSetup) {
+		t.Fatalf("expected setup %+v, got %+v", passedSetup, setup)
 	}
 
 	// All tests passed, so the tests step must be passed.
@@ -250,7 +252,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
+	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
@@ -259,7 +261,7 @@ func TestReportRunAllPassed(t *testing.T) {
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
+	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[1])
 	}
 
@@ -328,7 +330,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
+	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
@@ -337,7 +339,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
+	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])
 	}
 
@@ -391,13 +393,14 @@ func TestReportCleanFailed(t *testing.T) {
 	// The cleanup step failed, the step must be passed.
 	cleanup := r.Steps[1]
 	failedCleanup := &Step{Name: CleanupStep, Status: Failed}
-	if !reflect.DeepEqual(cleanup, failedCleanup) {
+	if !cleanup.Equal(failedCleanup) {
 		t.Fatalf("expected setup %+v, got %+v", cleanup, failedCleanup)
 	}
 
 	// Counts updated.
-	if r.Summary.Passed != 1 || r.Summary.Failed != 0 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
+	expectedSummary := Summary{Passed: 1}
+	if r.Summary != expectedSummary {
+		t.Errorf("expected summary %+v, got %+v", expectedSummary, r.Summary)
 	}
 
 	// We can marshal and unmarshal the report
@@ -466,7 +469,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 		Config: rbdTest.Config,
 		Status: rbdTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[0], rbdResult) {
+	if !tests.Items[0].Equal(rbdResult) {
 		t.Errorf("expected result %+v, got %+v", rbdResult, tests.Items[0])
 	}
 
@@ -475,20 +478,21 @@ func TestReportCleanAllPassed(t *testing.T) {
 		Config: cephfsTest.Config,
 		Status: cephfsTest.Status,
 	}
-	if !reflect.DeepEqual(tests.Items[1], cephfsResult) {
+	if !tests.Items[1].Equal(cephfsResult) {
 		t.Errorf("expected result %+v, got %+v", cephfsResult, tests.Items[1])
 	}
 
 	// The cleanup step passed, the step must be passed.
 	cleanup := r.Steps[1]
 	passedCleanup := &Step{Name: CleanupStep, Status: Passed}
-	if !reflect.DeepEqual(cleanup, passedCleanup) {
+	if !cleanup.Equal(passedCleanup) {
 		t.Fatalf("expected setup %+v, got %+v", cleanup, passedCleanup)
 	}
 
 	// Counts updated.
-	if r.Summary.Passed != 2 || r.Summary.Failed != 0 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
+	expectedSummary := Summary{Passed: 2}
+	if r.Summary != expectedSummary {
+		t.Errorf("expected %+v, got %+v", expectedSummary, r.Summary)
 	}
 
 	// We can marshal and unmarshal the report
@@ -505,7 +509,7 @@ func checkRoundtrip(t *testing.T, r1 *Report) {
 	if err := yaml.Unmarshal(b, r2); err != nil {
 		t.Fatalf("failed to unmarshal report: %s", err)
 	}
-	if !reflect.DeepEqual(r1, r2) {
+	if !r1.Equal(r2) {
 		t.Fatalf("expected report %+v, got %+v", r1, r2)
 	}
 }


### PR DESCRIPTION
We want to ensure that ramenctl works on all supported platforms. The best way to do this is to run the unit tests.

Add test matrix job running on all available github runners[1]:

- ubuntu-24.04 (x86_64)
- ubuntu-24.04-arm (arm64)
- windwos-latest (x86_64)
- macos-13 (x86_64)
- macos-15 (arm64)

On each runner we build the executables and run the tests.

We cannot use the build job since all jobs run on ubuntu-latest (x86_64) and we use cross compiling to build the executables for all os and architectures.

[1] https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Fixes: #42