### PR TITLE
build: Upload built executables

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Create build tag
-        run: git tag latest
+        run: git tag build-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Setup go
         uses: actions/setup-go@v5
         with:
@@ -52,6 +52,13 @@ jobs:
         run: go mod download
       - name: Build binary
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ramenctl-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: ramenctl*
+          retention-days: 15
+          compression-level: 9
 
   test-matrix:
     name: Test


### PR DESCRIPTION
Upload the built executables so they are available for download from the                                                                         
build page. This will be useful for testing PRs by non-developers,
saving the time to build and send files manually.

We use a special tag "build-14503707498-1", corresponding to
https://github.com/RamenDR/ramenctl/actions/runs/14503707498/attempts/1.

The build tag is reported in --version:

    $ ramenctl --version
    build-14503707498-1

And in the report build info:

    build:
      version: build-14503707498-1
      commit: 375a5318b851ce1fb3f70c0c02a69b3f454a2992

On macOS executables downloaded by the browser are considered unsafe and                                                                         
cannot run. To remove the protection run:

    xattr -d com.apple.quarantine ramenctl

Fixes: #117