### PR TITLE
test: Make clean flow more robust                                                                                                                

### DIFF
--- a/docs/test.md
+++ b/docs/test.md
@@ -90,8 +90,8 @@ $ ramenctl test clean -o test
    ✅ Config validated
 
 🔎 Clean tests ...
-   ✅ Application "appset-deploy-rbd" unprotected
    ✅ Application "appset-deploy-rbd" undeployed
+   ✅ Application "appset-deploy-rbd" unprotected
 
 🔎 Clean environment ...
    ✅ Environment cleaned

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -280,8 +280,8 @@ $ ramenctl test clean -o ramenctl-test
    ✅ Config validated
 
 🔎 Clean tests ...
-   ✅ Application "appset-deploy-rbd" unprotected
    ✅ Application "appset-deploy-rbd" undeployed
+   ✅ Application "appset-deploy-rbd" unprotected
 
 🔎 Clean environment ...
    ✅ Environment cleaned
@@ -303,14 +303,14 @@ ramenctl-test
 
 #### The clean flow
 
-When runnning the clean command *ramenctl* deletes all the tests applications
+When running the clean command *ramenctl* deletes all the tests applications
 specified in the configuration file and cleans up the clusters.
 
 For every test specified in the configuration file perform the following steps:
+1. **undeploy**: Undeploy the application from the managed clusters and wait
+   until the application is deleted.
 1. **unprotect**: Delete the *drpc* resource for the application and wait
    until the *drpc* is deleted.
-2. **undeploy**: Undeploy the application from the managed clusters and wait
-   until the application is deleted.
 
 Cleaning up the clusters includes:
 1. Delete the channel and the namespace "test-gitops" on the hub cluster.
@@ -318,8 +318,8 @@ Cleaning up the clusters includes:
 ### Failed tests
 
 When a test fails, the test command gathers data related to the failed tests in
-the ouput directory. The gathered data can help you or develpers to diagnose the
-issue.
+the output directory. The gathered data can help you or developers to diagnose
+the issue.
 
 The following example shows a test run with a failed test, and how to inspect
 the failure.
@@ -563,8 +563,8 @@ $ ramenctl test clean -o example-failure
    ✅ Config validated
 
 🔎 Clean tests ...
-   ✅ Application "appset-deploy-rbd" unprotected
    ✅ Application "appset-deploy-rbd" undeployed
+   ✅ Application "appset-deploy-rbd" unprotected
 
 🔎 Clean environment ...
    ✅ Environment cleaned

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -188,10 +188,15 @@ func (c *Command) runFlow(test *Test) {
 }
 
 func (c *Command) cleanFlow(test *Test) {
-	if !test.Unprotect() {
+	// Deleting the application also deletes the placement which trigger DRPC deletion in ramen. This is also less
+	// likely to get stuck because of rbd-mirroing issues.
+	// https://github.com/RamenDR/ramenctl/issues/112
+	if !test.Undeploy() {
 		return
 	}
-	test.Undeploy()
+	// Undeploy does not wait until the DRPC is deleted in all cases. We call unprotect to ensure that the DRPC is
+	// deleted when the clean flow completes.
+	test.Unprotect()
 }
 
 func (c *Command) namespacesToGather() []string {

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -322,8 +322,8 @@ func TestReportCleanTestFailed(t *testing.T) {
 		},
 		Status: Passed,
 		Steps: []*Step{
-			{Name: "unprotect", Status: Passed},
 			{Name: "undeploy", Status: Passed},
+			{Name: "unprotect", Status: Passed},
 		},
 	}
 	r.AddTest(rbdTest)
@@ -340,6 +340,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 		},
 		Status: Failed,
 		Steps: []*Step{
+			{Name: "undeploy", Status: Passed},
 			{Name: "unprotect", Status: Failed},
 		},
 	}
@@ -409,8 +410,8 @@ func TestReportCleanFailed(t *testing.T) {
 		},
 		Status: Passed,
 		Steps: []*Step{
-			{Name: "unprotect", Status: Passed},
 			{Name: "undeploy", Status: Passed},
+			{Name: "unprotect", Status: Passed},
 		},
 	}
 	r.AddTest(rbdTest)
@@ -468,8 +469,8 @@ func TestReportCleanAllPassed(t *testing.T) {
 		},
 		Status: Passed,
 		Steps: []*Step{
-			{Name: "unprotect", Status: Passed},
 			{Name: "undeploy", Status: Passed},
+			{Name: "unprotect", Status: Passed},
 		},
 	}
 	r.AddTest(rbdTest)
@@ -486,8 +487,8 @@ func TestReportCleanAllPassed(t *testing.T) {
 		},
 		Status: Passed,
 		Steps: []*Step{
-			{Name: "unprotect", Status: Passed},
 			{Name: "undeploy", Status: Passed},
+			{Name: "unprotect", Status: Passed},
 		},
 	}
 	r.AddTest(cephfsTest)


### PR DESCRIPTION
When deleting the VRG ramen may wait until the VR reaches the desired
state. If storage is broken this may never happen, and deleting the VRG 
may never complete. In the case describe in he issue, manual deletion of
the VR was required to allow test clean to complete.

Change the clean flow to first undeploy the application, which delete
the PVCs. This makes the VR less likely to get stuck because of
rbd-mirroring issues.

Undeploying the application deletes the placement and trigger a DRPC
deletion in ramen. This should be enough for cleaning up, however
undeploy does not wait until the DRPC is deleted in all cases, so we
call unprotect to ensure that the DRPC is deleted when the clean flow
completes.

Depends on https://github.com/RamenDR/ramen/issues/2005

Fixes #112