### PR TITLE
Support cancellation

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -20,6 +20,7 @@
       1. [The clean flow](#the-clean-flow)
    1. [Failed tests](#failed-tests)
       1. [Inspecting gathered data](#inspecting-gathered-data)
+   1. [Canceling tests](#canceling-tests)
 
 ## Issue
 
@@ -621,3 +622,12 @@ $ ramenctl test clean -o example-failure
 
 ✅ passed (1 passed, 0 failed, 0 skipped)
 ```
+
+### Canceling tests
+
+The run or clean command may take up to 10 minutes to complete the current test
+step. To get all the information about failed tests you should wait until the
+command completes and gathers data for failed tests.
+
+You can cancel the command by pressing `Ctrl+C`. This saves the current tests
+progress but does not gather data for incomplete tests.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.8
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013
+	github.com/ramendr/ramen/e2e v0.0.0-20250424122329-3f0bedcd598d
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013 h1:WoMHVclMYFCnsdJGTqT11CAzyMEEULhbS7+i63SmznM=
-github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250424122329-3f0bedcd598d h1:sslvFZsWLy28r6xxF8zSD2ptvucM+KICDfTtGKiHlts=
+github.com/ramendr/ramen/e2e v0.0.0-20250424122329-3f0bedcd598d/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -20,16 +20,16 @@ import (
 
 // Command is a ramenctl command.
 type Command struct {
-	// Name is the command name (e.g. "test-run")
-	Name string
-	// OutputDir contains the command log, summary, and gathered files.
-	OutputDir string
-	// Config loaded from configFile.
-	Config *types.Config
-	// Env loaded from the config.
-	Env *types.Env
-	// Logger logging to the command log.
-	Logger *zap.SugaredLogger
+	// name is the command name (e.g. "test-run")
+	name string
+	// outputDir contains the command log, summary, and gathered files.
+	outputDir string
+	// config loaded from configFile.
+	config *types.Config
+	// env loaded from the config.
+	env *types.Env
+	// log logging to the command log.
+	log *zap.SugaredLogger
 }
 
 func New(commandName, configFile, outputDir string) (*Command, error) {
@@ -58,12 +58,34 @@ func New(commandName, configFile, outputDir string) (*Command, error) {
 	}
 
 	return &Command{
-		Name:      commandName,
-		OutputDir: outputDir,
-		Config:    cfg,
-		Env:       env,
-		Logger:    log,
+		name:      commandName,
+		outputDir: outputDir,
+		config:    cfg,
+		env:       env,
+		log:       log,
 	}, nil
+}
+
+func (c *Command) Name() string {
+	return c.name
+}
+
+func (c *Command) OutputDir() string {
+	return c.outputDir
+}
+
+// ramen/e2e/types.Context interface
+
+func (c *Command) Logger() *zap.SugaredLogger {
+	return c.log
+}
+
+func (c *Command) Config() *types.Config {
+	return c.config
+}
+
+func (c *Command) Env() *types.Env {
+	return c.env
 }
 
 // WriteReport writes report in yaml format to the command output directory.
@@ -72,6 +94,6 @@ func (c *Command) WriteReport(report any) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal report: %w", err)
 	}
-	path := filepath.Join(c.OutputDir, c.Name+".yaml")
+	path := filepath.Join(c.outputDir, c.name+".yaml")
 	return os.WriteFile(path, data, 0o640)
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -4,6 +4,7 @@
 package command
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -18,7 +19,7 @@ import (
 	"github.com/ramendr/ramenctl/pkg/console"
 )
 
-// Command is a ramenctl command.
+// Command is a ramenctl command implementing the ramen/e2e/types.Context interface.
 type Command struct {
 	// name is the command name (e.g. "test-run")
 	name string
@@ -31,6 +32,8 @@ type Command struct {
 	// log logging to the command log.
 	log *zap.SugaredLogger
 }
+
+var _ types.Context = &Command{}
 
 func New(commandName, configFile, outputDir string) (*Command, error) {
 	// Create the logger first so we can log early command errors to the command log.
@@ -50,7 +53,7 @@ func New(commandName, configFile, outputDir string) (*Command, error) {
 
 	console.Info("Using config %q", configFile)
 
-	env, err := e2eenv.New(cfg, log)
+	env, err := e2eenv.New(context.Background(), cfg, log)
 	if err != nil {
 		err := fmt.Errorf("failed to create env: %w", err)
 		log.Error(err)
@@ -86,6 +89,10 @@ func (c *Command) Config() *types.Config {
 
 func (c *Command) Env() *types.Env {
 	return c.env
+}
+
+func (c *Command) Context() context.Context {
+	return context.Background()
 }
 
 // WriteReport writes report in yaml format to the command output directory.

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -14,7 +14,6 @@ func Clean(configFile string, outputDir string) error {
 	}
 
 	if !cmd.CleanTests() {
-		cmd.GatherData()
 		return cmd.Failed()
 	}
 

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -8,6 +8,7 @@ func Clean(configFile string, outputDir string) error {
 	if err != nil {
 		return err
 	}
+	defer cmd.Stop()
 
 	if !cmd.Validate() {
 		return cmd.Failed()

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -133,16 +133,14 @@ func (c *Command) Failed() error {
 	if err := c.WriteReport(c.Report); err != nil {
 		console.Error("failed to write report: %s", err)
 	}
-	return fmt.Errorf("failed (%d passed, %d failed, %d skipped)",
-		c.Report.Summary.Passed, c.Report.Summary.Failed, c.Report.Summary.Skipped)
+	return fmt.Errorf("%s (%s)", c.Report.Status, c.Report.Summary)
 }
 
 func (c *Command) Passed() {
 	if err := c.WriteReport(c.Report); err != nil {
 		console.Error("failed to write report: %s", err)
 	}
-	console.Completed("passed (%d passed, %d failed, %d skipped)",
-		c.Report.Summary.Passed, c.Report.Summary.Failed, c.Report.Summary.Skipped)
+	console.Completed("%s (%s)", c.Report.Status, c.Report.Summary)
 }
 
 func (c *Command) fail(msg string, err error) {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -109,7 +109,7 @@ func (c *Command) CleanTests() bool {
 	return c.runFlowFunc(c.cleanFlow)
 }
 
-func (c *Command) GatherData() {
+func (c *Command) gatherData() {
 	console.Step("Gather data")
 	namespaces := c.namespacesToGather()
 	outputDir := filepath.Join(c.OutputDir(), c.Name()+".gather")
@@ -181,7 +181,11 @@ func (c *Command) runFlowFunc(f flowFunc) bool {
 		c.Current.AddTest(test)
 	}
 
-	return c.finishStep()
+	res := c.finishStep()
+	if c.Report.Status == Failed {
+		c.gatherData()
+	}
+	return res
 }
 
 func (c *Command) runFlow(test *Test) {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -157,7 +157,16 @@ func (c *Command) passStep() bool {
 	return true
 }
 
+func (c *Command) finishStep() bool {
+	c.Logger.Infof("Step %q finished", c.Current.Name)
+	c.Report.AddStep(c.Current)
+	c.Current = nil
+	return c.Report.Status == Passed
+}
+
 func (c *Command) runFlowFunc(f flowFunc) bool {
+	c.startStep(TestsStep)
+
 	var wg sync.WaitGroup
 	for _, test := range c.Tests {
 		wg.Add(1)
@@ -168,13 +177,11 @@ func (c *Command) runFlowFunc(f flowFunc) bool {
 	}
 	wg.Wait()
 
-	tests := &Step{Name: TestsStep}
 	for _, test := range c.Tests {
-		tests.AddTest(test)
+		c.Current.AddTest(test)
 	}
-	c.Report.AddStep(tests)
 
-	return c.Report.Status == Passed
+	return c.finishStep()
 }
 
 func (c *Command) runFlow(test *Test) {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -72,7 +72,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 func (c *Command) Validate() bool {
 	c.startStep(ValidateStep)
 	console.Step("Validate config")
-	if err := validate.TestConfig(c.Env(), c.Config(), c.Logger()); err != nil {
+	if err := validate.TestConfig(c); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Config validated")
@@ -82,7 +82,7 @@ func (c *Command) Validate() bool {
 func (c *Command) Setup() bool {
 	c.startStep(SetupStep)
 	console.Step("Setup environment")
-	if err := util.EnsureChannel(c.Env().Hub, c.Config(), c.Logger()); err != nil {
+	if err := util.EnsureChannel(c); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Environment setup")
@@ -92,7 +92,7 @@ func (c *Command) Setup() bool {
 func (c *Command) Cleanup() bool {
 	c.startStep(CleanupStep)
 	console.Step("Clean environment")
-	if err := util.EnsureChannelDeleted(c.Env().Hub, c.Config(), c.Logger()); err != nil {
+	if err := util.EnsureChannelDeleted(c); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Environment cleaned")

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -4,6 +4,7 @@
 package test
 
 import (
+	"context"
 	"fmt"
 
 	"go.uber.org/zap"
@@ -11,7 +12,7 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 )
 
-// Context implements types.Context interface.
+// Context implements types.TestContext interface.
 type Context struct {
 	workload types.Workload
 	deployer types.Deployer
@@ -20,7 +21,7 @@ type Context struct {
 	cmd      *Command
 }
 
-var _ types.Context = &Context{}
+var _ types.TestContext = &Context{}
 
 func newContext(workload types.Workload, deployer types.Deployer, cmd *Command) *Context {
 	name := fmt.Sprintf("%s-%s", deployer.GetName(), workload.GetName())
@@ -66,4 +67,8 @@ func (c *Context) Env() *types.Env {
 
 func (c *Context) Config() *types.Config {
 	return c.cmd.Config()
+}
+
+func (c *Context) Context() context.Context {
+	return c.cmd.Context()
 }

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -28,7 +28,7 @@ func newContext(workload types.Workload, deployer types.Deployer, cmd *Command) 
 		workload: workload,
 		deployer: deployer,
 		name:     name,
-		logger:   cmd.Logger.Named(name),
+		logger:   cmd.Logger().Named(name),
 		cmd:      cmd,
 	}
 }
@@ -61,9 +61,9 @@ func (c *Context) Logger() *zap.SugaredLogger {
 }
 
 func (c *Context) Env() *types.Env {
-	return c.cmd.Env
+	return c.cmd.Env()
 }
 
 func (c *Context) Config() *types.Config {
-	return c.cmd.Config
+	return c.cmd.Config()
 }

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -15,9 +15,10 @@ import (
 type Status string
 
 const (
-	Passed  = Status("passed")
-	Failed  = Status("failed")
-	Skipped = Status("skipped")
+	Passed   = Status("passed")
+	Failed   = Status("failed")
+	Skipped  = Status("skipped")
+	Canceled = Status("canceled")
 )
 
 const (
@@ -37,9 +38,10 @@ type Step struct {
 
 // Summary summaries a test run or clean.
 type Summary struct {
-	Passed  int `json:"passed"`
-	Failed  int `json:"failed"`
-	Skipped int `json:"skipped"`
+	Passed   int `json:"passed"`
+	Failed   int `json:"failed"`
+	Skipped  int `json:"skipped"`
+	Canceled int `json:"canceled"`
 }
 
 // Report created by test sub commands.
@@ -75,8 +77,8 @@ func (r *Report) AddStep(step *Step) {
 		if r.Status == "" {
 			r.Status = Passed
 		}
-	case Failed:
-		r.Status = Failed
+	case Failed, Canceled:
+		r.Status = step.Status
 	}
 
 	// Handle the special "tests" step.
@@ -145,8 +147,8 @@ func (s *Step) AddTest(t *Test) {
 		if s.Status == "" {
 			s.Status = Passed
 		}
-	case Failed:
-		s.Status = Failed
+	case Failed, Canceled:
+		s.Status = t.Status
 	}
 }
 
@@ -188,5 +190,12 @@ func (s *Summary) AddTest(t *Step) {
 		s.Failed++
 	case Skipped:
 		s.Skipped++
+	case Canceled:
+		s.Canceled++
 	}
+}
+
+func (s Summary) String() string {
+	return fmt.Sprintf("%d passed, %d failed, %d skipped, %d canceled",
+		s.Passed, s.Failed, s.Skipped, s.Canceled)
 }

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -139,7 +139,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	step2 := &Step{Name: TestsStep}
 
 	failedTest := &Test{
-		Context: &Context{name: "appset-deploy-rbd"},
+		TestContext: &Context{name: "appset-deploy-rbd"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -160,7 +160,7 @@ func TestReportRunTestFailed(t *testing.T) {
 	}
 
 	passedTest := &Test{
-		Context: &Context{name: "appset-deploy-cephfs"},
+		TestContext: &Context{name: "appset-deploy-cephfs"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -255,7 +255,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	step2 := &Step{Name: TestsStep}
 
 	rbdTest := &Test{
-		Context: &Context{name: "appset-deploy-rbd"},
+		TestContext: &Context{name: "appset-deploy-rbd"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -279,7 +279,7 @@ func TestReportRunAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Context: &Context{name: "appset-deploy-cephfs"},
+		TestContext: &Context{name: "appset-deploy-cephfs"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -368,7 +368,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	step1 := &Step{Name: TestsStep}
 
 	rbdTest := &Test{
-		Context: &Context{name: "appset-deploy-rbd"},
+		TestContext: &Context{name: "appset-deploy-rbd"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -388,7 +388,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Context: &Context{name: "appset-deploy-cephfs"},
+		TestContext: &Context{name: "appset-deploy-cephfs"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -467,7 +467,7 @@ func TestReportCleanFailed(t *testing.T) {
 	step1 := &Step{Name: TestsStep}
 
 	rbdTest := &Test{
-		Context: &Context{name: "appset-deploy-rbd"},
+		TestContext: &Context{name: "appset-deploy-rbd"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -538,7 +538,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	step1 := &Step{Name: TestsStep}
 
 	rbdTest := &Test{
-		Context: &Context{name: "appset-deploy-rbd"},
+		TestContext: &Context{name: "appset-deploy-rbd"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",
@@ -558,7 +558,7 @@ func TestReportCleanAllPassed(t *testing.T) {
 	}
 
 	cephfsTest := &Test{
-		Context: &Context{name: "appset-deploy-cephfs"},
+		TestContext: &Context{name: "appset-deploy-cephfs"},
 		Config: &types.TestConfig{
 			Workload: "deploy",
 			Deployer: "appset",

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -20,7 +20,6 @@ func Run(configFile string, outputDir string) error {
 	}
 
 	if !cmd.RunTests() {
-		cmd.GatherData()
 		return cmd.Failed()
 	}
 

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -8,6 +8,7 @@ func Run(configFile string, outputDir string) error {
 	if err != nil {
 		return err
 	}
+	defer cmd.Stop()
 
 	if !cmd.Validate() {
 		return cmd.Failed()

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -49,75 +49,68 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 func (t *Test) Deploy() bool {
 	step := &Step{Name: "deploy"}
 	if err := t.Deployer().Deploy(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to deploy application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q deployed", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q deployed", t.Name())
+	return t.pass(step)
 }
 
 func (t *Test) Undeploy() bool {
 	step := &Step{Name: "undeploy"}
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to undeploy application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q undeployed", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q undeployed", t.Name())
+	return t.pass(step)
 }
 
 func (t *Test) Protect() bool {
 	step := &Step{Name: "protect"}
 	if err := dractions.EnableProtection(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to protect application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q protected", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q protected", t.Name())
+	return t.pass(step)
 }
 
 func (t *Test) Unprotect() bool {
 	step := &Step{Name: "unprotect"}
 	if err := dractions.DisableProtection(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to unprotect application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q unprotected", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q unprotected", t.Name())
+	return t.pass(step)
 }
 
 func (t *Test) Failover() bool {
 	step := &Step{Name: "failover"}
 	if err := dractions.Failover(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to failover application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q failed over", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q failed over", t.Name())
+	return t.pass(step)
 }
 
 func (t *Test) Relocate() bool {
 	step := &Step{Name: "relocate"}
 	if err := dractions.Relocate(t.Context); err != nil {
-		msg := fmt.Sprintf("failed to relocate application %q", t.Name())
-		return t.fail(step, msg, err)
+		return t.fail(step, err)
 	}
-	msg := fmt.Sprintf("Application %q relocated", t.Name())
-	return t.pass(step, msg)
+	console.Pass("Application %q relocated", t.Name())
+	return t.pass(step)
 }
 
-func (t *Test) fail(step *Step, msg string, err error) bool {
+func (t *Test) fail(step *Step, err error) bool {
 	step.Status = Failed
 	t.Steps = append(t.Steps, step)
 	t.Status = Failed
-	console.Error(msg)
-	t.Logger().Errorf("%s: %s", msg, err)
+	t.Logger().Errorf("Step %q failed: %s", step.Name, err)
+	console.Error("Failed to %s application %q", step.Name, t.Name())
 	return false
 }
 
-func (t *Test) pass(step *Step, msg string) bool {
+func (t *Test) pass(step *Step) bool {
 	step.Status = Passed
 	t.Steps = append(t.Steps, step)
-	console.Pass(msg)
 	return true
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -47,70 +47,77 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 }
 
 func (t *Test) Deploy() bool {
-	step := &Step{Name: "deploy"}
+	t.start("deploy")
 	if err := t.Deployer().Deploy(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
 func (t *Test) Undeploy() bool {
-	step := &Step{Name: "undeploy"}
+	t.start("undeploy")
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
 func (t *Test) Protect() bool {
-	step := &Step{Name: "protect"}
+	t.start("protect")
 	if err := dractions.EnableProtection(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q protected", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
 func (t *Test) Unprotect() bool {
-	step := &Step{Name: "unprotect"}
+	t.start("unprotect")
 	if err := dractions.DisableProtection(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
 func (t *Test) Failover() bool {
-	step := &Step{Name: "failover"}
+	t.start("failover")
 	if err := dractions.Failover(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
 func (t *Test) Relocate() bool {
-	step := &Step{Name: "relocate"}
+	t.start("relocate")
 	if err := dractions.Relocate(t.Context); err != nil {
-		return t.fail(step, err)
+		return t.fail(err)
 	}
 	console.Pass("Application %q relocated", t.Name())
-	return t.pass(step)
+	return t.pass()
 }
 
-func (t *Test) fail(step *Step, err error) bool {
-	step.Status = Failed
+func (t *Test) start(name string) {
+	step := &Step{Name: name}
 	t.Steps = append(t.Steps, step)
+	t.Logger().Infof("Step %q started", step.Name)
+}
+
+func (t *Test) fail(err error) bool {
+	step := t.Steps[len(t.Steps)-1]
+	step.Status = Failed
 	t.Status = Failed
 	t.Logger().Errorf("Step %q failed: %s", step.Name, err)
 	console.Error("Failed to %s application %q", step.Name, t.Name())
 	return false
 }
 
-func (t *Test) pass(step *Step) bool {
+func (t *Test) pass() bool {
+	step := t.Steps[len(t.Steps)-1]
 	step.Status = Passed
-	t.Steps = append(t.Steps, step)
+	t.Logger().Infof("Step %q passed", step.Name)
 	return true
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -47,66 +47,66 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 }
 
 func (t *Test) Deploy() bool {
-	t.start("deploy")
+	t.startStep("deploy")
 	if err := t.Deployer().Deploy(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
 func (t *Test) Undeploy() bool {
-	t.start("undeploy")
+	t.startStep("undeploy")
 	if err := t.Deployer().Undeploy(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
 func (t *Test) Protect() bool {
-	t.start("protect")
+	t.startStep("protect")
 	if err := dractions.EnableProtection(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q protected", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
 func (t *Test) Unprotect() bool {
-	t.start("unprotect")
+	t.startStep("unprotect")
 	if err := dractions.DisableProtection(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
 func (t *Test) Failover() bool {
-	t.start("failover")
+	t.startStep("failover")
 	if err := dractions.Failover(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
 func (t *Test) Relocate() bool {
-	t.start("relocate")
+	t.startStep("relocate")
 	if err := dractions.Relocate(t.Context); err != nil {
-		return t.fail(err)
+		return t.failStep(err)
 	}
 	console.Pass("Application %q relocated", t.Name())
-	return t.pass()
+	return t.passStep()
 }
 
-func (t *Test) start(name string) {
+func (t *Test) startStep(name string) {
 	step := &Step{Name: name}
 	t.Steps = append(t.Steps, step)
 	t.Logger().Infof("Step %q started", step.Name)
 }
 
-func (t *Test) fail(err error) bool {
+func (t *Test) failStep(err error) bool {
 	step := t.Steps[len(t.Steps)-1]
 	step.Status = Failed
 	t.Status = Failed
@@ -115,7 +115,7 @@ func (t *Test) fail(err error) bool {
 	return false
 }
 
-func (t *Test) pass() bool {
+func (t *Test) passStep() bool {
 	step := t.Steps[len(t.Steps)-1]
 	step.Status = Passed
 	t.Logger().Infof("Step %q passed", step.Name)

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -18,7 +18,7 @@ import (
 
 // Test perform DR opetaions for testing DR flow.
 type Test struct {
-	types.Context
+	types.TestContext
 	Status Status
 	Config *types.TestConfig
 	Steps  []*Step
@@ -42,15 +42,15 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 	}
 
 	return &Test{
-		Context: newContext(workload, deployer, cmd),
-		Status:  Passed,
-		Config:  &tc,
+		TestContext: newContext(workload, deployer, cmd),
+		Status:      Passed,
+		Config:      &tc,
 	}
 }
 
 func (t *Test) Deploy() bool {
 	t.startStep("deploy")
-	if err := t.Deployer().Deploy(t.Context); err != nil {
+	if err := t.Deployer().Deploy(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
@@ -59,7 +59,7 @@ func (t *Test) Deploy() bool {
 
 func (t *Test) Undeploy() bool {
 	t.startStep("undeploy")
-	if err := t.Deployer().Undeploy(t.Context); err != nil {
+	if err := t.Deployer().Undeploy(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
@@ -68,7 +68,7 @@ func (t *Test) Undeploy() bool {
 
 func (t *Test) Protect() bool {
 	t.startStep("protect")
-	if err := dractions.EnableProtection(t.Context); err != nil {
+	if err := dractions.EnableProtection(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q protected", t.Name())
@@ -77,7 +77,7 @@ func (t *Test) Protect() bool {
 
 func (t *Test) Unprotect() bool {
 	t.startStep("unprotect")
-	if err := dractions.DisableProtection(t.Context); err != nil {
+	if err := dractions.DisableProtection(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
@@ -86,7 +86,7 @@ func (t *Test) Unprotect() bool {
 
 func (t *Test) Failover() bool {
 	t.startStep("failover")
-	if err := dractions.Failover(t.Context); err != nil {
+	if err := dractions.Failover(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
@@ -95,7 +95,7 @@ func (t *Test) Failover() bool {
 
 func (t *Test) Relocate() bool {
 	t.startStep("relocate")
-	if err := dractions.Relocate(t.Context); err != nil {
+	if err := dractions.Relocate(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q relocated", t.Name())

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -4,6 +4,8 @@
 package test
 
 import (
+	"context"
+	"errors"
 	"fmt"
 
 	"github.com/ramendr/ramen/e2e/deployers"
@@ -108,10 +110,15 @@ func (t *Test) startStep(name string) {
 
 func (t *Test) failStep(err error) bool {
 	step := t.Steps[len(t.Steps)-1]
-	step.Status = Failed
-	t.Status = Failed
-	t.Logger().Errorf("Step %q failed: %s", step.Name, err)
-	console.Error("Failed to %s application %q", step.Name, t.Name())
+	if errors.Is(err, context.Canceled) {
+		step.Status = Canceled
+		console.Error("Canceled application %q %s", t.Name(), step.Name)
+	} else {
+		step.Status = Failed
+		console.Error("Failed to %s application %q", step.Name, t.Name())
+	}
+	t.Status = step.Status
+	t.Logger().Errorf("Step %q %s: %s", step.Name, step.Status, err)
 	return false
 }
 

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -31,7 +31,7 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 		panic(fmt.Sprintf("unknown pvcSpec %q", tc.PVCSpec))
 	}
 
-	workload, err := workloads.New(tc.Workload, cmd.Config.Repo.Branch, pvcSpec)
+	workload, err := workloads.New(tc.Workload, cmd.Config().Repo.Branch, pvcSpec)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
When a user interrupt a ramenctl command we want to cancel if-flight steps and write a report with the canceled steps. To make this possible ramen/e2e added cancellation support using context.Context.

We have a new Canceled status, used for steps that failed with context.Canceled error. Adding a canceled step makes the containing step and the entire report canceled.

The command.Command and test.Command types implement ramen/e2e/types.Context. We create a cancellable context when creating command.Command. The command starts a signal handler that will cancel the context when receiving a SIGINT signal. Cancelling the context will cancel the e2e calls and mark the report as canceled.

## Example run

I scale down the rbd-mirror deployment on cluster dr2 to fail the rbd applications to fail in the protect step.

```console:
% ramenctl test run -o test
⭐ Using report "test"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-cephfs" deployed
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "disapp-deploy-cephfs" deployed
   ✅ Application "disapp-deploy-rbd" deployed
   ✅ Application "subscr-deploy-rbd" deployed
   ✅ Application "subscr-deploy-cephfs" deployed
   ✅ Application "disapp-deploy-cephfs" protected
   ✅ Application "appset-deploy-cephfs" protected
   ✅ Application "subscr-deploy-cephfs" protected
   ✅ Application "disapp-deploy-cephfs" failed over
   ✅ Application "subscr-deploy-cephfs" failed over
   ✅ Application "appset-deploy-cephfs" failed over
   ✅ Application "disapp-deploy-cephfs" relocated
   ✅ Application "disapp-deploy-cephfs" unprotected
   ✅ Application "disapp-deploy-cephfs" undeployed
   ✅ Application "subscr-deploy-cephfs" relocated
   ❌ Failed to protect application "appset-deploy-rbd"
   ❌ Failed to protect application "disapp-deploy-rbd"
   ❌ Failed to protect application "subscr-deploy-rbd"
   ✅ Application "subscr-deploy-cephfs" unprotected
   ✅ Application "subscr-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-cephfs" relocated
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" undeployed

🔎 Gather data ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"

❌ failed (3 passed, 3 failed, 0 skipped, 0 canceled)
```

Then I cleaned up without recovering the rbd-mirror deployment. This blocks for long time, and I interrupted the command.

```console
% ramenctl test clean -o test
⭐ Using report "test"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "subscr-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "disapp-deploy-cephfs" unprotected
   ✅ Application "subscr-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-cephfs" undeployed
   ✅ Application "disapp-deploy-cephfs" undeployed
^C   ❌ Canceled application "disapp-deploy-rbd" unprotect
   ❌ Canceled application "subscr-deploy-rbd" unprotect
   ❌ Canceled application "appset-deploy-rbd" unprotect

❌ canceled (3 passed, 0 failed, 0 skipped, 3 canceled)
```

We have test and clean reports gathered data from the run command:

```console
% tree -L3 test
test
├── test-clean.log
├── test-clean.yaml
├── test-run.gather
│   ├── dr1
│   │   ├── cluster
│   │   └── namespaces
│   ├── dr2
│   │   ├── cluster
│   │   └── namespaces
│   └── hub
│       ├── cluster
│       └── namespaces
├── test-run.log
└── test-run.yaml
```

The clean report shows that we canceled the command. 3 tests were cleaned successfully, and 3 were canceled.

```yaml
% cat test/test-clean.yaml 
build:
  commit: bc7c0e77a00d6487c173da770d4796655012e554
  version: v0.4.0-22-gbc7c0e7
config:
  channel:
    name: https-github-com-ramendr-ocm-ramen-samples-git
    namespace: test-gitops
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/nir/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/nir/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/nir/.config/drenv/rdr/kubeconfigs/hub
  distro: k8s
  drPolicy: dr-policy
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
  pvcSpecs:
  - accessModes: ReadWriteOnce
    name: rbd
    storageClassName: rook-ceph-block
  - accessModes: ReadWriteMany
    name: cephfs
    storageClassName: rook-cephfs-fs1
  repo:
    branch: main
    url: https://github.com/RamenDR/ocm-ramen-samples.git
  tests:
  - deployer: appset
    pvcSpec: rbd
    workload: deploy
  - deployer: appset
    pvcSpec: cephfs
    workload: deploy
  - deployer: subscr
    pvcSpec: rbd
    workload: deploy
  - deployer: subscr
    pvcSpec: cephfs
    workload: deploy
  - deployer: disapp
    pvcSpec: rbd
    workload: deploy
  - deployer: disapp
    pvcSpec: cephfs
    workload: deploy
created: "2025-04-24T21:35:16.524151+03:00"
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
status: canceled
steps:
- name: validate
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: unprotect
      status: canceled
    name: appset-deploy-rbd
    status: canceled
  - config:
      deployer: appset
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-cephfs
    status: passed
  - config:
      deployer: subscr
      pvcSpec: rbd
      workload: deploy
    items:
    - name: unprotect
      status: canceled
    name: subscr-deploy-rbd
    status: canceled
  - config:
      deployer: subscr
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: subscr-deploy-cephfs
    status: passed
  - config:
      deployer: disapp
      pvcSpec: rbd
      workload: deploy
    items:
    - name: unprotect
      status: canceled
    name: disapp-deploy-rbd
    status: canceled
  - config:
      deployer: disapp
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: disapp-deploy-cephfs
    status: passed
  name: tests
  status: canceled
summary:
  canceled: 3
  failed: 0
  passed: 3
  skipped: 0
```

Test flow for from the clean command log:

```console
% grep -E 'INFO|ERROR' test/test-clean.log
2025-04-24T21:35:16.504+0300	INFO	env/env.go:108	Using "hub" cluster name: "hub"
2025-04-24T21:35:16.518+0300	INFO	env/env.go:116	Detected "c1" managed cluster name: "dr1"
2025-04-24T21:35:16.524+0300	INFO	env/env.go:116	Detected "c2" managed cluster name: "dr2"
2025-04-24T21:35:16.524+0300	INFO	test/command.go:135	Step "validate" started
2025-04-24T21:35:16.529+0300	INFO	validate/validate.go:222	Detected kubernetes distribution: "k8s"
2025-04-24T21:35:16.529+0300	INFO	validate/validate.go:223	Using namespaces: {RamenHubNamespace:ramen-system RamenDRClusterNamespace:ramen-system RamenOpsNamespace:ramen-ops ArgocdNamespace:argocd}
2025-04-24T21:35:16.537+0300	INFO	validate/validate.go:145	Validated clusters ["dr1", "dr2"] in DRPolicy "dr-policy"
2025-04-24T21:35:16.541+0300	INFO	validate/validate.go:175	Validated clusters ["dr1", "dr2"] in ClusterSet "default"
2025-04-24T21:35:16.541+0300	INFO	test/command.go:154	Step "validate" passed
2025-04-24T21:35:16.541+0300	INFO	test/command.go:135	Step "tests" started
2025-04-24T21:35:16.541+0300	INFO	subscr-deploy-cephfs	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.541+0300	INFO	disapp-deploy-rbd	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.541+0300	INFO	disapp-deploy-cephfs	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.541+0300	INFO	appset-deploy-cephfs	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.541+0300	INFO	appset-deploy-rbd	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.541+0300	INFO	subscr-deploy-rbd	test/test.go:108	Step "unprotect" started
2025-04-24T21:35:16.544+0300	INFO	subscr-deploy-cephfs	dractions/actions.go:118	Unprotecting workload "test-subscr-deploy-cephfs/busybox"
2025-04-24T21:35:16.544+0300	INFO	appset-deploy-cephfs	dractions/actions.go:118	Unprotecting workload "test-appset-deploy-cephfs/busybox"
2025-04-24T21:35:16.545+0300	INFO	disapp-deploy-cephfs	dractions/disapp.go:89	Unprotecting workload "test-disapp-deploy-cephfs/busybox"
2025-04-24T21:35:16.547+0300	INFO	subscr-deploy-cephfs	dractions/actions.go:135	Workload unprotected
2025-04-24T21:35:16.547+0300	INFO	subscr-deploy-cephfs	test/test.go:128	Step "unprotect" passed
2025-04-24T21:35:16.547+0300	INFO	subscr-deploy-cephfs	test/test.go:108	Step "undeploy" started
2025-04-24T21:35:16.547+0300	INFO	subscr-deploy-rbd	dractions/actions.go:120	Unprotecting workload "test-subscr-deploy-rbd/busybox" in cluster "dr1"
2025-04-24T21:35:16.547+0300	INFO	disapp-deploy-rbd	dractions/disapp.go:91	Unprotecting workload "test-disapp-deploy-rbd/busybox" in cluster "dr1"
2025-04-24T21:35:16.548+0300	INFO	subscr-deploy-cephfs	deployers/subscr.go:89	Undeploying subscription app "test-subscr-deploy-cephfs/busybox"
2025-04-24T21:35:16.550+0300	INFO	appset-deploy-rbd	dractions/actions.go:120	Unprotecting workload "test-appset-deploy-rbd/busybox" in cluster "dr1"
2025-04-24T21:35:16.550+0300	INFO	appset-deploy-cephfs	dractions/actions.go:135	Workload unprotected
2025-04-24T21:35:16.551+0300	INFO	appset-deploy-cephfs	test/test.go:128	Step "unprotect" passed
2025-04-24T21:35:16.551+0300	INFO	appset-deploy-cephfs	test/test.go:108	Step "undeploy" started
2025-04-24T21:35:16.553+0300	INFO	appset-deploy-cephfs	deployers/appset.go:59	Undeploying applicationset app "test-appset-deploy-cephfs/busybox"
2025-04-24T21:35:16.553+0300	INFO	disapp-deploy-cephfs	dractions/disapp.go:113	Workload unprotected
2025-04-24T21:35:16.553+0300	INFO	disapp-deploy-cephfs	test/test.go:128	Step "unprotect" passed
2025-04-24T21:35:16.553+0300	INFO	disapp-deploy-cephfs	test/test.go:108	Step "undeploy" started
2025-04-24T21:35:16.553+0300	INFO	disapp-deploy-cephfs	deployers/disapp.go:79	Undeploying discovered app "test-disapp-deploy-cephfs/busybox" in clusters "dr1" and "dr2"
2025-04-24T21:35:16.560+0300	INFO	subscr-deploy-cephfs	deployers/subscr.go:115	Workload undeployed
2025-04-24T21:35:16.560+0300	INFO	subscr-deploy-cephfs	test/test.go:128	Step "undeploy" passed
2025-04-24T21:35:16.745+0300	INFO	appset-deploy-cephfs	deployers/appset.go:80	Workload undeployed
2025-04-24T21:35:16.745+0300	INFO	appset-deploy-cephfs	test/test.go:128	Step "undeploy" passed
2025-04-24T21:35:19.512+0300	INFO	disapp-deploy-cephfs	deployers/disapp.go:100	Workload undeployed
2025-04-24T21:35:19.512+0300	INFO	disapp-deploy-cephfs	test/test.go:128	Step "undeploy" passed
2025-04-24T21:35:51.640+0300	ERROR	disapp-deploy-rbd	test/test.go:121	Step "unprotect" canceled: context canceled
2025-04-24T21:35:51.640+0300	ERROR	subscr-deploy-rbd	test/test.go:121	Step "unprotect" canceled: context canceled
2025-04-24T21:35:51.640+0300	ERROR	appset-deploy-rbd	test/test.go:121	Step "unprotect" canceled: context canceled
2025-04-24T21:35:51.641+0300	INFO	test/command.go:161	Step "tests" finished

```

To clean up I scaled up the rbd-mirror deployment and run clean again.

```console
% ramenctl test clean -o clean                                                       
⭐ Using report "clean"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "subscr-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "subscr-deploy-rbd" unprotected
   ✅ Application "disapp-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-rbd" unprotected
   ✅ Application "subscr-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-cephfs" undeployed
   ✅ Application "disapp-deploy-rbd" unprotected
   ✅ Application "appset-deploy-rbd" undeployed
   ✅ Application "disapp-deploy-cephfs" undeployed
   ✅ Application "subscr-deploy-rbd" undeployed
   ✅ Application "disapp-deploy-rbd" undeployed

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (6 passed, 0 failed, 0 skipped, 0 canceled)
```

Full report:
[test.tar.gz](https://github.com/user-attachments/files/19897610/test.tar.gz)

Fixes #43 