### PR TITLE
update ramen/e2e to include PVCSpec validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.8
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250409060232-8779d6472b3f
+	github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250409060232-8779d6472b3f h1:DjcBFWJ2XC+rvG8odnhct0dmOMuD7/ett0V6nd/usik=
-github.com/ramendr/ramen/e2e v0.0.0-20250409060232-8779d6472b3f/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af h1:T3m9NMZ6TkTINXxj98lnA0aWqn94gFcPL456pIMQdus=
+github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
This updates ramen/e2e to include the following validations and improvements:

- PVCSpec config validation:
  - Detects duplicate PVCSpec names and contents
  - Validates storageClassName format (RFC1123)
  - Validates accessModes are valid and supported
  - Verifies storageClass exists in both managed clusters

- Removed the unused UnsupportedDeployers field from PVCSpec

Example validation messages in ramenctl:

- Duplicate PVCSpec names:
❌ failed to read config "config.yaml": unable to read config: duplicate pvcSpec name "rbd" found: {Name:rbd StorageClassName:rook-ceph-block AccessModes:ReadWriteOnce} {Name:rbd StorageClassName:rook-cephfs-fs1 AccessModes:ReadWriteMany}

- Duplicate PVCSpec content:
❌ failed to read config "config.yaml": unable to read config: duplicate pvcSpec content found: {Name:rbd StorageClassName:rook-ceph-block AccessModes:ReadWriteOnce} {Name:cephfs StorageClassName:rook-ceph-block AccessModes:ReadWriteOnce}

- Invalid storageClassName format:
 ❌ failed to read config: invalid storageClassName "Rook_rbd" in pvcSpec "rbd": [a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character]

- Invalid access mode: 
❌ failed to read config "config.yaml": unable to read config: invalid accessMode "INVALID" in pvcSpec "cephfs"

- SC does not exist in cluster: 
ERROR Failed to validate pvcSpec "cephfs" storage class: storageClass "rook-cephfs-fs10" not found in cluster "dr1"

Ramen issue fixed: https://github.com/RamenDR/ramen/issues/1890