### PR TITLE
Include test config in report

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,6 +207,43 @@ The test-run.yaml is a machine and human readable description of the the
 test run:
 
 ```yaml
+build:
+  commit: de6950adf6666a4ff0886e29e99a998615142fe5
+  version: v0.4.0-7-gde6950a
+config:
+  channel:
+    name: https-github-com-ramendr-ocm-ramen-samples-git
+    namespace: test-gitops
+  clusterSet: submariner
+  clusters:
+    c1:
+      kubeconfig: mykubeconfigs/primary-cluster
+    c2:
+      kubeconfig: mykubeconfigs/secondary-cluster
+    hub:
+      kubeconfig: mykubeconfigs/hub
+  distro: ocp
+  drPolicy: drpolicy-1m
+  namespaces:
+    argocdNamespace: openshift-gitops
+    ramenDRClusterNamespace: openshift-dr-system
+    ramenHubNamespace: openshift-operators
+    ramenOpsNamespace: openshift-dr-ops
+  pvcSpecs:
+  - accessModes: ReadWriteOnce
+    name: rbd
+    storageClassName: ocs-storagecluster-ceph-rbd
+  - accessModes: ReadWriteMany
+    name: cephfs
+    storageClassName: ocs-storagecluster-cephfs
+  repo:
+    branch: main
+    url: https://github.com/RamenDR/ocm-ramen-samples.git
+  tests:
+  - deployer: appset
+    pvcSpec: rbd
+    workload: deploy
+created: "2025-04-24T16:33:28.800757+05:30"
 host:
   arch: arm64
   cpus: 12
@@ -223,6 +260,19 @@ steps:
       deployer: appset
       pvcSpec: rbd
       workload: deploy
+    items:
+    - name: deploy
+      status: passed
+    - name: protect
+      status: passed
+    - name: failover
+      status: passed
+    - name: relocate
+      status: passed
+    - name: unprotect
+      status: passed
+    - name: undeploy
+      status: passed
     name: appset-deploy-rbd
     status: passed
   name: tests

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.8
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af
+	github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af h1:T3m9NMZ6TkTINXxj98lnA0aWqn94gFcPL456pIMQdus=
-github.com/ramendr/ramen/e2e v0.0.0-20250422151402-f0980a06b5af/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013 h1:WoMHVclMYFCnsdJGTqT11CAzyMEEULhbS7+i63SmznM=
+github.com/ramendr/ramen/e2e v0.0.0-20250423173219-ee933a04e013/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -53,7 +53,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 		Command:         cmd,
 		NamespacePrefix: "test-",
 		PVCSpecs:        e2econfig.PVCSpecsMap(cmd.Config),
-		Report:          newReport(name),
+		Report:          newReport(name, cmd.Config),
 	}
 
 	for _, tc := range cmd.Config.Tests {

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -45,16 +45,21 @@ type Summary struct {
 // Report created by test sub commands.
 type Report struct {
 	*report.Report
-	Name    string  `json:"name"`
-	Steps   []*Step `json:"steps"`
-	Summary Summary `json:"summary"`
-	Status  Status  `json:"status,omitempty"`
+	Name    string        `json:"name"`
+	Config  *types.Config `json:"config"`
+	Steps   []*Step       `json:"steps"`
+	Summary Summary       `json:"summary"`
+	Status  Status        `json:"status,omitempty"`
 }
 
-func newReport(commandName string) *Report {
+func newReport(commandName string, config *types.Config) *Report {
+	if config == nil {
+		panic("config must not be nil")
+	}
 	return &Report{
 		Report: report.New(),
 		Name:   commandName,
+		Config: config,
 	}
 }
 
@@ -119,6 +124,14 @@ func (r *Report) Equal(o *Report) bool {
 	}
 	if r.Name != o.Name {
 		return false
+	}
+	if r.Config != o.Config {
+		if r.Config == nil || o.Config == nil {
+			return false
+		}
+		if !r.Config.Equal(o.Config) {
+			return false
+		}
 	}
 	if r.Status != o.Status {
 		return false

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -14,9 +14,37 @@ import (
 	"github.com/ramendr/ramenctl/pkg/report"
 )
 
+var config = &types.Config{
+	Distro:     "ocp",
+	Repo:       types.RepoConfig{URL: "https://github.com/org/repo", Branch: "main"},
+	DRPolicy:   "dr-policy",
+	ClusterSet: "clusterset",
+	Clusters: map[string]types.ClusterConfig{
+		"hub": {Kubeconfig: "hub-kubeconfig"},
+		"c1":  {Kubeconfig: "c1-kubeconfig"},
+		"c2":  {Kubeconfig: "c2-kubeconfig"},
+	},
+	PVCSpecs: []types.PVCSpecConfig{
+		{Name: "pvc-a", StorageClassName: "standard", AccessModes: "ReadWriteOnce"},
+	},
+	Tests: []types.TestConfig{
+		{Workload: "wl1", Deployer: "ocm-hub", PVCSpec: "pvc-a"},
+	},
+	Channel: types.ChannelConfig{
+		Name:      "my-channel",
+		Namespace: "ramen-system",
+	},
+	Namespaces: types.NamespacesConfig{
+		RamenHubNamespace:       "ramen-hub",
+		RamenDRClusterNamespace: "ramen-dr-cluster",
+		RamenOpsNamespace:       "ramen-ops",
+		ArgocdNamespace:         "argocd",
+	},
+}
+
 func TestReportEmpty(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run")
+	r := newReport("test-run", config)
 
 	// Host and ramenctl info is ready.
 	expectedReport := report.New()
@@ -41,7 +69,7 @@ func TestReportEmpty(t *testing.T) {
 
 func TestReportRunSetupFailed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run")
+	r := newReport("test-run", config)
 	step := &Step{Name: SetupStep, Status: Failed}
 	r.AddStep(step)
 
@@ -71,7 +99,7 @@ func TestReportRunSetupFailed(t *testing.T) {
 
 func TestReportRunSetupPassed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run")
+	r := newReport("test-run", config)
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -100,7 +128,7 @@ func TestReportRunSetupPassed(t *testing.T) {
 
 func TestReportRunTestFailed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run")
+	r := newReport("test-run", config)
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -204,7 +232,7 @@ func TestReportRunTestFailed(t *testing.T) {
 
 func TestReportRunAllPassed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run")
+	r := newReport("test-run", config)
 
 	step := &Step{Name: SetupStep, Status: Passed}
 	r.AddStep(step)
@@ -311,7 +339,7 @@ func TestReportRunAllPassed(t *testing.T) {
 
 func TestReportCleanTestFailed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-clean")
+	r := newReport("test-clean", config)
 
 	rbdTest := &Test{
 		Context: &Context{name: "appset-deploy-rbd"},
@@ -398,7 +426,7 @@ func TestReportCleanTestFailed(t *testing.T) {
 
 func TestReportCleanFailed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-clean")
+	r := newReport("test-clean", config)
 
 	rbdTest := &Test{
 		Context: &Context{name: "appset-deploy-rbd"},
@@ -457,7 +485,7 @@ func TestReportCleanFailed(t *testing.T) {
 
 func TestReportCleanAllPassed(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-clean")
+	r := newReport("test-clean", config)
 
 	rbdTest := &Test{
 		Context: &Context{name: "appset-deploy-rbd"},


### PR DESCRIPTION
This PR updates ramen/e2e dependency to include Config.Equal support and test report now includes *types.Config field
to capture test configuration in the report.

Report testing:
1. ramenctl test run:
```
build:
  commit: de6950adf6666a4ff0886e29e99a998615142fe5
  version: v0.4.0-7-gde6950a
config:
  channel:
    name: https-github-com-ramendr-ocm-ramen-samples-git
    namespace: test-gitops
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/hub
  distro: k8s
  drPolicy: dr-policy
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
  pvcSpecs:
  - accessModes: ReadWriteOnce
    name: rbd
    storageClassName: rook-ceph-block
  - accessModes: ReadWriteMany
    name: cephfs
    storageClassName: rook-cephfs-fs1
  repo:
    branch: main
    url: https://github.com/RamenDR/ocm-ramen-samples.git
  tests:
  - deployer: appset
    pvcSpec: rbd
    workload: deploy
created: "2025-04-24T16:33:28.800757+05:30"
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
status: passed
steps:
- name: validate
  status: passed
- name: setup
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: passed
    - name: failover
      status: passed
    - name: relocate
      status: passed
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-rbd
    status: passed
  name: tests
  status: passed
summary:
  failed: 0
  passed: 1
  skipped: 0
```

2. ramenctl test clean:
```
build:
  commit: de6950adf6666a4ff0886e29e99a998615142fe5
  version: v0.4.0-7-gde6950a
config:
  channel:
    name: https-github-com-ramendr-ocm-ramen-samples-git
    namespace: test-gitops
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/hub
  distro: k8s
  drPolicy: dr-policy
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
  pvcSpecs:
  - accessModes: ReadWriteOnce
    name: rbd
    storageClassName: rook-ceph-block
  - accessModes: ReadWriteMany
    name: cephfs
    storageClassName: rook-cephfs-fs1
  repo:
    branch: main
    url: https://github.com/RamenDR/ocm-ramen-samples.git
  tests:
  - deployer: appset
    pvcSpec: rbd
    workload: deploy
created: "2025-04-24T16:32:56.846368+05:30"
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
status: passed
steps:
- name: validate
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-rbd
    status: passed
  name: tests
  status: passed
- name: cleanup
  status: passed
summary:
  failed: 0
  passed: 1
  skipped: 0
```

Fixes #116 