### PR TITLE
Update cleanFlow to run unprotect and undeploy parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ramendr/ramen/e2e v0.0.0-20250424122329-3f0bedcd598d
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
+	golang.org/x/sync v0.13.0
 	k8s.io/client-go v0.31.1
 	sigs.k8s.io/yaml v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ golang.org/x/oauth2 v0.27.0/go.mod h1:onh5ek6nERTohokkhCD/y2cV4Do3fxFHFuAejCkRWT
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
+golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -241,10 +241,7 @@ func (c *Command) runFlow(test *Test) {
 }
 
 func (c *Command) cleanFlow(test *Test) {
-	if !test.Unprotect() {
-		return
-	}
-	test.Undeploy()
+	test.Cleanup()
 }
 
 func (c *Command) namespacesToGather() []string {


### PR DESCRIPTION
Implemented Test.Cleanup() to undeploy the application and
disable protection concurrently.

Testing:
1. Scaled down the rbd-mirror deployment on cluster dr2 to fail the applications in the protect step.
```
./ramenctl test run -o run
⭐ Using report "run"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-cephfs" deployed
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "disapp-deploy-rbd" deployed
   ✅ Application "disapp-deploy-cephfs" deployed
   ✅ Application "subscr-deploy-cephfs" deployed
   ✅ Application "subscr-deploy-rbd" deployed
   ✅ Application "disapp-deploy-cephfs" protected
   ✅ Application "subscr-deploy-cephfs" protected
   ✅ Application "appset-deploy-cephfs" protected
   ✅ Application "disapp-deploy-cephfs" failed over
   ✅ Application "subscr-deploy-cephfs" failed over
   ✅ Application "appset-deploy-cephfs" failed over
   ✅ Application "disapp-deploy-cephfs" relocated
   ✅ Application "subscr-deploy-cephfs" relocated
   ❌ Failed to protect application "disapp-deploy-rbd"
   ✅ Application "disapp-deploy-cephfs" unprotected
   ❌ Failed to protect application "appset-deploy-rbd"
   ✅ Application "subscr-deploy-cephfs" unprotected
   ❌ Failed to protect application "subscr-deploy-rbd"
   ✅ Application "subscr-deploy-cephfs" undeployed
   ✅ Application "disapp-deploy-cephfs" undeployed
   ✅ Application "appset-deploy-cephfs" relocated
   ✅ Application "appset-deploy-cephfs" unprotected
   ✅ Application "appset-deploy-cephfs" undeployed

🔎 Gather data ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"

❌ failed (3 passed, 3 failed, 0 skipped, 0 canceled)
```
test run report:
```
build:
  commit: 9304e104c93d849333169c9c9b6dcaf60fd4dbcc
  version: v0.4.0-23-g9304e10
config:
  channel:
    name: https-github-com-ramendr-ocm-ramen-samples-git
    namespace: test-gitops
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/hub
  distro: k8s
  drPolicy: dr-policy
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
  pvcSpecs:
  - accessModes: ReadWriteOnce
    name: rbd
    storageClassName: rook-ceph-block
  - accessModes: ReadWriteMany
    name: cephfs
    storageClassName: rook-cephfs-fs1
  repo:
    branch: main
    url: https://github.com/RamenDR/ocm-ramen-samples.git
  tests:
  - deployer: appset
    pvcSpec: rbd
    workload: deploy
  - deployer: appset
    pvcSpec: cephfs
    workload: deploy
  - deployer: subscr
    pvcSpec: rbd
    workload: deploy
  - deployer: subscr
    pvcSpec: cephfs
    workload: deploy
  - deployer: disapp
    pvcSpec: rbd
    workload: deploy
  - deployer: disapp
    pvcSpec: cephfs
    workload: deploy
created: "2025-04-29T12:22:27.334137+05:30"
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
status: failed
steps:
- name: validate
  status: passed
- name: setup
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: failed
    name: appset-deploy-rbd
    status: failed
  - config:
      deployer: appset
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: passed
    - name: failover
      status: passed
    - name: relocate
      status: passed
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: appset-deploy-cephfs
    status: passed
  - config:
      deployer: subscr
      pvcSpec: rbd
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: failed
    name: subscr-deploy-rbd
    status: failed
  - config:
      deployer: subscr
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: passed
    - name: failover
      status: passed
    - name: relocate
      status: passed
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: subscr-deploy-cephfs
    status: passed
  - config:
      deployer: disapp
      pvcSpec: rbd
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: failed
    name: disapp-deploy-rbd
    status: failed
  - config:
      deployer: disapp
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: deploy
      status: passed
    - name: protect
      status: passed
    - name: failover
      status: passed
    - name: relocate
      status: passed
    - name: unprotect
      status: passed
    - name: undeploy
      status: passed
    name: disapp-deploy-cephfs
    status: passed
  name: tests
  status: failed
summary:
  canceled: 0
  failed: 3
  passed: 3
  skipped: 0
  ```

2. Then I ran test clean without scaling back the rbd-mirror deployment.
```
./ramenctl test clean -o clean
⭐ Using report "clean"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "subscr-deploy-cephfs" cleaned up
   ✅ Application "appset-deploy-cephfs" cleaned up
   ✅ Application "disapp-deploy-cephfs" cleaned up
   ✅ Application "appset-deploy-rbd" cleaned up
   ✅ Application "disapp-deploy-rbd" cleaned up
   ✅ Application "subscr-deploy-rbd" cleaned up

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (6 passed, 0 failed, 0 skipped, 0 canceled)
```
test clean report:
```
build:
  commit: 9304e104c93d849333169c9c9b6dcaf60fd4dbcc
  version: v0.4.0-23-g9304e10
config:
  channel:
    name: https-github-com-ramendr-ocm-ramen-samples-git
    namespace: test-gitops
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/hub
  distro: k8s
  drPolicy: dr-policy
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
  pvcSpecs:
  - accessModes: ReadWriteOnce
    name: rbd
    storageClassName: rook-ceph-block
  - accessModes: ReadWriteMany
    name: cephfs
    storageClassName: rook-cephfs-fs1
  repo:
    branch: main
    url: https://github.com/RamenDR/ocm-ramen-samples.git
  tests:
  - deployer: appset
    pvcSpec: rbd
    workload: deploy
  - deployer: appset
    pvcSpec: cephfs
    workload: deploy
  - deployer: subscr
    pvcSpec: rbd
    workload: deploy
  - deployer: subscr
    pvcSpec: cephfs
    workload: deploy
  - deployer: disapp
    pvcSpec: rbd
    workload: deploy
  - deployer: disapp
    pvcSpec: cephfs
    workload: deploy
created: "2025-04-29T12:38:54.309528+05:30"
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
status: passed
steps:
- name: validate
  status: passed
- items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: appset-deploy-rbd
    status: passed
  - config:
      deployer: appset
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: appset-deploy-cephfs
    status: passed
  - config:
      deployer: subscr
      pvcSpec: rbd
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: subscr-deploy-rbd
    status: passed
  - config:
      deployer: subscr
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: subscr-deploy-cephfs
    status: passed
  - config:
      deployer: disapp
      pvcSpec: rbd
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: disapp-deploy-rbd
    status: passed
  - config:
      deployer: disapp
      pvcSpec: cephfs
      workload: deploy
    items:
    - name: cleanup
      status: passed
    name: disapp-deploy-cephfs
    status: passed
  name: tests
  status: passed
- name: cleanup
  status: passed
summary:
  canceled: 0
  failed: 0
  passed: 6
  skipped: 0
```

Fixes #112 