### PR TITLE
Add fast command tests

### DIFF
--- a/pkg/e2e/e2e.go
+++ b/pkg/e2e/e2e.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import (
+	"github.com/ramendr/ramen/e2e/dractions"
+	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
+	"github.com/ramendr/ramen/e2e/validate"
+)
+
+type Backend struct{}
+
+var _ Testing = &Backend{}
+
+func (Backend) Validate(ctx types.Context) error {
+	return validate.TestConfig(ctx)
+}
+
+func (Backend) Setup(ctx types.Context) error {
+	return util.EnsureChannel(ctx)
+}
+
+func (Backend) Cleanup(ctx types.Context) error {
+	return util.EnsureChannelDeleted(ctx)
+}
+
+func (Backend) Deploy(ctx types.TestContext) error {
+	return ctx.Deployer().Deploy(ctx)
+}
+
+func (Backend) Undeploy(ctx types.TestContext) error {
+	return ctx.Deployer().Undeploy(ctx)
+}
+
+func (Backend) Protect(ctx types.TestContext) error {
+	return dractions.EnableProtection(ctx)
+}
+
+func (Backend) Unprotect(ctx types.TestContext) error {
+	return dractions.DisableProtection(ctx)
+}
+
+func (Backend) Failover(ctx types.TestContext) error {
+	return dractions.Failover(ctx)
+}
+
+func (Backend) Relocate(ctx types.TestContext) error {
+	return dractions.Relocate(ctx)
+}

--- a/pkg/e2e/testing.go
+++ b/pkg/e2e/testing.go
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package e2e
+
+import "github.com/ramendr/ramen/e2e/types"
+
+// Testing interface for ramenctl commands.
+type Testing interface {
+	// Operations on types.Context.
+	Validate(types.Context) error
+	Setup(types.Context) error
+	Cleanup(types.Context) error
+
+	// Operations on types.TestContext.
+	Deploy(types.TestContext) error
+	Undeploy(types.TestContext) error
+	Protect(types.TestContext) error
+	Unprotect(types.TestContext) error
+	Failover(types.TestContext) error
+	Relocate(types.TestContext) error
+}

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -10,7 +10,7 @@ func Clean(configFile string, outputDir string) error {
 	if err != nil {
 		return err
 	}
-	defer cmd.Stop()
+	defer cmd.Close()
 
 	testCmd := newCommand(cmd)
 

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -15,20 +15,6 @@ func Clean(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	testCmd := newCommand(cmd, e2e.Backend{})
-
-	if !testCmd.Validate() {
-		return testCmd.Failed()
-	}
-
-	if !testCmd.CleanTests() {
-		return testCmd.Failed()
-	}
-
-	if !testCmd.Cleanup() {
-		return testCmd.Failed()
-	}
-
-	testCmd.Passed()
-	return nil
+	test := newCommand(cmd, e2e.Backend{})
+	return test.Clean()
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -15,6 +15,6 @@ func Clean(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, e2e.Backend{})
+	test := newCommand(cmd, e2e.Backend{}, Options{GatherData: true})
 	return test.Clean()
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -3,25 +3,29 @@
 
 package test
 
+import "github.com/ramendr/ramenctl/pkg/command"
+
 func Clean(configFile string, outputDir string) error {
-	cmd, err := newCommand("test-clean", configFile, outputDir)
+	cmd, err := command.New("test-clean", configFile, outputDir)
 	if err != nil {
 		return err
 	}
 	defer cmd.Stop()
 
-	if !cmd.Validate() {
-		return cmd.Failed()
+	testCmd := newCommand(cmd)
+
+	if !testCmd.Validate() {
+		return testCmd.Failed()
 	}
 
-	if !cmd.CleanTests() {
-		return cmd.Failed()
+	if !testCmd.CleanTests() {
+		return testCmd.Failed()
 	}
 
-	if !cmd.Cleanup() {
-		return cmd.Failed()
+	if !testCmd.Cleanup() {
+		return testCmd.Failed()
 	}
 
-	cmd.Passed()
+	testCmd.Passed()
 	return nil
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -3,7 +3,10 @@
 
 package test
 
-import "github.com/ramendr/ramenctl/pkg/command"
+import (
+	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/e2e"
+)
 
 func Clean(configFile string, outputDir string) error {
 	cmd, err := command.New("test-clean", configFile, outputDir)
@@ -12,7 +15,7 @@ func Clean(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	testCmd := newCommand(cmd)
+	testCmd := newCommand(cmd, e2e.Backend{})
 
 	if !testCmd.Validate() {
 		return testCmd.Failed()

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -20,14 +20,15 @@ import (
 	"github.com/ramendr/ramenctl/pkg/gather"
 )
 
+// namespacePrefix is used for all namespaces created by tests.
+const namespacePrefix = "test-"
+
 // Command is a ramenctl test command.
 type Command struct {
 	*command.Command
 
 	Backend e2e.Testing
 
-	// NamespacePrefix is used for all namespaces created by tests.
-	NamespacePrefix string
 
 	// PCCSpecs maps pvscpec name to pvcspec.
 	PVCSpecs map[string]types.PVCSpecConfig
@@ -48,14 +49,13 @@ type flowFunc func(t *Test)
 // newCommand return a new test command.
 func newCommand(cmd *command.Command, backend e2e.Testing) *Command {
 	// This is not user configurable. We use the same prefix for all namespaces created by the test.
-	cmd.Config().Channel.Namespace = "test-gitops"
+	cmd.Config().Channel.Namespace = namespacePrefix + "gitops"
 
 	testCmd := &Command{
-		Command:         cmd,
-		Backend:         backend,
-		NamespacePrefix: "test-",
-		PVCSpecs:        e2econfig.PVCSpecsMap(cmd.Config()),
-		Report:          newReport(cmd.Name(), cmd.Config()),
+		Command:  cmd,
+		Backend:  backend,
+		PVCSpecs: e2econfig.PVCSpecsMap(cmd.Config()),
+		Report:   newReport(cmd.Name(), cmd.Config()),
 	}
 
 	for _, tc := range cmd.Config().Tests {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -66,6 +66,37 @@ func newCommand(cmd *command.Command, backend e2e.Testing) *Command {
 	return testCmd
 }
 
+// Run a test flow and return an error if one or more tests failed. When completed you need to call Clean() to remove
+// resources created during the run.
+func (c *Command) Run() error {
+	if !c.Validate() {
+		return c.Failed()
+	}
+	if !c.Setup() {
+		return c.Failed()
+	}
+	if !c.RunTests() {
+		return c.Failed()
+	}
+	c.Passed()
+	return nil
+}
+
+// Clean up after running a test flow and return an if cleaning one or more tests failed.
+func (c *Command) Clean() error {
+	if !c.Validate() {
+		return c.Failed()
+	}
+	if !c.CleanTests() {
+		return c.Failed()
+	}
+	if !c.Cleanup() {
+		return c.Failed()
+	}
+	c.Passed()
+	return nil
+}
+
 func (c *Command) Validate() bool {
 	c.startStep(ValidateStep)
 	console.Step("Validate config")

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -45,12 +45,7 @@ type Command struct {
 type flowFunc func(t *Test)
 
 // newCommand return a new test command.
-func newCommand(name, configFile, outputDir string) (*Command, error) {
-	cmd, err := command.New(name, configFile, outputDir)
-	if err != nil {
-		return nil, err
-	}
-
+func newCommand(cmd *command.Command) *Command {
 	// This is not user configurable. We use the same prefix for all namespaces created by the test.
 	cmd.Config().Channel.Namespace = "test-gitops"
 
@@ -58,7 +53,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 		Command:         cmd,
 		NamespacePrefix: "test-",
 		PVCSpecs:        e2econfig.PVCSpecsMap(cmd.Config()),
-		Report:          newReport(name, cmd.Config()),
+		Report:          newReport(cmd.Name(), cmd.Config()),
 	}
 
 	for _, tc := range cmd.Config().Tests {
@@ -66,7 +61,7 @@ func newCommand(name, configFile, outputDir string) (*Command, error) {
 		testCmd.Tests = append(testCmd.Tests, test)
 	}
 
-	return testCmd, nil
+	return testCmd
 }
 
 func (c *Command) Validate() bool {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -69,35 +69,35 @@ func newCommand(cmd *command.Command, backend e2e.Testing) *Command {
 // Run a test flow and return an error if one or more tests failed. When completed you need to call Clean() to remove
 // resources created during the run.
 func (c *Command) Run() error {
-	if !c.Validate() {
-		return c.Failed()
+	if !c.validate() {
+		return c.failed()
 	}
-	if !c.Setup() {
-		return c.Failed()
+	if !c.setup() {
+		return c.failed()
 	}
-	if !c.RunTests() {
-		return c.Failed()
+	if !c.runTests() {
+		return c.failed()
 	}
-	c.Passed()
+	c.passed()
 	return nil
 }
 
 // Clean up after running a test flow and return an if cleaning one or more tests failed.
 func (c *Command) Clean() error {
-	if !c.Validate() {
-		return c.Failed()
+	if !c.validate() {
+		return c.failed()
 	}
-	if !c.CleanTests() {
-		return c.Failed()
+	if !c.cleanTests() {
+		return c.failed()
 	}
-	if !c.Cleanup() {
-		return c.Failed()
+	if !c.cleanup() {
+		return c.failed()
 	}
-	c.Passed()
+	c.passed()
 	return nil
 }
 
-func (c *Command) Validate() bool {
+func (c *Command) validate() bool {
 	c.startStep(ValidateStep)
 	console.Step("Validate config")
 	if err := c.Backend.Validate(c); err != nil {
@@ -107,7 +107,7 @@ func (c *Command) Validate() bool {
 	return c.passStep()
 }
 
-func (c *Command) Setup() bool {
+func (c *Command) setup() bool {
 	c.startStep(SetupStep)
 	console.Step("Setup environment")
 	if err := c.Backend.Setup(c); err != nil {
@@ -117,7 +117,7 @@ func (c *Command) Setup() bool {
 	return c.passStep()
 }
 
-func (c *Command) Cleanup() bool {
+func (c *Command) cleanup() bool {
 	c.startStep(CleanupStep)
 	console.Step("Clean environment")
 	if err := c.Backend.Cleanup(c); err != nil {
@@ -127,12 +127,12 @@ func (c *Command) Cleanup() bool {
 	return c.passStep()
 }
 
-func (c *Command) RunTests() bool {
+func (c *Command) runTests() bool {
 	console.Step("Run tests")
 	return c.runFlowFunc(c.runFlow)
 }
 
-func (c *Command) CleanTests() bool {
+func (c *Command) cleanTests() bool {
 	console.Step("Clean tests")
 	return c.runFlowFunc(c.cleanFlow)
 }
@@ -144,14 +144,14 @@ func (c *Command) gatherData() {
 	gather.Namespaces(c.Env(), namespaces, outputDir, c.Logger())
 }
 
-func (c *Command) Failed() error {
+func (c *Command) failed() error {
 	if err := c.WriteReport(c.Report); err != nil {
 		console.Error("failed to write report: %s", err)
 	}
 	return fmt.Errorf("%s (%s)", c.Report.Status, c.Report.Summary)
 }
 
-func (c *Command) Passed() {
+func (c *Command) passed() {
 	if err := c.WriteReport(c.Report); err != nil {
 		console.Error("failed to write report: %s", err)
 	}

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -1,0 +1,404 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramenctl/pkg/command"
+)
+
+var testConfig = types.Config{
+	PVCSpecs: []types.PVCSpecConfig{
+		{Name: "block", StorageClassName: "block-storage"},
+		{Name: "file", StorageClassName: "file-storage"},
+	},
+	Tests: []types.TestConfig{
+		{Workload: "deploy", Deployer: "appset", PVCSpec: "block"},
+		{Workload: "deploy", Deployer: "appset", PVCSpec: "file"},
+		{Workload: "deploy", Deployer: "subscr", PVCSpec: "block"},
+		{Workload: "deploy", Deployer: "subscr", PVCSpec: "file"},
+		{Workload: "deploy", Deployer: "disapp", PVCSpec: "block"},
+		{Workload: "deploy", Deployer: "disapp", PVCSpec: "file"},
+	},
+}
+
+var testEnv = types.Env{
+	Hub: types.Cluster{Name: "hub"},
+	C1:  types.Cluster{Name: "c1"},
+	C2:  types.Cluster{Name: "c2"},
+}
+
+var testOptions Options
+
+var validateFailed = MockBackend{
+	ValidateFunc: func(ctx types.Context) error {
+		return errors.New("No validate for you!")
+	},
+}
+
+var validateCanceled = MockBackend{
+	ValidateFunc: func(ctx types.Context) error {
+		return context.Canceled
+	},
+}
+
+var setupFailed = MockBackend{
+	SetupFunc: func(ctx types.Context) error {
+		return errors.New("No setup for you!")
+	},
+}
+var setupCanceled = MockBackend{
+	SetupFunc: func(ctx types.Context) error {
+		return context.Canceled
+	},
+}
+
+var cleanupFailed = MockBackend{
+	CleanupFunc: func(ctx types.Context) error {
+		return errors.New("No cleanup for you!")
+	},
+}
+
+var cleanupCanceled = MockBackend{
+	CleanupFunc: func(ctx types.Context) error {
+		return context.Canceled
+	},
+}
+
+var failoverFailed = MockBackend{
+	FailoverFunc: func(ctx types.TestContext) error {
+		return errors.New("No failover for you!")
+	},
+}
+
+var failoverCanceled = MockBackend{
+	FailoverFunc: func(ctx types.TestContext) error {
+		return context.Canceled
+	},
+}
+
+var disappFailoverFailed = MockBackend{
+	FailoverFunc: func(ctx types.TestContext) error {
+		if ctx.Deployer().IsDiscovered() {
+			return errors.New("No failover for you!")
+		}
+		return nil
+	},
+}
+
+var unprotectFailed = MockBackend{
+	UnprotectFunc: func(ctx types.TestContext) error {
+		return errors.New("No unprotect for you!")
+	},
+}
+
+var unprotectCanceled = MockBackend{
+	UnprotectFunc: func(ctx types.TestContext) error {
+		return context.Canceled
+	},
+}
+
+func TestRun(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &MockBackend{}, testOptions)
+	if err := test.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if test.Report.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, test.Report.Status)
+	}
+	summary := Summary{Passed: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunValidateFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &validateFailed, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunValidateCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &validateCanceled, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunSetupFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &setupFailed, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunSetupCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &setupCanceled, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Canceled, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunTestsFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &failoverFailed, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Failed: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunDisappFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &disappFailoverFailed, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Passed: 4, Failed: 2}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestRunTestsCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &failoverCanceled, testOptions)
+	if err := test.Run(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Canceled: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestClean(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &MockBackend{}, testOptions)
+	if err := test.Clean(); err != nil {
+		t.Fatal(err)
+	}
+	if test.Report.Status != Passed {
+		t.Errorf("expected status %q, got %q", Passed, test.Report.Status)
+	}
+	summary := Summary{Passed: 6}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanValidateFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &validateFailed, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanValidateCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &validateCanceled, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Canceled, test.Report.Status)
+	}
+	summary := Summary{}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanTestsFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &unprotectFailed, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Failed: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanTestsCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &unprotectCanceled, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Canceled: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanCleanupFailed(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &cleanupFailed, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Failed {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Passed: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}
+
+func TestCleanCleanupCanceled(t *testing.T) {
+	outputDir := t.TempDir()
+	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmd.Close()
+	test := newCommand(cmd, &cleanupCanceled, testOptions)
+	if err := test.Clean(); err == nil {
+		t.Fatal("command did not fail")
+	}
+	if test.Report.Status != Canceled {
+		t.Errorf("expected status %q, got %q", Failed, test.Report.Status)
+	}
+	summary := Summary{Passed: len(testConfig.Tests)}
+	if test.Report.Summary != summary {
+		t.Errorf("expected summary %+v, got %+v", summary, test.Report.Summary)
+	}
+}

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -54,7 +54,7 @@ func (c *Context) ManagementNamespace() string {
 }
 
 func (c *Context) AppNamespace() string {
-	return c.cmd.NamespacePrefix + c.name
+	return namespacePrefix + c.name
 }
 
 func (c *Context) Logger() *zap.SugaredLogger {

--- a/pkg/test/mock.go
+++ b/pkg/test/mock.go
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"github.com/ramendr/ramen/e2e/types"
+
+	"github.com/ramendr/ramenctl/pkg/e2e"
+)
+
+type ContextFunc func(types.Context) error
+type TestContextFunc func(types.TestContext) error
+
+// MockBackend implements the e2e.Testing interface. All operations succeed without accessing the clusters. To cause
+// operations to fail, set a function returning an error.
+type MockBackend struct {
+	// Operations on types.Context
+	ValidateFunc ContextFunc
+	SetupFunc    ContextFunc
+	CleanupFunc  ContextFunc
+
+	// Operations on types.TestContext
+	DeployFunc    TestContextFunc
+	UndeployFunc  TestContextFunc
+	ProtectFunc   TestContextFunc
+	UnprotectFunc TestContextFunc
+	FailoverFunc  TestContextFunc
+	RelocateFunc  TestContextFunc
+}
+
+var _ e2e.Testing = &MockBackend{}
+
+func (m *MockBackend) Validate(ctx types.Context) error {
+	if m.ValidateFunc != nil {
+		return m.ValidateFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Setup(ctx types.Context) error {
+	if m.SetupFunc != nil {
+		return m.SetupFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Cleanup(ctx types.Context) error {
+	if m.CleanupFunc != nil {
+		return m.CleanupFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Deploy(ctx types.TestContext) error {
+	if m.DeployFunc != nil {
+		return m.DeployFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Undeploy(ctx types.TestContext) error {
+	if m.UndeployFunc != nil {
+		return m.UndeployFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Protect(ctx types.TestContext) error {
+	if m.ProtectFunc != nil {
+		return m.ProtectFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Unprotect(ctx types.TestContext) error {
+	if m.UnprotectFunc != nil {
+		return m.UnprotectFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Failover(ctx types.TestContext) error {
+	if m.FailoverFunc != nil {
+		return m.FailoverFunc(ctx)
+	}
+	return nil
+}
+
+func (m *MockBackend) Relocate(ctx types.TestContext) error {
+	if m.RelocateFunc != nil {
+		return m.RelocateFunc(ctx)
+	}
+	return nil
+}

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -10,7 +10,7 @@ func Run(configFile string, outputDir string) error {
 	if err != nil {
 		return err
 	}
-	defer cmd.Stop()
+	defer cmd.Close()
 
 	testCmd := newCommand(cmd)
 

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -3,7 +3,10 @@
 
 package test
 
-import "github.com/ramendr/ramenctl/pkg/command"
+import (
+	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/e2e"
+)
 
 func Run(configFile string, outputDir string) error {
 	cmd, err := command.New("test-run", configFile, outputDir)
@@ -12,7 +15,7 @@ func Run(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	testCmd := newCommand(cmd)
+	testCmd := newCommand(cmd, e2e.Backend{})
 
 	if !testCmd.Validate() {
 		return testCmd.Failed()

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -3,27 +3,31 @@
 
 package test
 
+import "github.com/ramendr/ramenctl/pkg/command"
+
 func Run(configFile string, outputDir string) error {
-	cmd, err := newCommand("test-run", configFile, outputDir)
+	cmd, err := command.New("test-run", configFile, outputDir)
 	if err != nil {
 		return err
 	}
 	defer cmd.Stop()
 
-	if !cmd.Validate() {
-		return cmd.Failed()
+	testCmd := newCommand(cmd)
+
+	if !testCmd.Validate() {
+		return testCmd.Failed()
 	}
 
 	// NOTE: The environment will be cleaned up by `test clean` command. If a test fail we want to keep the environment
 	// as is for inspection.
-	if !cmd.Setup() {
-		return cmd.Failed()
+	if !testCmd.Setup() {
+		return testCmd.Failed()
 	}
 
-	if !cmd.RunTests() {
-		return cmd.Failed()
+	if !testCmd.RunTests() {
+		return testCmd.Failed()
 	}
 
-	cmd.Passed()
+	testCmd.Passed()
 	return nil
 }

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -15,6 +15,6 @@ func Run(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, e2e.Backend{})
+	test := newCommand(cmd, e2e.Backend{}, Options{GatherData: true})
 	return test.Run()
 }

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -15,22 +15,6 @@ func Run(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	testCmd := newCommand(cmd, e2e.Backend{})
-
-	if !testCmd.Validate() {
-		return testCmd.Failed()
-	}
-
-	// NOTE: The environment will be cleaned up by `test clean` command. If a test fail we want to keep the environment
-	// as is for inspection.
-	if !testCmd.Setup() {
-		return testCmd.Failed()
-	}
-
-	if !testCmd.RunTests() {
-		return testCmd.Failed()
-	}
-
-	testCmd.Passed()
-	return nil
+	test := newCommand(cmd, e2e.Backend{})
+	return test.Run()
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -9,19 +9,20 @@ import (
 	"fmt"
 
 	"github.com/ramendr/ramen/e2e/deployers"
-	"github.com/ramendr/ramen/e2e/dractions"
 	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/workloads"
 
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/e2e"
 )
 
 // Test perform DR opetaions for testing DR flow.
 type Test struct {
 	types.TestContext
-	Status Status
-	Config *types.TestConfig
-	Steps  []*Step
+	Backend e2e.Testing
+	Status  Status
+	Config  *types.TestConfig
+	Steps   []*Step
 }
 
 // newTest creates a test from test configuration and command context.
@@ -43,6 +44,7 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 
 	return &Test{
 		TestContext: newContext(workload, deployer, cmd),
+		Backend:     cmd.Backend,
 		Status:      Passed,
 		Config:      &tc,
 	}
@@ -50,7 +52,7 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 
 func (t *Test) Deploy() bool {
 	t.startStep("deploy")
-	if err := t.Deployer().Deploy(t.TestContext); err != nil {
+	if err := t.Backend.Deploy(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
@@ -59,7 +61,7 @@ func (t *Test) Deploy() bool {
 
 func (t *Test) Undeploy() bool {
 	t.startStep("undeploy")
-	if err := t.Deployer().Undeploy(t.TestContext); err != nil {
+	if err := t.Backend.Undeploy(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
@@ -68,7 +70,7 @@ func (t *Test) Undeploy() bool {
 
 func (t *Test) Protect() bool {
 	t.startStep("protect")
-	if err := dractions.EnableProtection(t.TestContext); err != nil {
+	if err := t.Backend.Protect(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q protected", t.Name())
@@ -77,7 +79,7 @@ func (t *Test) Protect() bool {
 
 func (t *Test) Unprotect() bool {
 	t.startStep("unprotect")
-	if err := dractions.DisableProtection(t.TestContext); err != nil {
+	if err := t.Backend.Unprotect(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
@@ -86,7 +88,7 @@ func (t *Test) Unprotect() bool {
 
 func (t *Test) Failover() bool {
 	t.startStep("failover")
-	if err := dractions.Failover(t.TestContext); err != nil {
+	if err := t.Backend.Failover(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
@@ -95,7 +97,7 @@ func (t *Test) Failover() bool {
 
 func (t *Test) Relocate() bool {
 	t.startStep("relocate")
-	if err := dractions.Relocate(t.TestContext); err != nil {
+	if err := t.Backend.Relocate(t.TestContext); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q relocated", t.Name())


### PR DESCRIPTION
Add fast tests for entire test commands.

Currently testing test.Command requires a real cluster and take about 10 minutes for the simplest flow. We want to test multiple positive and negative flows in milliseconds.

To make this possible, we need to use a mock e2e interface that succeeds immediately without accessing any cluster, and allow simulating errors for particular workloads, deployers, or actions.

We change test.Command to accept a command.Command, so we can create it with a plain command created by the tests with a config, env, and log configured for the test.

Instead of using the e2e packages directly, we use a backend implementing a testing interface providing all the operations that e2e provides. During the test we use a MockBackend that succeeds immediately. The backend can be configured to fail for any workload, deployer, or action.

With this change we test all possible positive and negative flows with all workloads, deployers and pvcSpecs in *51 milliseconds*.
    
Coverage for the test package increased from 16.1% to 75.2%.

## New tests

```console
% go test -list='Test(Run|Clean)' ./pkg/test
TestRun
TestRunValidateFailed
TestRunValidateCanceled
TestRunSetupFailed
TestRunSetupCanceled
TestRunTestsFailed
TestRunDisappFailed
TestRunTestsCanceled
TestClean
TestCleanValidateFailed
TestCleanValidateCanceled
TestCleanTestsFailed
TestCleanTestsCanceled
TestCleanCleanupFailed
TestCleanCleanupCanceled
```

## Example test

```console
% go test -v -run TestRunDisappFailed ./pkg/test
=== RUN   TestRunDisappFailed

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "disapp-deploy-file" deployed
   ✅ Application "appset-deploy-block" deployed
   ✅ Application "appset-deploy-block" protected
   ✅ Application "disapp-deploy-file" protected
   ❌ Failed to failover application "disapp-deploy-file"
   ✅ Application "subscr-deploy-file" deployed
   ✅ Application "appset-deploy-file" deployed
   ✅ Application "disapp-deploy-block" deployed
   ✅ Application "disapp-deploy-block" protected
   ✅ Application "subscr-deploy-block" deployed
   ✅ Application "subscr-deploy-block" protected
   ✅ Application "subscr-deploy-block" failed over
   ✅ Application "subscr-deploy-block" relocated
   ❌ Failed to failover application "disapp-deploy-block"
   ✅ Application "appset-deploy-block" failed over
   ✅ Application "subscr-deploy-file" protected
   ✅ Application "appset-deploy-file" protected
   ✅ Application "subscr-deploy-file" failed over
   ✅ Application "subscr-deploy-block" unprotected
   ✅ Application "appset-deploy-block" relocated
   ✅ Application "appset-deploy-block" unprotected
   ✅ Application "appset-deploy-block" undeployed
   ✅ Application "appset-deploy-file" failed over
   ✅ Application "appset-deploy-file" relocated
   ✅ Application "subscr-deploy-file" relocated
   ✅ Application "subscr-deploy-file" unprotected
   ✅ Application "subscr-deploy-file" undeployed
   ✅ Application "subscr-deploy-block" undeployed
   ✅ Application "appset-deploy-file" unprotected
   ✅ Application "appset-deploy-file" undeployed
--- PASS: TestRunDisappFailed (0.01s)
PASS
ok  	github.com/ramendr/ramenctl/pkg/test	0.417s
```

## Example build

https://github.com/RamenDR/ramenctl/actions/runs/14741180428/job/41379312203

Fixes #70 