### PR TITLE
Add duration tracking for test and command steps

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -245,6 +245,7 @@ config:
     pvcSpec: rbd
     workload: deploy
 created: "2025-04-24T16:33:28.800757+05:30"
+duration: 695.608462543
 host:
   arch: arm64
   cpus: 12
@@ -252,33 +253,44 @@ host:
 name: test-run
 status: passed
 steps:
-- name: validate
+- duration: 0.022823334
+  name: validate
   status: passed
-- name: setup
+- duration: 0.009449584
+  name: setup
   status: passed
-- items:
+- duration: 695.576189625
+  items:
   - config:
       deployer: appset
       pvcSpec: rbd
       workload: deploy
+    duration: 695.576118209
     items:
-    - name: deploy
+    - duration: 0.013429167
+      name: deploy
       status: passed
-    - name: protect
+    - duration: 95.095957834
+      name: protect
       status: passed
-    - name: failover
+    - duration: 270.193688542
+      name: failover
       status: passed
-    - name: relocate
+    - duration: 270.207244208
+      name: relocate
       status: passed
-    - name: unprotect
+    - duration: 60.052227083
+      name: unprotect
       status: passed
-    - name: undeploy
+    - duration: 0.013571375
+      name: undeploy
       status: passed
     name: appset-deploy-rbd
     status: passed
   name: tests
   status: passed
 summary:
+  canceled: 0
   failed: 0
   passed: 1
   skipped: 0

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -5,13 +5,10 @@ package report
 
 import (
 	"runtime"
-	"time"
 
 	"github.com/ramendr/ramenctl/pkg/build"
+	"github.com/ramendr/ramenctl/pkg/time"
 )
-
-// Now used to provide a custom clock for testing.
-var Now func() time.Time
 
 // Host describes the host ramenctl is running on.
 type Host struct {
@@ -41,7 +38,8 @@ func New() *Report {
 			Arch: runtime.GOARCH,
 			Cpus: runtime.NumCPU(),
 		},
-		Created: Now(),
+		// time value without monotonic clock reading
+		Created: time.Now().Local(),
 	}
 	if build.Version != "" || build.Commit != "" {
 		r.Build = &Build{
@@ -75,14 +73,4 @@ func (r *Report) Equal(o *Report) bool {
 		}
 	}
 	return true
-}
-
-// marshalableTime return a time value without monotonic time info. This makes it possible to marshal and unmarshal the
-// time value.
-func marshalableTime() time.Time {
-	return time.Now().Local()
-}
-
-func init() {
-	Now = marshalableTime
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -7,12 +7,12 @@ import (
 	"reflect"
 	"runtime"
 	"testing"
-	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramenctl/pkg/build"
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/time"
 )
 
 func TestHost(t *testing.T) {
@@ -62,8 +62,8 @@ func TestBuildInfo(t *testing.T) {
 func TestCreatedTime(t *testing.T) {
 	fakeTime(t)
 	r := report.New()
-	if r.Created != report.Now() {
-		t.Fatalf("expected %v, got %v", report.Now(), r.Created)
+	if r.Created != time.Now().Local() {
+		t.Fatalf("expected %v, got %v", time.Now().Local(), r.Created)
 	}
 }
 
@@ -82,14 +82,14 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
-var fakeNow = report.Now()
+var fakeNow = time.Now()
 
 func fakeTime(t *testing.T) {
-	savedNow := report.Now
-	report.Now = func() time.Time {
+	savedNow := time.Now
+	time.Now = func() time.Time {
 		return fakeNow
 	}
 	t.Cleanup(func() {
-		report.Now = savedNow
+		time.Now = savedNow
 	})
 }

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -101,7 +101,7 @@ func TestReportRunSetupPassed(t *testing.T) {
 	fakeTime(t)
 	r := newReport("test-run", config)
 
-	step := &Step{Name: SetupStep, Status: Passed}
+	step := &Step{Name: SetupStep, Status: Passed, Duration: 1.23}
 	r.AddStep(step)
 	if r.Status != Passed {
 		t.Errorf("expected status %q, got %q", Passed, r.Status)
@@ -111,7 +111,7 @@ func TestReportRunSetupPassed(t *testing.T) {
 	if len(r.Steps) != 1 {
 		t.Errorf("unexpected steps %+v", r.Steps)
 	}
-	passedSetup := &Step{Name: SetupStep, Status: Passed}
+	passedSetup := &Step{Name: SetupStep, Status: Passed, Duration: 1.23}
 	if !r.Steps[0].Equal(passedSetup) {
 		t.Fatalf("expected setup %+v, got %+v", passedSetup, r.Steps[0])
 	}

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -5,13 +5,13 @@ package test
 
 import (
 	"testing"
-	"time"
 
 	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramen/e2e/types"
 
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/time"
 )
 
 var config = &types.Config{
@@ -662,14 +662,14 @@ func checkRoundtrip(t *testing.T, r1 *Report) {
 	}
 }
 
-var fakeNow = report.Now()
+var fakeNow = time.Now()
 
 func fakeTime(t *testing.T) {
-	savedNow := report.Now
-	report.Now = func() time.Time {
+	savedNow := time.Now
+	time.Now = func() time.Time {
 		return fakeNow
 	}
 	t.Cleanup(func() {
-		report.Now = savedNow
+		time.Now = savedNow
 	})
 }

--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -1,0 +1,25 @@
+package time
+
+import "time"
+
+// A Time represents an instant in time with nanosecond precision. This is an
+// alias of time.Time to make it possible to control the time during tests.
+type Time = time.Time
+
+// Now returns the current local time. It can be set to fake time function
+// during tests.
+var Now func() Time
+
+// Since returns the time elapsed since t. It is shorthand for time.Now().Sub(t).
+func Since(t Time) time.Duration {
+	// return Now().Sub(t)
+	return Now().Sub(t)
+}
+
+func now() Time {
+	return time.Now()
+}
+
+func init() {
+	Now = now
+}


### PR DESCRIPTION
Updated report to record duration of test steps and overall test execution
This allows timing info to be included in test reports for for better timing and performance insights.

Testing:
1. test run report:
```
build:
  commit: c2907b0328599ccbded336602f57b0a26854068a
  version: v0.4.0-23-gc2907b0
config:
  ....
created: "2025-05-05T18:35:44.587494+05:30"
duration: 695.608462543
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-run
status: passed
steps:
- duration: 0.022823334
  name: validate
  status: passed
- duration: 0.009449584
  name: setup
  status: passed
- duration: 695.576189625
  items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    duration: 695.576118209
    items:
    - duration: 0.013429167
      name: deploy
      status: passed
    - duration: 95.095957834
      name: protect
      status: passed
    - duration: 270.193688542
      name: failover
      status: passed
    - duration: 270.207244208
      name: relocate
      status: passed
    - duration: 60.052227083
      name: unprotect
      status: passed
    - duration: 0.013571375
      name: undeploy
      status: passed
    name: appset-deploy-rbd
    status: passed
  name: tests
  status: passed
summary:
  canceled: 0
  failed: 0
  passed: 1
  skipped: 0
```

2. test clean report:
```
build:
  commit: c2907b0328599ccbded336602f57b0a26854068a
  version: v0.4.0-23-gc2907b0
config:
.....
created: "2025-05-05T18:53:29.732014+05:30"
duration: 6.055538834
host:
  arch: arm64
  cpus: 12
  os: darwin
name: test-clean
status: passed
steps:
- duration: 0.021151959
  name: validate
  status: passed
- duration: 0.006969833
  items:
  - config:
      deployer: appset
      pvcSpec: rbd
      workload: deploy
    duration: 0.006952541
    items:
    - duration: 0.006952541
      name: cleanup
      status: passed
    name: appset-deploy-rbd
    status: passed
  name: tests
  status: passed
- duration: 6.027417042
  name: cleanup
  status: passed
summary:
  canceled: 0
  failed: 0
  passed: 1
  skipped: 0
```

Fixes #51 