### PR TITLE
Fix typos in testing.md and command.go

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -369,7 +369,7 @@ Cleaning up the clusters includes:
 ### Failed tests
 
 When a test fails, the test command gathers data related to the failed tests in
-the ouput directory. The gathered data can help you or develpers to diagnose the
+the output directory. The gathered data can help you or developers to diagnose the
 issue.
 
 The following example shows a test run with a failed test, and how to inspect

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -61,7 +61,7 @@ func New(commandName, configFile, outputDir string) (*Command, error) {
 	console.Info("Using config %q", configFile)
 
 	// Create the context before creating the env so we can cancel the command cleanly if accessing the clusters block
-	// for long time. The log will contain the cancelation error.
+	// for long time. The log will contain the cancellation error.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 
 	env, err := e2eenv.New(ctx, cfg, log)


### PR DESCRIPTION
This pull request fixes several typos:

- `ouput` → `output`
- `develpers` → `developers`
- `cancelation` → `cancellation`

The typo `ot` in `go.sum` appears to be part of hash values and was left unchanged to avoid breaking code integrity.

Let me know if there are any other edits you'd like me to make!

Fixes #134 