### PR TITLE
report: Fix Duration tags

### DIFF
--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -32,7 +32,7 @@ const (
 type Step struct {
 	Name     string            `json:"name"`
 	Status   Status            `json:"status,omitempty"`
-	Duration float64           `json:"time,omitempty"`
+	Duration float64           `json:"duration,omitempty"`
 	Config   *types.TestConfig `json:"config,omitempty"`
 	Items    []*Step           `json:"items,omitempty"`
 }
@@ -53,7 +53,7 @@ type Report struct {
 	Steps    []*Step       `json:"steps"`
 	Summary  Summary       `json:"summary"`
 	Status   Status        `json:"status,omitempty"`
-	Duration float64       `json:"time,omitempty"`
+	Duration float64       `json:"duration,omitempty"`
 }
 
 func newReport(commandName string, config *types.Config) *Report {


### PR DESCRIPTION
When we renamed Time to Duration we forgot to rename the tags. We want to use the same name for consistency. We may wan to add "time" later for the time the step was started.