### PR TITLE
remove unintended comment in time.go module

### DIFF
--- a/pkg/time/time.go
+++ b/pkg/time/time.go
@@ -12,7 +12,6 @@ var Now func() Time
 
 // Since returns the time elapsed since t. It is shorthand for time.Now().Sub(t).
 func Since(t Time) time.Duration {
-	// return Now().Sub(t)
 	return Now().Sub(t)
 }
 


### PR DESCRIPTION
Removing unintended comment in time.go module added as part of PR: https://github.com/RamenDR/ramenctl/pull/130