### PR TITLE
build: Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# This is the top-most config.
+root = true
+
+[*.go]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+max_line_length = 100
+
+[*.md]
+indent_style = space
+indent_size = 4
+max_line_length = 80
+
+[*.yaml]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+# git commit message
+[COMMIT_EDITMSG]
+max_line_length = 72

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,5 +81,15 @@ git commit --amend -s
 
 ## Coding Style
 
-The *ramenctl* project is written in Go programming language and follows
-the style guidelines dictated by the go fmt as well as go vet tools.
+The *ramenctl* project is written in the Go programming language and follows the
+style guidelines of gofmt, goimports, and golines tools.
+
+If your editor supports the [EditorConfig](https://editorconfig.org/) file it
+will format the code properaly automatically. For some editors you will need to
+install an [EditorConfig plugin](https://editorconfig.org/#download).
+
+To format the code automatically before committing a change run:
+
+```console
+make fmt
+```


### PR DESCRIPTION
- Add .editorconfig file to help contributor configure their editor automatically
- Update code style section in the contribution guide

Fixes #143 