### PR TITLE
build: Harden workflow permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,8 +9,8 @@ on:
     types: [created]
 
 permissions:
-    contents: write
-    packages: write
+  contents: write
+  packages: write
 
 jobs:
   release-matrix:
@@ -26,8 +26,8 @@ jobs:
         - amd64
         - arm64
         exclude:
-          - goarch: arm64
-            goos: windows
+        - goarch: arm64
+          goos: windows
     steps:
     - uses: actions/checkout@v4
     - uses: wangyoucao577/go-release-action@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,8 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        goos: [linux, windows, darwin]
-        goarch: [amd64, arm64]
+        goos:
+        - linux
+        - windows
+        - darwin
+        goarch:
+        - amd64
+        - arm64
         exclude:
           - goarch: arm64
             goos: windows

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ on:
 jobs:
   lint:
     name: Lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -29,6 +31,8 @@ jobs:
 
   build-matrix:
     name: Build
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -62,6 +66,8 @@ jobs:
 
   test-matrix:
     name: Test
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
When workflow do no specify permissions, they inherit the permissions
from the repository permissions. Often these permissions do not adhere
to the principle of least privilege and can be reduced to read-only.
    
The test workflows does not need to change anything in the repository so
it should use read-only permission.

Fixes #144 