### PR TITLE
Deleting a duplicate call to close a file in pkg/config/config.go

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -63,5 +63,5 @@ func createFile(name string, content []byte) error {
 	if _, err := f.Write(content); err != nil {
 		return err
 	}
-	return f.Close()
+	return nil
 }


### PR DESCRIPTION
Hi! I want to suggest changes to refactor the file saving function. I have removed the repetitive file closing operation. Returned null, as there were no errors.

I want to discuss about defer with you, theoretically it can return an error, do I need to handle this case too?