### PR TITLE
report: update status logic for Failed and Canceled

### DIFF
--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -80,7 +80,11 @@ func (r *Report) AddStep(step *Step) {
 		if r.Status == "" {
 			r.Status = Passed
 		}
-	case Failed, Canceled:
+	case Failed:
+		if r.Status != Canceled {
+			r.Status = step.Status
+		}
+	case Canceled:
 		r.Status = step.Status
 	}
 
@@ -154,7 +158,11 @@ func (s *Step) AddTest(t *Test) {
 		if s.Status == "" {
 			s.Status = Passed
 		}
-	case Failed, Canceled:
+	case Failed:
+		if s.Status != Canceled {
+			s.Status = t.Status
+		}
+	case Canceled:
 		s.Status = t.Status
 	}
 }


### PR DESCRIPTION
The fix addresses this by modifying the status priority logic for AddTest and AddStep:

- "Canceled" now has the highest priority and will override any other status
- "Failed" will only be set if the current status isn't already "Canceled"

This ensures that once a step has a "Canceled" status, it won't be changed to "Failed" by subsequently added tests.

Fixes #155 