### PR TITLE
Report tests cleanups

### DIFF
--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -353,7 +353,7 @@ func TestReportEqual(t *testing.T) {
 
 	t.Run("different duration", func(t *testing.T) {
 		r2 := createReport()
-		r2.Duration = 4.0
+		r2.Duration += 1.0
 		if r1.Equal(r2) {
 			t.Error("reports with different duration should not be equal")
 		}

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -229,25 +229,21 @@ func TestReportDuration(t *testing.T) {
 }
 
 func TestReportAddDuplicateStep(t *testing.T) {
-	fakeTime(t)
 	r := newReport("test-command", config)
 	step := &Step{Name: "unique-step", Status: Passed, Duration: 1.0}
 	r.AddStep(step)
 
-	// Add another step with the same name
-	duplicateStep := &Step{Name: "unique-step", Status: Failed, Duration: 1.0}
-
-	// AddStep should panic
+	// Adding another step with the same name should panic.
+	dup := &Step{Name: "unique-step", Status: Failed, Duration: 1.0}
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("expected panic when adding duplicate step, but it didn't happen")
 		}
 	}()
-	r.AddStep(duplicateStep)
+	r.AddStep(dup)
 }
 
 func TestReportSummary(t *testing.T) {
-	fakeTime(t)
 	r := newReport("test-command", config)
 	testsStep := &Step{
 		Name:     TestsStep,

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -87,6 +87,32 @@ func TestReportAddPassedStep(t *testing.T) {
 			t.Errorf("expected steps to br equal, got %v", r.Steps)
 		}
 	})
+
+	// Adding a passed test should not modify failed status.
+	t.Run("failed", func(t *testing.T) {
+		r := newReport("test-command", config)
+		r.Status = Failed
+		r.AddStep(passedStep)
+		if r.Status != Failed {
+			t.Errorf("expected status %s, got %s", Failed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
+
+	// Adding a passed test should not modify canceled status.
+	t.Run("failed", func(t *testing.T) {
+		r := newReport("test-command", config)
+		r.Status = Canceled
+		r.AddStep(passedStep)
+		if r.Status != Canceled {
+			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
 }
 
 func TestReportAddFailedStep(t *testing.T) {

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -180,32 +180,29 @@ func TestReportAddCanceledStep(t *testing.T) {
 func TestReportAddSkippedStep(t *testing.T) {
 	fakeTime(t)
 	skippedStep := &Step{Name: "skipped-step", Status: Skipped, Duration: 0.0}
-	t.Run("empty initial status", func(t *testing.T) {
+
+	// Skipped step with empty status should result in Passed.
+	t.Run("empty", func(t *testing.T) {
 		r := newReport("test-command", config)
 		r.AddStep(skippedStep)
-
-		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-
-		// Skipped step with empty status should result in Passed
 		if r.Status != Passed {
 			t.Errorf("expected status %s, got %s", Passed, r.Status)
 		}
-	})
-
-	t.Run("failed initial status", func(t *testing.T) {
-		r := newReport("test-command", config)
-		r.Status = Failed
-		r.AddStep(skippedStep)
-
 		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
 		}
+	})
 
-		// Failed status should not be overridden by Skipped
+	// Failed status should not be overridden by Skipped.
+	t.Run("failed", func(t *testing.T) {
+		r := newReport("test-command", config)
+		r.Status = Failed
+		r.AddStep(skippedStep)
 		if r.Status != Failed {
 			t.Errorf("expected status %s, got %s", Failed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
 		}
 	})
 }

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -208,27 +208,21 @@ func TestReportAddSkippedStep(t *testing.T) {
 }
 
 func TestReportDuration(t *testing.T) {
-	fakeTime(t)
 	r := newReport("test-command", config)
 	steps := []*Step{
 		{Name: "step1", Status: Passed, Duration: 1.0},
 		{Name: "step2", Status: Passed, Duration: 1.0},
-		{Name: "step3", Status: Skipped, Duration: 0.0},
+		{Name: "step3", Status: Skipped, Duration: 1.0},
+		{Name: "step4", Status: Failed, Duration: 1.0},
+		{Name: "step5", Status: Canceled, Duration: 1.0},
 	}
 	for _, step := range steps {
 		r.AddStep(step)
 	}
-
-	// Verify cumulative duration
-	expectedDuration := steps[0].Duration + steps[1].Duration + steps[2].Duration
-	if r.Duration != expectedDuration {
-		t.Errorf("expected duration %f, got %f", expectedDuration, r.Duration)
+	var expectedDuration float64
+	for _, s := range r.Steps {
+		expectedDuration += s.Duration
 	}
-
-	// Add a failing step and verify duration updates
-	failStep := &Step{Name: "step4", Status: Failed, Duration: 1.0}
-	r.AddStep(failStep)
-	expectedDuration += failStep.Duration
 	if r.Duration != expectedDuration {
 		t.Errorf("expected duration %f, got %f", expectedDuration, r.Duration)
 	}

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -74,16 +74,19 @@ func TestReportEmpty(t *testing.T) {
 
 func TestReportAddPassedStep(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-command", config)
 	passedStep := &Step{Name: "passed_step", Status: Passed, Duration: 1.0}
-	r.AddStep(passedStep)
 
-	if !slices.Equal(r.Steps, []*Step{passedStep}) {
-		t.Errorf("expected steps to br equal, got %v", r.Steps)
-	}
-	if r.Status != Passed {
-		t.Errorf("expected status %s, got %s", Passed, r.Status)
-	}
+	// Adding a passed test should set the report status.
+	t.Run("empty", func(t *testing.T) {
+		r := newReport("test-command", config)
+		r.AddStep(passedStep)
+		if r.Status != Passed {
+			t.Errorf("expected status %s, got %s", Passed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
 }
 
 func TestReportAddFailedStep(t *testing.T) {

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -162,6 +162,19 @@ func TestReportAddCanceledStep(t *testing.T) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
 		}
 	})
+
+	// Adding canceled step mark the report as cancled.
+	t.Run("passed", func(t *testing.T) {
+		r := newReport("test-command", config)
+		r.Status = Passed
+		r.AddStep(canceledStep)
+		if r.Status != Canceled {
+			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*Step{canceledStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
 }
 
 func TestReportAddSkippedStep(t *testing.T) {

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -320,7 +320,7 @@ func TestReportEqual(t *testing.T) {
 	t.Run("different config content", func(t *testing.T) {
 		r2 := createReport()
 		differentConfig := *config
-		differentConfig.DRPolicy = "differentDrPolicy"
+		differentConfig.DRPolicy = "different-dr-policy"
 		r2.Config = &differentConfig
 		if r1.Equal(r2) {
 			t.Error("reports with different config content should not be equal")

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -423,12 +423,14 @@ func TestStepAddPassedTest(t *testing.T) {
 			{Name: "undeploy", Status: Passed, Duration: 1.0},
 		},
 	}
-	t.Run("empty initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root"}
-		rootStep.AddTest(passedTest)
-		expectedStep := &Step{
-			Name:   rootStep.Name,
-			Status: passedTest.Status,
+
+	// Adding passed step should set step status.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &Step{Name: "root"}
+		s1.AddTest(passedTest)
+		s2 := &Step{
+			Name:   s1.Name,
+			Status: Passed,
 			Items: []*Step{
 				{
 					Name:     passedTest.Name(),
@@ -439,17 +441,17 @@ func TestStepAddPassedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("failed initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Failed}
-		rootStep.AddTest(passedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Failed status should not be changed
+	// If a report is failed adding new step should not change the status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Failed}
+		s1.AddTest(passedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Failed,
 			Items: []*Step{
 				{
@@ -461,17 +463,17 @@ func TestStepAddPassedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("canceled initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Canceled}
-		rootStep.AddTest(passedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Canceled status should not be changed
+	// If a report is failed adding new step should not change the status.
+	t.Run("canceled", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Canceled}
+		s1.AddTest(passedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Canceled,
 			Items: []*Step{
 				{
@@ -483,8 +485,8 @@ func TestStepAddPassedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 }
@@ -499,12 +501,13 @@ func TestStepAddFailedTest(t *testing.T) {
 			{Name: "undeploy", Status: Failed, Duration: 1.0},
 		},
 	}
-	t.Run("empty initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root"}
-		rootStep.AddTest(failedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Status should be Failed
+
+	// Addding failed test should set report status.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &Step{Name: "root"}
+		s1.AddTest(failedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Failed,
 			Items: []*Step{
 				{
@@ -516,16 +519,17 @@ func TestStepAddFailedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("passed initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Passed}
-		rootStep.AddTest(failedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
+	// Adding failed tests shuuld change report status.
+	t.Run("passed", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Passed}
+		s1.AddTest(failedTest)
+		s2 := &Step{
+			Name: s1.Name,
 			// Passed status should be changed to Failed
 			Status: Failed,
 			Items: []*Step{
@@ -538,17 +542,17 @@ func TestStepAddFailedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("canceled initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Canceled}
-		rootStep.AddTest(failedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Canceled status should not be changed
+	// Adding failed step should not change canceled report.
+	t.Run("canceled", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Canceled}
+		s1.AddTest(failedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Canceled,
 			Items: []*Step{
 				{
@@ -560,28 +564,29 @@ func TestStepAddFailedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 }
 
 func TestStepAddCanceledTest(t *testing.T) {
-	t.Run("failed initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Failed}
-		canceledTest := &Test{
-			TestContext: &Context{name: "canceled_test"},
-			Status:      Canceled,
-			Duration:    1.0,
-			Steps: []*Step{
-				{Name: "deploy", Status: Canceled, Duration: 1.0},
-			},
-		}
-		rootStep.AddTest(canceledTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Failed status should be overridden with Canceled
-			Status: canceledTest.Status,
+	canceledTest := &Test{
+		TestContext: &Context{name: "canceled_test"},
+		Status:      Canceled,
+		Duration:    1.0,
+		Steps: []*Step{
+			{Name: "deploy", Status: Canceled, Duration: 1.0},
+		},
+	}
+
+	// Adding canceled test should override failed status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Failed}
+		s1.AddTest(canceledTest)
+		s2 := &Step{
+			Name:   s1.Name,
+			Status: Canceled,
 			Items: []*Step{
 				{
 					Name:     canceledTest.Name(),
@@ -591,37 +596,29 @@ func TestStepAddCanceledTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("canceled initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Canceled}
-		failedTest := &Test{
-			TestContext: &Context{name: "failed_test"},
-			Status:      Failed,
-			Duration:    1.0,
-			Steps: []*Step{
-				{Name: "deploy", Status: Failed, Duration: 1.0},
-			},
-		}
-		rootStep.AddTest(failedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Status should still be Canceled, not overridden by Failed
+	// Adding canceled test should override passed status.
+	t.Run("passed", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Passed}
+		s1.AddTest(canceledTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Canceled,
 			Items: []*Step{
 				{
-					Name:     failedTest.Name(),
-					Status:   failedTest.Status,
-					Duration: failedTest.Duration,
-					Items:    failedTest.Steps,
+					Name:     canceledTest.Name(),
+					Status:   canceledTest.Status,
+					Duration: canceledTest.Duration,
+					Items:    canceledTest.Steps,
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 }
@@ -632,12 +629,13 @@ func TestStepAddSkippedTest(t *testing.T) {
 		Status:      Skipped,
 		Duration:    0.0,
 	}
-	t.Run("empty initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root"}
-		rootStep.AddTest(skippedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Skipped tests get Passed status when parent has no status
+
+	// Adding skipped test should set status to passed.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &Step{Name: "root"}
+		s1.AddTest(skippedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Passed,
 			Items: []*Step{
 				{
@@ -647,17 +645,17 @@ func TestStepAddSkippedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 
-	t.Run("failed initial status", func(t *testing.T) {
-		rootStep := &Step{Name: "root", Status: Failed}
-		rootStep.AddTest(skippedTest)
-		expectedStep := &Step{
-			Name: rootStep.Name,
-			// Failed status should not change
+	// Adding skipped test should not modify failed status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &Step{Name: "root", Status: Failed}
+		s1.AddTest(skippedTest)
+		s2 := &Step{
+			Name:   s1.Name,
 			Status: Failed,
 			Items: []*Step{
 				{
@@ -667,8 +665,8 @@ func TestStepAddSkippedTest(t *testing.T) {
 				},
 			},
 		}
-		if !rootStep.Equal(expectedStep) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", rootStep, expectedStep)
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
 		}
 	})
 }
@@ -699,105 +697,105 @@ func TestStepMarshal(t *testing.T) {
 }
 
 func TestStepEqual(t *testing.T) {
-	baseStep := Step{Name: "base_test", Status: Passed, Duration: 1.0, Config: &config.Tests[0]}
+	s1 := Step{Name: "base_test", Status: Passed, Duration: 1.0, Config: &config.Tests[0]}
 
 	t.Run("equal to self", func(t *testing.T) {
-		if !baseStep.Equal(&baseStep) {
+		if !s1.Equal(&s1) {
 			t.Fatalf("step should be equal to itself")
 		}
 	})
 
 	t.Run("not equal to nil", func(t *testing.T) {
-		if baseStep.Equal(nil) {
+		if s1.Equal(nil) {
 			t.Fatalf("step should not be equal to nil")
 		}
 	})
 
 	t.Run("different name", func(t *testing.T) {
-		differentStep := baseStep
-		differentStep.Name = "new_test"
-		if baseStep.Equal(&differentStep) {
+		s2 := s1
+		s2.Name = "new_test"
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different names should not be equal")
 		}
 	})
 
 	t.Run("different status", func(t *testing.T) {
-		differentStep := baseStep
-		differentStep.Status = Failed
-		if baseStep.Equal(&differentStep) {
+		s2 := s1
+		s2.Status = Failed
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different status should not be equal")
 		}
 	})
 
 	t.Run("different duration", func(t *testing.T) {
-		differentStep := baseStep
-		differentStep.Duration = 2.0
-		if baseStep.Equal(&differentStep) {
+		s2 := s1
+		s2.Duration = 2.0
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different duration should not be equal")
 		}
 	})
 
 	t.Run("different config", func(t *testing.T) {
-		differentStep := baseStep
-		differentStep.Config = &config.Tests[1]
-		if baseStep.Equal(&differentStep) {
+		s2 := s1
+		s2.Config = &config.Tests[1]
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different config should not be equal")
 		}
 	})
 
 	t.Run("one nil config", func(t *testing.T) {
-		differentStep := baseStep
-		differentStep.Config = nil
-		if baseStep.Equal(&differentStep) {
+		s2 := s1
+		s2.Config = nil
+		if s1.Equal(&s2) {
 			t.Fatalf("step with config should not be equal to step without config")
 		}
 	})
 
 	t.Run("both nil config", func(t *testing.T) {
-		stepA := Step{Name: "test", Status: Passed, Duration: 1.0, Config: nil}
-		stepB := stepA
-		if !stepA.Equal(&stepB) {
+		s1 := Step{Name: "test", Status: Passed, Duration: 1.0, Config: nil}
+		s2 := s1
+		if !s1.Equal(&s2) {
 			t.Fatalf("steps with nil config should be equal")
 		}
 	})
 
 	t.Run("equal subitems", func(t *testing.T) {
-		stepA := Step{
+		s1 := Step{
 			Name:     "parent",
 			Status:   Passed,
 			Duration: 1.0,
 			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
 		}
-		stepB := stepA
-		if !stepA.Equal(&stepB) {
+		s2 := s1
+		if !s1.Equal(&s2) {
 			t.Fatalf("steps with equal subitems should be equal")
 		}
 	})
 
 	t.Run("different subitem name", func(t *testing.T) {
-		stepA := Step{
+		s1 := Step{
 			Name:     "parent",
 			Status:   Passed,
 			Duration: 1.0,
 			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
 		}
-		stepB := stepA
-		stepB.Items = []*Step{{Name: "child1", Status: Passed}, {Name: "different", Status: Failed}}
-		if stepA.Equal(&stepB) {
+		s2 := s1
+		s2.Items = []*Step{{Name: "child1", Status: Passed}, {Name: "different", Status: Failed}}
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different subitem names should not be equal")
 		}
 	})
 
 	t.Run("different number of subitems", func(t *testing.T) {
-		stepA := Step{
+		s1 := Step{
 			Name:     "parent",
 			Status:   Passed,
 			Duration: 1.0,
 			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
 		}
-		stepB := stepA
-		stepB.Items = []*Step{{Name: "child1", Status: Passed}}
-		if stepA.Equal(&stepB) {
+		s2 := s1
+		s2.Items = []*Step{{Name: "child1", Status: Passed}}
+		if s1.Equal(&s2) {
 			t.Fatalf("steps with different number of subitems should not be equal")
 		}
 	})
@@ -805,7 +803,6 @@ func TestStepEqual(t *testing.T) {
 
 func TestSummaryString(t *testing.T) {
 	summary := Summary{Passed: 5, Failed: 2, Skipped: 3, Canceled: 1}
-
 	expectedString := "5 passed, 2 failed, 3 skipped, 1 canceled"
 	if summary.String() != expectedString {
 		t.Errorf("expected summary string %s, got %s", expectedString, summary.String())

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -310,7 +310,7 @@ func TestReportEqual(t *testing.T) {
 		}
 	})
 
-	t.Run("different config reference", func(t *testing.T) {
+	t.Run("same config reference", func(t *testing.T) {
 		r2 := createReport()
 		if !r1.Equal(r2) {
 			t.Error("reports with equal configs should be equal")

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -296,8 +296,8 @@ func TestReportEqual(t *testing.T) {
 	})
 
 	t.Run("equal reports", func(t *testing.T) {
-		equalReport := createReport()
-		if !r1.Equal(equalReport) {
+		r2 := createReport()
+		if !r1.Equal(r2) {
 			t.Error("reports with identical content should be equal")
 		}
 	})


### PR DESCRIPTION
Add minor cleanups to report tests:
- Missing test cases
- Move sub tests to correct test
- Shorter sub test names
- Unify variable name style
- Simplify tests
- Improve test documentation