### PR TITLE
add support to rename context name and currentContext in kubeconfig

### DIFF
--- a/pkg/gather/gather_test.go
+++ b/pkg/gather/gather_test.go
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+package gather
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/ramendr/ramen/e2e/types"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestRestConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		kubeconfig    string
+		clusterName   string
+		expectedError bool
+	}{
+		{
+			name:          "non existent kubeconfig",
+			kubeconfig:    "does_not_exist.yaml",
+			clusterName:   "test-cluster",
+			expectedError: true,
+		},
+		{
+			name:          "invalid kubeconfig",
+			kubeconfig:    "invalid_kubeconfig.yaml",
+			clusterName:   "test-cluster",
+			expectedError: true,
+		},
+		{
+			name:          "same context name",
+			kubeconfig:    "valid_kubeconfig.yaml",
+			clusterName:   "admin",
+			expectedError: false,
+		},
+		{
+			name:          "different context name",
+			kubeconfig:    "valid_kubeconfig.yaml",
+			clusterName:   "dr1",
+			expectedError: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			kubeconfigPath := filepath.Join("testdata", tc.kubeconfig)
+			cluster := &types.Cluster{
+				Name:       tc.clusterName,
+				Kubeconfig: kubeconfigPath,
+			}
+
+			log := zaptest.NewLogger(t).Sugar()
+
+			_, err := restConfig(cluster, log)
+			if tc.expectedError && err == nil {
+				t.Fatal("expected error but got nil")
+			} else if !tc.expectedError && err != nil {
+				t.Fatalf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/gather/testdata/invalid_kubeconfig.yaml
+++ b/pkg/gather/testdata/invalid_kubeconfig.yaml
@@ -1,0 +1,3 @@
+# This is an invalid YAML file for testing error handling
+this is not a valid yaml kubeconfig
+it should cause parsing errors

--- a/pkg/gather/testdata/valid_kubeconfig.yaml
+++ b/pkg/gather/testdata/valid_kubeconfig.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+clusters:
+- cluster:
+    certificate-authority-data: OMIT
+    server: https://1.2.3.4:6443
+  name: dr1
+contexts:
+- context:
+    cluster: dr1
+    user: user1
+  name: admin
+current-context: admin
+kind: Config
+preferences: {}
+users:
+- name: user1
+  user:
+    client-certificate-data: OMIT
+    client-key-data: OMIT


### PR DESCRIPTION
When using kubeconfig the context name can be too long and contain special characters that are rejected when gathering data. This change use cluster names from Env when we read the kubeconfig files, so we can manipulate the context name and the current context with the cluster name.

Testing:

Renamed the context to "admin" in all kubeconfig files. Example updated updated contexts to admin:
```
contexts:
- context:
    cluster: dr1
    user: dr1
  name: admin
current-context: admin
```
Scaled downed rbd mirror on a dr cluster to fail and gather.
```
⭐ Using report "run"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "appset-deploy-rbd" deployed
   ❌ Failed to protect application "appset-deploy-rbd"

🔎 Gather data ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"

❌ failed (0 passed, 1 failed, 0 skipped, 0 canceled)
```
[run.tar.gz](https://github.com/user-attachments/files/20262847/run.tar.gz)


Fixes #115 