### PR TITLE
test: Use context deadline for all operations

### DIFF
--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	stdtime "time"
 
 	"go.uber.org/zap"
 	"sigs.k8s.io/yaml"
@@ -133,6 +134,14 @@ func (c *Command) Env() *types.Env {
 
 func (c *Command) Context() context.Context {
 	return c.context
+}
+
+// WithTimeout returns a derived command with a deadline. Call cancel to release resources
+// associated with the context as soon as the operation running in the context complete.
+func (c Command) WithTimeout(d stdtime.Duration) (*Command, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.context, d)
+	c.context = ctx
+	return &c, cancel
 }
 
 // Close log and stop handling signals and mark the command context as done. Calling while a command

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"sort"
 	"sync"
+	stdtime "time"
 
 	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
@@ -110,7 +111,9 @@ func (c *Command) Clean() error {
 func (c *Command) validate() bool {
 	c.startStep(ValidateStep)
 	console.Step("Validate config")
-	if err := c.Backend.Validate(c); err != nil {
+	timedCmd, cancel := c.WithTimeout(30 * stdtime.Second)
+	defer cancel()
+	if err := c.Backend.Validate(timedCmd); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Config validated")
@@ -120,7 +123,9 @@ func (c *Command) validate() bool {
 func (c *Command) setup() bool {
 	c.startStep(SetupStep)
 	console.Step("Setup environment")
-	if err := c.Backend.Setup(c); err != nil {
+	timedCmd, cancel := c.WithTimeout(30 * stdtime.Second)
+	defer cancel()
+	if err := c.Backend.Setup(timedCmd); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Environment setup")
@@ -130,7 +135,9 @@ func (c *Command) setup() bool {
 func (c *Command) cleanup() bool {
 	c.startStep(CleanupStep)
 	console.Step("Clean environment")
-	if err := c.Backend.Cleanup(c); err != nil {
+	timedCmd, cancel := c.WithTimeout(1 * stdtime.Minute)
+	defer cancel()
+	if err := c.Backend.Cleanup(timedCmd); err != nil {
 		return c.failStep(err)
 	}
 	console.Pass("Environment cleaned")

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -410,10 +410,10 @@ func TestReportMarshaling(t *testing.T) {
 
 func TestStepAddPassedTest(t *testing.T) {
 	passedTest := &Test{
-		TestContext: &Context{name: "passing_test"},
-		Status:      Passed,
-		Config:      &config.Tests[0],
-		Duration:    6.0,
+		Context:  &Context{name: "passing_test"},
+		Status:   Passed,
+		Config:   &config.Tests[0],
+		Duration: 6.0,
 		Steps: []*Step{
 			{Name: "deploy", Status: Passed, Duration: 1.0},
 			{Name: "protect", Status: Passed, Duration: 1.0},
@@ -493,10 +493,10 @@ func TestStepAddPassedTest(t *testing.T) {
 
 func TestStepAddFailedTest(t *testing.T) {
 	failedTest := &Test{
-		TestContext: &Context{name: "failing_test"},
-		Status:      Failed,
-		Config:      &config.Tests[0],
-		Duration:    1.0,
+		Context:  &Context{name: "failing_test"},
+		Status:   Failed,
+		Config:   &config.Tests[0],
+		Duration: 1.0,
 		Steps: []*Step{
 			{Name: "undeploy", Status: Failed, Duration: 1.0},
 		},
@@ -572,9 +572,9 @@ func TestStepAddFailedTest(t *testing.T) {
 
 func TestStepAddCanceledTest(t *testing.T) {
 	canceledTest := &Test{
-		TestContext: &Context{name: "canceled_test"},
-		Status:      Canceled,
-		Duration:    1.0,
+		Context:  &Context{name: "canceled_test"},
+		Status:   Canceled,
+		Duration: 1.0,
 		Steps: []*Step{
 			{Name: "deploy", Status: Canceled, Duration: 1.0},
 		},
@@ -625,9 +625,9 @@ func TestStepAddCanceledTest(t *testing.T) {
 
 func TestStepAddSkippedTest(t *testing.T) {
 	skippedTest := &Test{
-		TestContext: &Context{name: "skipped_test"},
-		Status:      Skipped,
-		Duration:    0.0,
+		Context:  &Context{name: "skipped_test"},
+		Status:   Skipped,
+		Duration: 0.0,
 	}
 
 	// Adding skipped test should set status to passed.

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/types"
+	"github.com/ramendr/ramen/e2e/util"
 	"github.com/ramendr/ramen/e2e/workloads"
 	"golang.org/x/sync/errgroup"
 
@@ -56,7 +57,9 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 
 func (t *Test) Deploy() bool {
 	t.startStep("deploy")
-	if err := t.Backend.Deploy(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Deploy(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
@@ -65,7 +68,9 @@ func (t *Test) Deploy() bool {
 
 func (t *Test) Undeploy() bool {
 	t.startStep("undeploy")
-	if err := t.Backend.Undeploy(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Undeploy(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
@@ -74,7 +79,9 @@ func (t *Test) Undeploy() bool {
 
 func (t *Test) Protect() bool {
 	t.startStep("protect")
-	if err := t.Backend.Protect(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Protect(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q protected", t.Name())
@@ -83,7 +90,9 @@ func (t *Test) Protect() bool {
 
 func (t *Test) Unprotect() bool {
 	t.startStep("unprotect")
-	if err := t.Backend.Unprotect(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Unprotect(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
@@ -92,7 +101,9 @@ func (t *Test) Unprotect() bool {
 
 func (t *Test) Failover() bool {
 	t.startStep("failover")
-	if err := t.Backend.Failover(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Failover(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
@@ -101,7 +112,9 @@ func (t *Test) Failover() bool {
 
 func (t *Test) Relocate() bool {
 	t.startStep("relocate")
-	if err := t.Backend.Relocate(t.Context); err != nil {
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
+	if err := t.Backend.Relocate(timedCtx); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q relocated", t.Name())
@@ -110,16 +123,18 @@ func (t *Test) Relocate() bool {
 
 func (t *Test) Cleanup() bool {
 	var g errgroup.Group
+	timedCtx, cancel := t.WithTimeout(util.Timeout)
+	defer cancel()
 
 	t.startStep("cleanup")
 	g.Go(func() error {
-		if err := t.Backend.Unprotect(t.Context); err != nil {
+		if err := t.Backend.Unprotect(timedCtx); err != nil {
 			return err
 		}
 		return nil
 	})
 	g.Go(func() error {
-		if err := t.Backend.Undeploy(t.Context); err != nil {
+		if err := t.Backend.Undeploy(timedCtx); err != nil {
 			return err
 		}
 		return nil
@@ -127,6 +142,7 @@ func (t *Test) Cleanup() bool {
 	if err := g.Wait(); err != nil {
 		return t.failStep(err)
 	}
+
 	console.Pass("Application %q cleaned up", t.Name())
 	return t.passStep()
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -20,7 +20,7 @@ import (
 
 // Test perform DR opetaions for testing DR flow.
 type Test struct {
-	types.TestContext
+	*Context
 	Backend     e2e.Testing
 	Status      Status
 	Config      *types.TestConfig
@@ -47,16 +47,16 @@ func newTest(tc types.TestConfig, cmd *Command) *Test {
 	}
 
 	return &Test{
-		TestContext: newContext(cmd, workload, deployer),
-		Backend:     cmd.Backend,
-		Status:      Passed,
-		Config:      &tc,
+		Context: newContext(cmd, workload, deployer),
+		Backend: cmd.Backend,
+		Status:  Passed,
+		Config:  &tc,
 	}
 }
 
 func (t *Test) Deploy() bool {
 	t.startStep("deploy")
-	if err := t.Backend.Deploy(t.TestContext); err != nil {
+	if err := t.Backend.Deploy(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q deployed", t.Name())
@@ -65,7 +65,7 @@ func (t *Test) Deploy() bool {
 
 func (t *Test) Undeploy() bool {
 	t.startStep("undeploy")
-	if err := t.Backend.Undeploy(t.TestContext); err != nil {
+	if err := t.Backend.Undeploy(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q undeployed", t.Name())
@@ -74,7 +74,7 @@ func (t *Test) Undeploy() bool {
 
 func (t *Test) Protect() bool {
 	t.startStep("protect")
-	if err := t.Backend.Protect(t.TestContext); err != nil {
+	if err := t.Backend.Protect(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q protected", t.Name())
@@ -83,7 +83,7 @@ func (t *Test) Protect() bool {
 
 func (t *Test) Unprotect() bool {
 	t.startStep("unprotect")
-	if err := t.Backend.Unprotect(t.TestContext); err != nil {
+	if err := t.Backend.Unprotect(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q unprotected", t.Name())
@@ -92,7 +92,7 @@ func (t *Test) Unprotect() bool {
 
 func (t *Test) Failover() bool {
 	t.startStep("failover")
-	if err := t.Backend.Failover(t.TestContext); err != nil {
+	if err := t.Backend.Failover(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q failed over", t.Name())
@@ -101,7 +101,7 @@ func (t *Test) Failover() bool {
 
 func (t *Test) Relocate() bool {
 	t.startStep("relocate")
-	if err := t.Backend.Relocate(t.TestContext); err != nil {
+	if err := t.Backend.Relocate(t.Context); err != nil {
 		return t.failStep(err)
 	}
 	console.Pass("Application %q relocated", t.Name())
@@ -113,13 +113,13 @@ func (t *Test) Cleanup() bool {
 
 	t.startStep("cleanup")
 	g.Go(func() error {
-		if err := t.Backend.Unprotect(t.TestContext); err != nil {
+		if err := t.Backend.Unprotect(t.Context); err != nil {
 			return err
 		}
 		return nil
 	})
 	g.Go(func() error {
-		if err := t.Backend.Undeploy(t.TestContext); err != nil {
+		if err := t.Backend.Undeploy(t.Context); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
Next ramen/e2e version will use context deadline instead of internal timeouts. To consume it we must pass a types.Context and types.TestContext with the right deadline.

Like ramen/e2e we implement WithTimeout on the concrete types (command.Command, test.Context) and use it to create a context with a deadline before we pass the context to ramen/e2e.

Additionally we add deadlines to validate and setup operations which do not use a deadline in e2e. This should be fixed in e2e to ensure quick failure for these operations.

With current ramen/e2e, this change limit the time we wait for testing operations, in case when we have multiple wait loops for the same operation (e.g. failover). With this change the entire operation will time out after 10 minutes, even if e2e try to wait 10 minutes per wait loop.

This change is required to consume ramen/e2e context deadline added in
https://github.com/RamenDR/ramen/pull/2043.
