### PR TITLE
Add spell checking to CI workflow and fix spelling errors

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,19 @@ on:
       - main
 
 jobs:
+  spell:
+    name: Spell Check
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+      - name: Run codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          skip: go.sum
+
   lint:
     name: Lint
     permissions:

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,9 @@ examples:
 fmt:
 	golangci-lint fmt
 
+spell:
+	codespell --skip="go.sum"
+
 lint:
 	golangci-lint run ./...
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -366,7 +366,7 @@ ramenctl-test
 
 #### The clean flow
 
-When runnning the clean command *ramenctl* deletes all the tests applications
+When running the clean command *ramenctl* deletes all the tests applications
 specified in the configuration file and cleans up the clusters.
 
 For every test specified in the configuration file perform the following steps:

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -150,7 +150,7 @@ func TestReportAddCanceledStep(t *testing.T) {
 	fakeTime(t)
 	canceledStep := &Step{Name: "canceled_step", Status: Canceled, Duration: 1.0}
 
-	// Adding canceled step mark the report as cancled.
+	// Adding canceled step mark the report as canceled.
 	t.Run("failed", func(t *testing.T) {
 		r := newReport("test-command", config)
 		r.Status = Failed
@@ -163,7 +163,7 @@ func TestReportAddCanceledStep(t *testing.T) {
 		}
 	})
 
-	// Adding canceled step mark the report as cancled.
+	// Adding canceled step mark the report as canceled.
 	t.Run("passed", func(t *testing.T) {
 		r := newReport("test-command", config)
 		r.Status = Passed
@@ -502,7 +502,7 @@ func TestStepAddFailedTest(t *testing.T) {
 		},
 	}
 
-	// Addding failed test should set report status.
+	// Adding failed test should set report status.
 	t.Run("empty", func(t *testing.T) {
 		s1 := &Step{Name: "root"}
 		s1.AddTest(failedTest)


### PR DESCRIPTION
This PR adds automated spell checking to our codebase and fixes existing spelling errors:

1. Added spell checking:
- Created a separate "spell" job in the CI workflow using the official codespell-project/actions-codespell@v2 GitHub Action
- Added a matching make spell command for local development
- Configured both to skip go.sum.

2. Fixed existing spelling errors :
```
$ make spell
codespell --skip="go.sum"
./docs/testing.md:369: runnning ==> running
./pkg/test/report_test.go:153: cancled ==> canceled
temp
./pkg/test/report_test.go:166: cancled ==> canceled
./pkg/test/report_test.go:505: Addding ==> Adding
```

Fixes: #133 