### PR TITLE
Add spell-fix target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,9 @@ fmt:
 spell:
 	codespell --skip="go.sum"
 
+spell-fix:
+	codespell --skip="go.sum" --write-changes
+
 lint:
 	golangci-lint run ./...
 


### PR DESCRIPTION
This PR adds a new make target that automatically fixes spelling errors using codespell's `--write-changes` flag, complementing the existing spell check target.

Tested by creating spell errors:

    $make spell
    codespell --skip="go.sum"
    ./docs/user-interface.md:58: applicatio ==> application
    ./pkg/report/report.go:13: runnig ==> running
    ./pkg/report/report.go:20: buld ==> build
    ./pkg/console/console.go:25: Eror ==> Error

Fixed using spell-fix:

    $make spell-fix
    codespell --skip="go.sum" --write-changes
    FIXED: ./docs/user-interface.md
    FIXED: ./pkg/report/report.go
    FIXED: ./pkg/console/console.go

