### PR TITLE
deps: update ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.23.8
 
 require (
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250526091425-21fdab969a70
+	github.com/ramendr/ramen/e2e v0.0.0-20250527195156-9b873833c437
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250526091425-21fdab969a70 h1:nJyocRLDtiRJpiddmDBX6c7foOTENEtJHbqYGx0tvcs=
-github.com/ramendr/ramen/e2e v0.0.0-20250526091425-21fdab969a70/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250527195156-9b873833c437 h1:HlbgyYbsx+Zj7RE5/vw3vNnd03djWZAwuW4dfnDSzQ8=
+github.com/ramendr/ramen/e2e v0.0.0-20250527195156-9b873833c437/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Consuming fix for creating and deleting namespaces with wait for namespace deletion using labels: RamenDR/ramen#2050

Issue fixed in ramen e2e: RamenDR/ramen#1958