### PR TITLE
Redirect k8s client logs to zap logger

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,14 @@ go 1.23.5
 toolchain go1.23.8
 
 require (
+	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.7.0
 	github.com/ramendr/ramen/e2e v0.0.0-20250527195156-9b873833c437
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.13.0
 	k8s.io/client-go v0.31.1
+	k8s.io/klog/v2 v2.130.1
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -76,7 +78,6 @@ require (
 	k8s.io/apimachinery v0.31.1 // indirect
 	k8s.io/cli-runtime v0.31.1 // indirect
 	k8s.io/component-base v0.31.1 // indirect
-	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240816214639-573285566f34 // indirect
 	k8s.io/kubectl v0.31.1 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect

--- a/pkg/command/log.go
+++ b/pkg/command/log.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/klog/v2"
 )
 
 func newLogger(outputDir, commandName string) (*zap.SugaredLogger, func(), error) {
@@ -29,6 +31,10 @@ func newLogger(outputDir, commandName string) (*zap.SugaredLogger, func(), error
 
 	core := zapcore.NewCore(encoder, writer, zapcore.DebugLevel)
 	logger := zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+
+	// Redirect klog output to zap logger to capture k8s client throttling messages and other klog
+	// outputs. Use zapr to convert zap logger to logr.Logger interface that klog expects.
+	klog.SetLogger(zapr.NewLogger(logger.Named("klog")))
 
 	return logger.Sugar(), closeFile, nil
 }


### PR DESCRIPTION
K8s client libraries use klog which outputs directly to stderr, causing throttling warnings and other messages to appear outside our logging. This change redirects all klog output to use our zap logger.

referred https://github.com/kubernetes/client-go/issues/18 and https://github.com/k3s-io/klog/blob/main/contextual.go#L42

Test clean with the klog in stderr:
```
./ramenctl test clean -o clean
⭐ Using report "clean"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "subscr-deploy-cephfs" cleaned up
   ✅ Application "subscr-deploy-rbd" cleaned up
I0605 15:01:19.365327   24314 request.go:700] Waited for 1.187288166s due to client-side throttling, not priority and fairness, request: DELETE:https://192.168.105.5:6443/apis/cluster.open-cluster-management.io/v1beta1/namespaces/argocd/placements/appset-deploy-rbd
   ✅ Application "appset-deploy-cephfs" cleaned up
   ✅ Application "appset-deploy-rbd" cleaned up
   ✅ Application "disapp-deploy-rbd" cleaned up
   ✅ Application "disapp-deploy-cephfs" cleaned up

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (6 passed, 0 failed, 0 skipped, 0 canceled)
```

Test clean with fix:
```
./ramenctl test clean -o clean
⭐ Using report "clean"
⭐ Using config "config.yaml"

🔎 Validate config ...
   ✅ Config validated

🔎 Clean tests ...
   ✅ Application "subscr-deploy-rbd" cleaned up
   ✅ Application "subscr-deploy-cephfs" cleaned up
   ✅ Application "appset-deploy-cephfs" cleaned up
   ✅ Application "appset-deploy-rbd" cleaned up
   ✅ Application "disapp-deploy-cephfs" cleaned up
   ✅ Application "disapp-deploy-rbd" cleaned up

🔎 Clean environment ...
   ✅ Environment cleaned

✅ passed (6 passed, 0 failed, 0 skipped, 0 canceled)
```
Test clean log o/p:
```
    2025-06-05T17:07:48.623+0530 INFO klog rest/request.go:700 Waited for 1.188020708s due to client-side throttling, not priority and fairness,
    request: DELETE:https://192.168.105.5:6443/apis/cluster.open-cluster-management.io/v1beta1/namespaces/argocd/placements/appset-deploy-cephfs
```

Full clean log:
[test-clean.log](https://github.com/user-attachments/files/20607396/test-clean.log)

Fixes https://github.com/RamenDR/ramen/issues/1957