### PR TITLE
Generic config for non-test commands                                                                                                                                        

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,11 +6,34 @@ package config
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 
+	"github.com/spf13/viper"
+
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramenctl/pkg/console"
 )
 
+// Config is used for all ramenctl commands except the test commands. It is a subset of
+// ramen/e2e/config.Config.
+type Config struct {
+	// Clusters are part of this environment. Requires "hub", "c1", and "c2".
+	Clusters map[string]config.Cluster `json:"clusters"`
+
+	// ClusterSet name with the managed clusters.
+	ClusterSet string `json:"clusterSet"`
+
+	// Distro is either config.DistroK8s or config.DistroOcp. If unset the distro is detected
+	// automatically when validating the config with the clusters.
+	Distro string `json:"distro"`
+
+	// Namespaces are set automatically based on Distro.
+	Namespaces config.Namespaces `json:"namespaces"`
+}
+
+// CreateSampleConfig create a sample config that can be used by all commands. The file can be
+// parsed using ReadConfig() or test.readConfig().
 func CreateSampleConfig(filename, commandName, envFile string) error {
 	var sample *Sample
 	if envFile != "" {
@@ -34,6 +57,79 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 			return fmt.Errorf("configuration file %q already exists", filename)
 		}
 		return fmt.Errorf("failed to create %q: %w", filename, err)
+	}
+	return nil
+}
+
+// ReadConfig reads the configuration file created by CreateSampleConfig, ignoring the test only
+// configuration.
+func ReadConfig(filename string) (*Config, error) {
+	viper.SetDefault("ClusterSet", config.DefaultClusterSetName)
+	viper.SetConfigFile(filename)
+
+	if err := viper.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config: %v", err)
+	}
+
+	cfg := &Config{}
+	if err := viper.Unmarshal(cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %v", err)
+	}
+
+	if err := cfg.validateDistro(); err != nil {
+		return nil, err
+	}
+
+	if err := cfg.validateClusters(); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Equal return true if config is equal to other config.
+func (c *Config) Equal(o *Config) bool {
+	if c == o {
+		return true
+	}
+	if c.Distro != o.Distro {
+		return false
+	}
+	if c.ClusterSet != o.ClusterSet {
+		return false
+	}
+	if c.Namespaces != o.Namespaces {
+		return false
+	}
+	return maps.Equal(c.Clusters, o.Clusters)
+}
+
+func (c *Config) validateDistro() error {
+	if c.Distro == "" {
+		// Will be detected when accessing the clusters.
+		return nil
+	}
+	switch c.Distro {
+	case config.DistroK8s:
+		c.Namespaces = config.K8sNamespaces
+	case config.DistroOcp:
+		c.Namespaces = config.OcpNamespaces
+	default:
+		return fmt.Errorf("invalid distro %q: (choose one of %q, %q)",
+			c.Distro, config.DistroK8s, config.DistroOcp)
+	}
+	return nil
+}
+
+func (c *Config) validateClusters() error {
+	if c.Clusters["hub"].Kubeconfig == "" {
+		return fmt.Errorf("failed to find hub cluster in configuration")
+	}
+	if c.Clusters["c1"].Kubeconfig == "" {
+		return fmt.Errorf("failed to find c1 cluster in configuration")
+	}
+	if c.Clusters["c2"].Kubeconfig == "" {
+		return fmt.Errorf("failed to find c2 cluster in configuration")
 	}
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,9 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/deployers"
-	"github.com/ramendr/ramen/e2e/workloads"
 	"github.com/ramendr/ramenctl/pkg/console"
 )
 
@@ -39,18 +36,6 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 		return fmt.Errorf("failed to create %q: %w", filename, err)
 	}
 	return nil
-}
-
-func ReadConfig(filename string) (*config.Config, error) {
-	options := config.Options{
-		Workloads: workloads.AvailableNames(),
-		Deployers: deployers.AvailableNames(),
-	}
-	config, err := config.ReadConfig(filename, options)
-	if err != nil {
-		return nil, fmt.Errorf("unable to read config: %w", err)
-	}
-	return config, nil
 }
 
 func createFile(name string, content []byte) error {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -10,25 +10,6 @@ import (
 	"github.com/ramendr/ramenctl/pkg/config"
 )
 
-func TestReadEnvFile(t *testing.T) {
-	env, err := config.ReadEnvFile("testdata/regional-dr.yaml")
-	if err != nil {
-		t.Fatalf("Failed to read environment file: %v", err)
-	}
-
-	expected := &config.EnvFile{
-		Name: "rdr",
-		Ramen: config.Ramen{
-			Hub:      "hub",
-			Clusters: []string{"dr1", "dr2"},
-		},
-	}
-
-	if !reflect.DeepEqual(expected, env) {
-		t.Fatalf("expected %+v, got %+v", expected, env)
-	}
-}
-
 func TestSample(t *testing.T) {
 	sample := config.NewSample("ramenctl")
 	expected := &config.Sample{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	e2econfig "github.com/ramendr/ramen/e2e/config"
+
 	"github.com/ramendr/ramenctl/pkg/config"
 )
 
@@ -60,4 +62,83 @@ func TestSampleFromEnv(t *testing.T) {
 	if !reflect.DeepEqual(expected, sample) {
 		t.Fatalf("expected %+v, got %+v", expected, sample)
 	}
+}
+
+func testConfig() *config.Config {
+	return &config.Config{
+		Clusters: map[string]e2econfig.Cluster{
+			"hub": {Kubeconfig: "hub/config"},
+			"c1":  {Kubeconfig: "dr1/config"},
+			"c2":  {Kubeconfig: "dr2/config"},
+		},
+		ClusterSet: "default",
+	}
+}
+
+func TestReadConfigGeneric(t *testing.T) {
+	// We read the same config from full test config or the simplified test config.
+	c, err := config.ReadConfig("testdata/generic.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := testConfig()
+	if !c.Equal(expected) {
+		t.Fatalf("expected %+v, got %+v", expected, c)
+	}
+}
+
+func TestReadConfigTest(t *testing.T) {
+	// We read the same config from full test config or the simplified test config.
+	c1, err := config.ReadConfig("testdata/test.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	c2, err := config.ReadConfig("testdata/generic.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !c1.Equal(c2) {
+		t.Fatalf("expected %+v, got %+v", c1, c2)
+	}
+}
+
+func TestConfigEqual(t *testing.T) {
+	c1 := testConfig()
+	t.Run("equal to itself", func(t *testing.T) {
+		c2 := c1
+		if !c1.Equal(c2) {
+			t.Errorf("config %+v is not equal to itself", c1)
+		}
+	})
+	t.Run("equal to other identical config", func(t *testing.T) {
+		c2 := testConfig()
+		if !c1.Equal(c2) {
+			t.Errorf("config %+v is not equal to other identical config %+v", c1, c2)
+		}
+	})
+}
+
+func TestConfigNotEqual(t *testing.T) {
+	c1 := testConfig()
+	t.Run("distro", func(t *testing.T) {
+		c2 := testConfig()
+		c2.Distro = "modified"
+		if c1.Equal(c2) {
+			t.Fatalf("config %+v non equal config %+v", c1, c2)
+		}
+	})
+	t.Run("clusterset", func(t *testing.T) {
+		c2 := testConfig()
+		c2.ClusterSet = "modified"
+		if c1.Equal(c2) {
+			t.Fatalf("config %+v non equal config %+v", c1, c2)
+		}
+	})
+	t.Run("clusters", func(t *testing.T) {
+		c2 := testConfig()
+		c2.Clusters["c2"] = e2econfig.Cluster{Kubeconfig: "modified"}
+		if c1.Equal(c2) {
+			t.Fatalf("config %+v non equal config %+v", c1, c2)
+		}
+	})
 }

--- a/pkg/config/envfile_test.go
+++ b/pkg/config/envfile_test.go
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package config_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ramendr/ramenctl/pkg/config"
+)
+
+func TestReadEnvFile(t *testing.T) {
+	env, err := config.ReadEnvFile("testdata/regional-dr.yaml")
+	if err != nil {
+		t.Fatalf("Failed to read environment file: %v", err)
+	}
+
+	expected := &config.EnvFile{
+		Name: "rdr",
+		Ramen: config.Ramen{
+			Hub:      "hub",
+			Clusters: []string{"dr1", "dr2"},
+		},
+	}
+
+	if !reflect.DeepEqual(expected, env) {
+		t.Fatalf("expected %+v, got %+v", expected, env)
+	}
+}

--- a/pkg/config/testdata/generic.yaml
+++ b/pkg/config/testdata/generic.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+clusters:
+  hub:
+    kubeconfig: hub/config
+  c1:
+    kubeconfig: dr1/config
+  c2:
+    kubeconfig: dr2/config
+clusterSet: default

--- a/pkg/config/testdata/test.yaml
+++ b/pkg/config/testdata/test.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+---
+clusters:
+  hub:
+    kubeconfig: hub/config
+  c1:
+    kubeconfig: dr1/config
+  c2:
+    kubeconfig: dr2/config
+clusterSet: default
+repo:
+  url: "https://github.com/RamenDR/ocm-ramen-samples.git"
+  branch: main
+drPolicy: dr-policy
+pvcspecs:
+  - name: rbd
+    storageclassname: rook-ceph-block
+    accessmodes: ReadWriteOnce
+  - name: cephfs
+    storageclassname: rook-cephfs-fs1
+    accessmodes: ReadWriteMany
+tests:
+  - deployer: appset
+    workload: deploy
+    pvcspec: rbd
+  - deployer: appset
+    workload: deploy
+    pvcspec: cephfs

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -5,16 +5,24 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
 )
 
 func Clean(configFile string, outputDir string) error {
-	cmd, err := command.New("test-clean", configFile, outputDir)
+	cfg, err := config.ReadConfig(configFile)
+	if err != nil {
+		return err
+	}
+	console.Info("Using config %q", configFile)
+
+	cmd, err := command.New("test-clean", cfg.Clusters, outputDir)
 	if err != nil {
 		return err
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, e2e.Backend{}, Options{GatherData: true})
+	test := newCommand(cmd, cfg, e2e.Backend{}, Options{GatherData: true})
 	return test.Clean()
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -5,17 +5,14 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/config"
-	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
 )
 
 func Clean(configFile string, outputDir string) error {
-	cfg, err := config.ReadConfig(configFile)
+	cfg, err := readConfig(configFile)
 	if err != nil {
 		return err
 	}
-	console.Info("Using config %q", configFile)
 
 	cmd, err := command.New("test-clean", cfg.Clusters, outputDir)
 	if err != nil {

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -120,13 +120,19 @@ var undeployCanceled = MockBackend{
 
 var runFlow = []string{"deploy", "protect", "failover", "relocate", "unprotect", "undeploy"}
 
-func TestRunPassed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
+func testCommand(t *testing.T, name string) *command.Command {
+	cmd, err := command.ForTest(name, &testEnv, t.TempDir())
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer cmd.Close()
+	t.Cleanup(func() {
+		cmd.Close()
+	})
+	return cmd
+}
+
+func TestRunPassed(t *testing.T) {
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &MockBackend{}, testOptions)
 
 	if err := test.Run(); err != nil {
@@ -150,12 +156,7 @@ func TestRunPassed(t *testing.T) {
 }
 
 func TestRunValidateFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &validateFailed, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -171,12 +172,7 @@ func TestRunValidateFailed(t *testing.T) {
 }
 
 func TestRunValidateCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &validateCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -192,12 +188,7 @@ func TestRunValidateCanceled(t *testing.T) {
 }
 
 func TestRunSetupFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &setupFailed, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -215,12 +206,7 @@ func TestRunSetupFailed(t *testing.T) {
 }
 
 func TestRunSetupCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &setupCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -238,12 +224,7 @@ func TestRunSetupCanceled(t *testing.T) {
 }
 
 func TestRunTestsFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &failoverFailed, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -267,12 +248,7 @@ func TestRunTestsFailed(t *testing.T) {
 }
 
 func TestRunDisappFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &disappFailoverFailed, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -300,12 +276,7 @@ func TestRunDisappFailed(t *testing.T) {
 }
 
 func TestRunTestsCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-run")
 	test := newCommand(cmd, &testConfig, &failoverCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
@@ -329,12 +300,7 @@ func TestRunTestsCanceled(t *testing.T) {
 }
 
 func TestCleanPassed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &MockBackend{}, testOptions)
 
 	if err := test.Clean(); err != nil {
@@ -358,12 +324,7 @@ func TestCleanPassed(t *testing.T) {
 }
 
 func TestCleanValidateFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &validateFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -379,12 +340,7 @@ func TestCleanValidateFailed(t *testing.T) {
 }
 
 func TestCleanValidateCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &validateCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -400,12 +356,7 @@ func TestCleanValidateCanceled(t *testing.T) {
 }
 
 func TestCleanUnprotectFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &unprotectFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -427,12 +378,7 @@ func TestCleanUnprotectFailed(t *testing.T) {
 }
 
 func TestCleanUndeployFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &undeployFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -454,12 +400,7 @@ func TestCleanUndeployFailed(t *testing.T) {
 }
 
 func TestCleanUnprotectCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &unprotectCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -481,12 +422,7 @@ func TestCleanUnprotectCanceled(t *testing.T) {
 }
 
 func TestCleanUndeployCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &undeployCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -508,12 +444,7 @@ func TestCleanUndeployCanceled(t *testing.T) {
 }
 
 func TestCleanCleanupFailed(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &cleanupFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
@@ -537,12 +468,7 @@ func TestCleanCleanupFailed(t *testing.T) {
 }
 
 func TestCleanCleanupCanceled(t *testing.T) {
-	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer cmd.Close()
+	cmd := testCommand(t, "test-clean")
 	test := newCommand(cmd, &testConfig, &cleanupCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -133,15 +133,15 @@ func TestRunPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkReport(t, test.Report, Passed, Summary{Passed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Passed, Summary{Passed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Passed)
-	tests := test.Report.Steps[2]
+	tests := test.report.Steps[2]
 	checkStep(t, tests, TestsStep, Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -162,11 +162,11 @@ func TestRunValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{})
-	if len(test.Report.Steps) != 1 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{})
+	if len(test.report.Steps) != 1 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Failed)
 }
 
@@ -183,11 +183,11 @@ func TestRunValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{})
-	if len(test.Report.Steps) != 1 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{})
+	if len(test.report.Steps) != 1 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Canceled)
 }
 
@@ -204,13 +204,13 @@ func TestRunSetupFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Failed)
 }
 
@@ -227,13 +227,13 @@ func TestRunSetupCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Canceled)
 }
 
@@ -250,15 +250,15 @@ func TestRunTestsFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{Failed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Passed)
-	tests := test.Report.Steps[2]
+	tests := test.report.Steps[2]
 	checkStep(t, tests, TestsStep, Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -279,15 +279,15 @@ func TestRunDisappFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{Passed: 4, Failed: 2})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{Passed: 4, Failed: 2})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Passed)
-	tests := test.Report.Steps[2]
+	tests := test.report.Steps[2]
 	checkStep(t, tests, TestsStep, Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -312,15 +312,15 @@ func TestRunTestsCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{Canceled: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	setup := test.Report.Steps[1]
+	setup := test.report.Steps[1]
 	checkStep(t, setup, SetupStep, Passed)
-	tests := test.Report.Steps[2]
+	tests := test.report.Steps[2]
 	checkStep(t, tests, TestsStep, Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -341,19 +341,19 @@ func TestCleanPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkReport(t, test.Report, Passed, Summary{Passed: 6})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Passed, Summary{Passed: 6})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, Passed, "cleanup")
 	}
-	cleanup := test.Report.Steps[2]
+	cleanup := test.report.Steps[2]
 	checkStep(t, cleanup, CleanupStep, Passed)
 }
 
@@ -370,11 +370,11 @@ func TestCleanValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{})
-	if len(test.Report.Steps) != 1 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{})
+	if len(test.report.Steps) != 1 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Failed)
 }
 
@@ -391,11 +391,11 @@ func TestCleanValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{})
-	if len(test.Report.Steps) != 1 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{})
+	if len(test.report.Steps) != 1 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Canceled)
 }
 
@@ -412,13 +412,13 @@ func TestCleanUnprotectFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{Failed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -439,13 +439,13 @@ func TestCleanUndeployFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{Failed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -466,13 +466,13 @@ func TestCleanUnprotectCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{Canceled: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -493,13 +493,13 @@ func TestCleanUndeployCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{Canceled: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 2 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	if len(test.report.Steps) != 2 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
@@ -520,19 +520,19 @@ func TestCleanCleanupFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Failed, Summary{Passed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Failed, Summary{Passed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, Passed, "cleanup")
 	}
-	cleanup := test.Report.Steps[2]
+	cleanup := test.report.Steps[2]
 	checkStep(t, cleanup, CleanupStep, Failed)
 }
 
@@ -549,19 +549,19 @@ func TestCleanCleanupCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.Report, Canceled, Summary{Passed: len(testConfig.Tests)})
-	if len(test.Report.Steps) != 3 {
-		t.Fatalf("unexpected steps %+v", test.Report.Steps)
+	checkReport(t, test.report, Canceled, Summary{Passed: len(testConfig.Tests)})
+	if len(test.report.Steps) != 3 {
+		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
-	validate := test.Report.Steps[0]
+	validate := test.report.Steps[0]
 	checkStep(t, validate, ValidateStep, Passed)
-	tests := test.Report.Steps[1]
+	tests := test.report.Steps[1]
 	checkStep(t, tests, TestsStep, Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, Passed, "cleanup")
 	}
-	cleanup := test.Report.Steps[2]
+	cleanup := test.report.Steps[2]
 	checkStep(t, cleanup, CleanupStep, Canceled)
 }
 

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -122,12 +122,12 @@ var runFlow = []string{"deploy", "protect", "failover", "relocate", "unprotect",
 
 func TestRunPassed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &MockBackend{}, testOptions)
+	test := newCommand(cmd, &testConfig, &MockBackend{}, testOptions)
 
 	if err := test.Run(); err != nil {
 		t.Fatal(err)
@@ -151,12 +151,12 @@ func TestRunPassed(t *testing.T) {
 
 func TestRunValidateFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &validateFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &validateFailed, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -172,12 +172,12 @@ func TestRunValidateFailed(t *testing.T) {
 
 func TestRunValidateCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &validateCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &validateCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -193,12 +193,12 @@ func TestRunValidateCanceled(t *testing.T) {
 
 func TestRunSetupFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &setupFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &setupFailed, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -216,12 +216,12 @@ func TestRunSetupFailed(t *testing.T) {
 
 func TestRunSetupCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &setupCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &setupCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -239,12 +239,12 @@ func TestRunSetupCanceled(t *testing.T) {
 
 func TestRunTestsFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &failoverFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &failoverFailed, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -268,12 +268,12 @@ func TestRunTestsFailed(t *testing.T) {
 
 func TestRunDisappFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &disappFailoverFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &disappFailoverFailed, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -301,12 +301,12 @@ func TestRunDisappFailed(t *testing.T) {
 
 func TestRunTestsCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &failoverCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &failoverCanceled, testOptions)
 
 	if err := test.Run(); err == nil {
 		t.Fatal("command did not fail")
@@ -330,12 +330,12 @@ func TestRunTestsCanceled(t *testing.T) {
 
 func TestCleanPassed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &MockBackend{}, testOptions)
+	test := newCommand(cmd, &testConfig, &MockBackend{}, testOptions)
 
 	if err := test.Clean(); err != nil {
 		t.Fatal(err)
@@ -359,12 +359,12 @@ func TestCleanPassed(t *testing.T) {
 
 func TestCleanValidateFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &validateFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &validateFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -380,12 +380,12 @@ func TestCleanValidateFailed(t *testing.T) {
 
 func TestCleanValidateCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &validateCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &validateCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -401,12 +401,12 @@ func TestCleanValidateCanceled(t *testing.T) {
 
 func TestCleanUnprotectFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &unprotectFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &unprotectFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -428,12 +428,12 @@ func TestCleanUnprotectFailed(t *testing.T) {
 
 func TestCleanUndeployFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &undeployFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &undeployFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -455,12 +455,12 @@ func TestCleanUndeployFailed(t *testing.T) {
 
 func TestCleanUnprotectCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &unprotectCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &unprotectCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -482,12 +482,12 @@ func TestCleanUnprotectCanceled(t *testing.T) {
 
 func TestCleanUndeployCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &undeployCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &undeployCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -509,12 +509,12 @@ func TestCleanUndeployCanceled(t *testing.T) {
 
 func TestCleanCleanupFailed(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &cleanupFailed, testOptions)
+	test := newCommand(cmd, &testConfig, &cleanupFailed, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")
@@ -538,12 +538,12 @@ func TestCleanCleanupFailed(t *testing.T) {
 
 func TestCleanCleanupCanceled(t *testing.T) {
 	outputDir := t.TempDir()
-	cmd, err := command.ForTest("test-run", &testConfig, &testEnv, outputDir)
+	cmd, err := command.ForTest("test-run", &testEnv, outputDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer cmd.Close()
-	test := newCommand(cmd, &cleanupCanceled, testOptions)
+	test := newCommand(cmd, &testConfig, &cleanupCanceled, testOptions)
 
 	if err := test.Clean(); err == nil {
 		t.Fatal("command did not fail")

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/deployers"
+	"github.com/ramendr/ramen/e2e/workloads"
+	"github.com/ramendr/ramenctl/pkg/console"
+)
+
+func readConfig(filename string) (*config.Config, error) {
+	options := config.Options{
+		Workloads: workloads.AvailableNames(),
+		Deployers: deployers.AvailableNames(),
+	}
+	config, err := config.ReadConfig(filename, options)
+	if err != nil {
+		return nil, fmt.Errorf("unable to read config: %w", err)
+	}
+	console.Info("Using config %q", filename)
+	return config, nil
+}

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
-var config = &e2econfig.Config{
+var reportConfig = &e2econfig.Config{
 	Distro:     "k8s",
 	Repo:       e2econfig.Repo{URL: "https://github.com/org/repo", Branch: "main"},
 	DRPolicy:   "dr-policy",
@@ -48,7 +48,7 @@ var config = &e2econfig.Config{
 
 func TestReportEmpty(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-run", config)
+	r := newReport("test-run", reportConfig)
 
 	// Host and ramenctl info is ready.
 	expectedReport := report.New()
@@ -78,7 +78,7 @@ func TestReportAddPassedStep(t *testing.T) {
 
 	// Adding a passed test should set the report status.
 	t.Run("empty", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.AddStep(passedStep)
 		if r.Status != Passed {
 			t.Errorf("expected status %s, got %s", Passed, r.Status)
@@ -90,7 +90,7 @@ func TestReportAddPassedStep(t *testing.T) {
 
 	// Adding a passed test should not modify failed status.
 	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Failed
 		r.AddStep(passedStep)
 		if r.Status != Failed {
@@ -103,7 +103,7 @@ func TestReportAddPassedStep(t *testing.T) {
 
 	// Adding a passed test should not modify canceled status.
 	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Canceled
 		r.AddStep(passedStep)
 		if r.Status != Canceled {
@@ -121,7 +121,7 @@ func TestReportAddFailedStep(t *testing.T) {
 
 	// Failed status should override existing Passed status.
 	t.Run("passed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Passed
 		r.AddStep(failedStep)
 		if r.Status != Failed {
@@ -134,7 +134,7 @@ func TestReportAddFailedStep(t *testing.T) {
 
 	// If a report is canceled, adding a failed test should not change the status.
 	t.Run("canceled", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Canceled
 		r.AddStep(failedStep)
 		if r.Status != Canceled {
@@ -152,7 +152,7 @@ func TestReportAddCanceledStep(t *testing.T) {
 
 	// Adding canceled step mark the report as canceled.
 	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Failed
 		r.AddStep(canceledStep)
 		if r.Status != Canceled {
@@ -165,7 +165,7 @@ func TestReportAddCanceledStep(t *testing.T) {
 
 	// Adding canceled step mark the report as canceled.
 	t.Run("passed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Passed
 		r.AddStep(canceledStep)
 		if r.Status != Canceled {
@@ -183,7 +183,7 @@ func TestReportAddSkippedStep(t *testing.T) {
 
 	// Skipped step with empty status should result in Passed.
 	t.Run("empty", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.AddStep(skippedStep)
 		if r.Status != Passed {
 			t.Errorf("expected status %s, got %s", Passed, r.Status)
@@ -195,7 +195,7 @@ func TestReportAddSkippedStep(t *testing.T) {
 
 	// Failed status should not be overridden by Skipped.
 	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Failed
 		r.AddStep(skippedStep)
 		if r.Status != Failed {
@@ -208,7 +208,7 @@ func TestReportAddSkippedStep(t *testing.T) {
 }
 
 func TestReportDuration(t *testing.T) {
-	r := newReport("test-command", config)
+	r := newReport("test-command", reportConfig)
 	steps := []*Step{
 		{Name: "step1", Status: Passed, Duration: 1.0},
 		{Name: "step2", Status: Passed, Duration: 1.0},
@@ -229,7 +229,7 @@ func TestReportDuration(t *testing.T) {
 }
 
 func TestReportAddDuplicateStep(t *testing.T) {
-	r := newReport("test-command", config)
+	r := newReport("test-command", reportConfig)
 	step := &Step{Name: "unique-step", Status: Passed, Duration: 1.0}
 	r.AddStep(step)
 
@@ -244,7 +244,7 @@ func TestReportAddDuplicateStep(t *testing.T) {
 }
 
 func TestReportSummary(t *testing.T) {
-	r := newReport("test-command", config)
+	r := newReport("test-command", reportConfig)
 	testsStep := &Step{
 		Name:     TestsStep,
 		Status:   Passed,
@@ -268,7 +268,7 @@ func TestReportEqual(t *testing.T) {
 	fakeTime(t)
 	// Helper function to create a standard report
 	createReport := func() *Report {
-		r := newReport("test-command", config)
+		r := newReport("test-command", reportConfig)
 		r.Status = Passed
 		r.Duration = 1.0
 		r.Steps = []*Step{
@@ -319,7 +319,7 @@ func TestReportEqual(t *testing.T) {
 
 	t.Run("different config content", func(t *testing.T) {
 		r2 := createReport()
-		differentConfig := *config
+		differentConfig := *reportConfig
 		differentConfig.DRPolicy = "different-dr-policy"
 		r2.Config = &differentConfig
 		if r1.Equal(r2) {
@@ -383,7 +383,7 @@ func TestReportEqual(t *testing.T) {
 
 func TestReportMarshaling(t *testing.T) {
 	fakeTime(t)
-	r := newReport("test-command", config)
+	r := newReport("test-command", reportConfig)
 	r.Status = Failed
 	r.Duration = 2.0
 	r.Steps = []*Step{
@@ -412,7 +412,7 @@ func TestStepAddPassedTest(t *testing.T) {
 	passedTest := &Test{
 		Context:  &Context{name: "passing_test"},
 		Status:   Passed,
-		Config:   &config.Tests[0],
+		Config:   &reportConfig.Tests[0],
 		Duration: 6.0,
 		Steps: []*Step{
 			{Name: "deploy", Status: Passed, Duration: 1.0},
@@ -495,7 +495,7 @@ func TestStepAddFailedTest(t *testing.T) {
 	failedTest := &Test{
 		Context:  &Context{name: "failing_test"},
 		Status:   Failed,
-		Config:   &config.Tests[0],
+		Config:   &reportConfig.Tests[0],
 		Duration: 1.0,
 		Steps: []*Step{
 			{Name: "undeploy", Status: Failed, Duration: 1.0},
@@ -675,7 +675,7 @@ func TestStepMarshal(t *testing.T) {
 		Name:     "test",
 		Status:   Passed,
 		Duration: 2.0,
-		Config:   &config.Tests[0],
+		Config:   &reportConfig.Tests[0],
 		Items: []*Step{
 			{Name: "subtest1", Status: Passed, Duration: 1.0},
 			{Name: "subtest2", Status: Failed, Duration: 1.0},
@@ -697,7 +697,7 @@ func TestStepMarshal(t *testing.T) {
 }
 
 func TestStepEqual(t *testing.T) {
-	s1 := Step{Name: "base_test", Status: Passed, Duration: 1.0, Config: &config.Tests[0]}
+	s1 := Step{Name: "base_test", Status: Passed, Duration: 1.0, Config: &reportConfig.Tests[0]}
 
 	t.Run("equal to self", func(t *testing.T) {
 		if !s1.Equal(&s1) {
@@ -737,7 +737,7 @@ func TestStepEqual(t *testing.T) {
 
 	t.Run("different config", func(t *testing.T) {
 		s2 := s1
-		s2.Config = &config.Tests[1]
+		s2.Config = &reportConfig.Tests[1]
 		if s1.Equal(&s2) {
 			t.Fatalf("steps with different config should not be equal")
 		}

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -5,17 +5,14 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/config"
-	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
 )
 
 func Run(configFile string, outputDir string) error {
-	cfg, err := config.ReadConfig(configFile)
+	cfg, err := readConfig(configFile)
 	if err != nil {
 		return err
 	}
-	console.Info("Using config %q", configFile)
 
 	cmd, err := command.New("test-run", cfg.Clusters, outputDir)
 	if err != nil {

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -5,16 +5,24 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
 )
 
 func Run(configFile string, outputDir string) error {
-	cmd, err := command.New("test-run", configFile, outputDir)
+	cfg, err := config.ReadConfig(configFile)
+	if err != nil {
+		return err
+	}
+	console.Info("Using config %q", configFile)
+
+	cmd, err := command.New("test-run", cfg.Clusters, outputDir)
 	if err != nil {
 		return err
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, e2e.Backend{}, Options{GatherData: true})
+	test := newCommand(cmd, cfg, e2e.Backend{}, Options{GatherData: true})
 	return test.Run()
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -32,7 +32,7 @@ type Test struct {
 
 // newTest creates a test from test configuration and command context.
 func newTest(tc e2econfig.Test, cmd *Command) *Test {
-	pvcSpec, ok := cmd.PVCSpecs[tc.PVCSpec]
+	pvcSpec, ok := cmd.pvcSpecs[tc.PVCSpec]
 	if !ok {
 		panic(fmt.Sprintf("unknown pvcSpec %q", tc.PVCSpec))
 	}
@@ -49,7 +49,7 @@ func newTest(tc e2econfig.Test, cmd *Command) *Test {
 
 	return &Test{
 		Context: newContext(cmd, workload, deployer),
-		Backend: cmd.Backend,
+		Backend: cmd.backend,
 		Status:  Passed,
 		Config:  &tc,
 	}


### PR DESCRIPTION
For new ramenctl commands (validate clusters, validate application, gather) we need a simplified configuration:

```yaml
clusters:
  hub:
    kubeconfig: hub/config
  c1:
    kubeconfig: dr1/config
  c2:
    kubeconfig: dr2/config
clusterSet: default
```

We cannot use ramen/e2e/config.ReadConfig() since is validates options which are not relevant to the new commands, and will fail with empty pvcspecs and tests. We need ramenctl ReadConfig() helper that can read both the simplified config and the full test config, and ignore test related configuration.

Changes:
- Remove config from command.Command, so we can use it with all commands
- Implement types.Context in test.Command, since command.Command is generic and cannot be passed to e2e code.
- Cleanup config package tests
- Move test config loading to the test package, used by test.Run() and test.Clean()
- Introduce the generic config to be used by all new commands 
- Add testCommand helper to remove duplicated boilerplate in all command tests

Fixes #193