### PR TITLE
deps: Adapt to new ramen/e2e API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.23.8
 require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250609154340-ae5a7218757d
+	github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409
 	github.com/spf13/cobra v1.9.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250609154340-ae5a7218757d h1:iDVklABUjoxVfZ6EiGSVIagXeVqimyFf+nvk3hx/Lik=
-github.com/ramendr/ramen/e2e v0.0.0-20250609154340-ae5a7218757d/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409 h1:Vhe5JON3byxEMj9f9JczwYNQBb8BpdA5JSAR/lbRqRM=
+github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -14,6 +14,7 @@ import (
 	"go.uber.org/zap"
 	"sigs.k8s.io/yaml"
 
+	e2econfig "github.com/ramendr/ramen/e2e/config"
 	e2eenv "github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/types"
 
@@ -28,7 +29,7 @@ type Command struct {
 	// outputDir contains the command log, summary, and gathered files.
 	outputDir string
 	// config loaded from configFile.
-	config *types.Config
+	config *e2econfig.Config
 	// env loaded from the config.
 	env *types.Env
 	// log logging to the command log.
@@ -66,7 +67,7 @@ func New(commandName, configFile, outputDir string) (*Command, error) {
 	// the clusters block for long time. The log will contain the cancellation error.
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 
-	env, err := e2eenv.New(ctx, cfg, log)
+	env, err := e2eenv.New(ctx, cfg.Clusters, log)
 	if err != nil {
 		// Stop the signal handler before we fail.
 		stop()
@@ -91,7 +92,7 @@ func New(commandName, configFile, outputDir string) (*Command, error) {
 // signals and its context cannot be cancelled.
 func ForTest(
 	commandName string,
-	cfg *types.Config,
+	cfg *e2econfig.Config,
 	env *types.Env,
 	outputDir string,
 ) (*Command, error) {
@@ -124,7 +125,7 @@ func (c *Command) Logger() *zap.SugaredLogger {
 	return c.log
 }
 
-func (c *Command) Config() *types.Config {
+func (c *Command) Config() *e2econfig.Config {
 	return c.config
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
-	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramen/e2e/workloads"
 	"github.com/ramendr/ramenctl/pkg/console"
 )
@@ -42,7 +41,7 @@ func CreateSampleConfig(filename, commandName, envFile string) error {
 	return nil
 }
 
-func ReadConfig(filename string) (*types.Config, error) {
+func ReadConfig(filename string) (*config.Config, error) {
 	options := config.Options{
 		Workloads: workloads.AvailableNames(),
 		Deployers: deployers.AvailableNames(),

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -13,7 +13,6 @@ import (
 	stdtime "time"
 
 	e2econfig "github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/types"
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
@@ -37,7 +36,7 @@ type Command struct {
 	Options Options
 
 	// PCCSpecs maps pvscpec name to pvcspec.
-	PVCSpecs map[string]types.PVCSpecConfig
+	PVCSpecs map[string]e2econfig.PVCSpec
 
 	// Tests to run or clean.
 	Tests []*Test

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -9,16 +9,18 @@ import (
 	"fmt"
 	"testing"
 
+	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
+
 	"github.com/ramendr/ramenctl/pkg/command"
 )
 
-var testConfig = types.Config{
-	PVCSpecs: []types.PVCSpecConfig{
+var testConfig = e2econfig.Config{
+	PVCSpecs: []e2econfig.PVCSpec{
 		{Name: "block", StorageClassName: "block-storage"},
 		{Name: "file", StorageClassName: "file-storage"},
 	},
-	Tests: []types.TestConfig{
+	Tests: []e2econfig.Test{
 		{Workload: "deploy", Deployer: "appset", PVCSpec: "block"},
 		{Workload: "deploy", Deployer: "appset", PVCSpec: "file"},
 		{Workload: "deploy", Deployer: "subscr", PVCSpec: "block"},
@@ -586,7 +588,7 @@ func checkStep(t *testing.T, step *Step, name string, status Status) {
 	// We cannot check duration since it may be zero on windows.
 }
 
-func checkTest(t *testing.T, test *Step, tc types.TestConfig, status Status, flow ...string) {
+func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status Status, flow ...string) {
 	name := fmt.Sprintf("%s-%s-%s", tc.Deployer, tc.Workload, tc.PVCSpec)
 	if name != test.Name {
 		t.Fatalf("expected step %q, got %q", name, test.Name)

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -10,6 +10,7 @@ import (
 
 	"go.uber.org/zap"
 
+	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
 )
 
@@ -68,7 +69,7 @@ func (c *Context) Env() *types.Env {
 	return c.parent.Env()
 }
 
-func (c *Context) Config() *types.Config {
+func (c *Context) Config() *e2econfig.Config {
 	return c.parent.Config()
 }
 

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/ramendr/ramen/e2e/types"
+	e2econfig "github.com/ramendr/ramen/e2e/config"
 
 	"github.com/ramendr/ramenctl/pkg/report"
 )
@@ -30,11 +30,11 @@ const (
 
 // A step is a test command step.
 type Step struct {
-	Name     string            `json:"name"`
-	Status   Status            `json:"status,omitempty"`
-	Duration float64           `json:"duration,omitempty"`
-	Config   *types.TestConfig `json:"config,omitempty"`
-	Items    []*Step           `json:"items,omitempty"`
+	Name     string          `json:"name"`
+	Status   Status          `json:"status,omitempty"`
+	Duration float64         `json:"duration,omitempty"`
+	Config   *e2econfig.Test `json:"config,omitempty"`
+	Items    []*Step         `json:"items,omitempty"`
 }
 
 // Summary summaries a test run or clean.
@@ -48,15 +48,15 @@ type Summary struct {
 // Report created by test sub commands.
 type Report struct {
 	*report.Report
-	Name     string        `json:"name"`
-	Config   *types.Config `json:"config"`
-	Steps    []*Step       `json:"steps"`
-	Summary  Summary       `json:"summary"`
-	Status   Status        `json:"status,omitempty"`
-	Duration float64       `json:"duration,omitempty"`
+	Name     string            `json:"name"`
+	Config   *e2econfig.Config `json:"config"`
+	Steps    []*Step           `json:"steps"`
+	Summary  Summary           `json:"summary"`
+	Status   Status            `json:"status,omitempty"`
+	Duration float64           `json:"duration,omitempty"`
 }
 
-func newReport(commandName string, config *types.Config) *Report {
+func newReport(commandName string, config *e2econfig.Config) *Report {
 	if config == nil {
 		panic("config must not be nil")
 	}

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -9,36 +9,36 @@ import (
 
 	"sigs.k8s.io/yaml"
 
-	"github.com/ramendr/ramen/e2e/types"
+	e2econfig "github.com/ramendr/ramen/e2e/config"
 
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
-var config = &types.Config{
+var config = &e2econfig.Config{
 	Distro:     "k8s",
-	Repo:       types.RepoConfig{URL: "https://github.com/org/repo", Branch: "main"},
+	Repo:       e2econfig.Repo{URL: "https://github.com/org/repo", Branch: "main"},
 	DRPolicy:   "dr-policy",
 	ClusterSet: "clusterset",
-	Clusters: map[string]types.ClusterConfig{
+	Clusters: map[string]e2econfig.Cluster{
 		"hub": {Kubeconfig: "hub-kubeconfig"},
 		"c1":  {Kubeconfig: "c1-kubeconfig"},
 		"c2":  {Kubeconfig: "c2-kubeconfig"},
 	},
-	PVCSpecs: []types.PVCSpecConfig{
+	PVCSpecs: []e2econfig.PVCSpec{
 		{Name: "rbd", StorageClassName: "rook-ceph-block", AccessModes: "ReadWriteOnce"},
 		{Name: "cephfs", StorageClassName: "rook-cephfs-fs", AccessModes: "ReadWriteMany"},
 	},
-	Tests: []types.TestConfig{
+	Tests: []e2econfig.Test{
 		{Workload: "appset", Deployer: "deploy", PVCSpec: "rbd"},
 		{Workload: "subscr", Deployer: "deploy", PVCSpec: "rbd"},
 		{Workload: "disapp", Deployer: "deploy", PVCSpec: "cephfs"},
 	},
-	Channel: types.ChannelConfig{
+	Channel: e2econfig.Channel{
 		Name:      "my-channel",
 		Namespace: "test-gitops",
 	},
-	Namespaces: types.NamespacesConfig{
+	Namespaces: e2econfig.Namespaces{
 		RamenHubNamespace:       "ramen-system",
 		RamenDRClusterNamespace: "ramen-system",
 		RamenOpsNamespace:       "ramen-ops",


### PR DESCRIPTION
Require latest ramen/2e including new API changes: https://github.com/RamenDR/ramen/pull/2088

Adapt to use the new API:
- types.Config and related types were moved to the config package
- env.New takes now clusters map instead of config
- util.Timeout replaced with per-operation timeout

This change reduces the chance of random timeouts during failover and relocate, after adding wait for application health that we already consumed recently.