### PR TITLE
Generic report for any ramenctl command

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -261,10 +261,6 @@ steps:
   status: passed
 - duration: 695.576189625
   items:
-  - config:
-      deployer: appset
-      pvcSpec: rbd
-      workload: deploy
     duration: 695.576118209
     items:
     - duration: 0.013429167

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -64,13 +64,12 @@ func (r *Report) Equal(o *Report) bool {
 	if !r.Created.Equal(o.Created) {
 		return false
 	}
-	if r.Build != o.Build {
-		if r.Build == nil || o.Build == nil {
-			return false
-		}
+	if r.Build != nil && o.Build != nil {
 		if *r.Build != *o.Build {
 			return false
 		}
+	} else if r.Build != o.Build {
+		return false
 	}
 	return true
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -37,12 +37,14 @@ type Report struct {
 	Host    Host      `json:"host"`
 	Build   *Build    `json:"build,omitempty"`
 	Created time.Time `json:"created"`
+	Name    string    `json:"name"`
 	Status  Status    `json:"status,omitempty"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
-func New() *Report {
+func New(commandName string) *Report {
 	r := &Report{
+		Name: commandName,
 		Host: Host{
 			OS:   runtime.GOOS,
 			Arch: runtime.GOARCH,
@@ -79,6 +81,9 @@ func (r *Report) Equal(o *Report) bool {
 			return false
 		}
 	} else if r.Build != o.Build {
+		return false
+	}
+	if r.Name != o.Name {
 		return false
 	}
 	if r.Status != o.Status {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -10,6 +10,15 @@ import (
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
+type Status string
+
+const (
+	Passed   = Status("passed")
+	Failed   = Status("failed")
+	Skipped  = Status("skipped")
+	Canceled = Status("canceled")
+)
+
 // Host describes the host ramenctl is running on.
 type Host struct {
 	OS   string `json:"os"`
@@ -28,6 +37,7 @@ type Report struct {
 	Host    Host      `json:"host"`
 	Build   *Build    `json:"build,omitempty"`
 	Created time.Time `json:"created"`
+	Status  Status    `json:"status,omitempty"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
@@ -69,6 +79,9 @@ func (r *Report) Equal(o *Report) bool {
 			return false
 		}
 	} else if r.Build != o.Build {
+		return false
+	}
+	if r.Status != o.Status {
 		return false
 	}
 	return true

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -34,11 +34,12 @@ type Build struct {
 
 // Report created by ramenctl command.
 type Report struct {
-	Host    Host      `json:"host"`
-	Build   *Build    `json:"build,omitempty"`
-	Created time.Time `json:"created"`
-	Name    string    `json:"name"`
-	Status  Status    `json:"status,omitempty"`
+	Host     Host      `json:"host"`
+	Build    *Build    `json:"build,omitempty"`
+	Created  time.Time `json:"created"`
+	Name     string    `json:"name"`
+	Status   Status    `json:"status,omitempty"`
+	Duration float64   `json:"duration,omitempty"`
 }
 
 // New create a new generic report. Commands embed the report in the command report.
@@ -87,6 +88,9 @@ func (r *Report) Equal(o *Report) bool {
 		return false
 	}
 	if r.Status != o.Status {
+		return false
+	}
+	if r.Duration != o.Duration {
 		return false
 	}
 	return true

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -81,6 +81,55 @@ func TestRoundtrip(t *testing.T) {
 	}
 }
 
+func TestReportEqual(t *testing.T) {
+	fakeTime(t)
+	r1 := report.New()
+	t.Run("equal to self", func(t *testing.T) {
+		r2 := r1
+		if !r1.Equal(r2) {
+			t.Fatal("report should be equal itself")
+		}
+	})
+	t.Run("equal reports", func(t *testing.T) {
+		r2 := report.New()
+		if !r1.Equal(r2) {
+			t.Fatalf("expected report %+v, got %+v", r1, r2)
+		}
+	})
+}
+
+func TestReportNotEqual(t *testing.T) {
+	fakeTime(t)
+	r1 := report.New()
+	t.Run("nil", func(t *testing.T) {
+		if r1.Equal(nil) {
+			t.Fatal("report should not be equal to nil")
+		}
+	})
+	t.Run("created", func(t *testing.T) {
+		r2 := report.New()
+		r2.Created = r2.Created.Add(1)
+		if r1.Equal(r2) {
+			t.Fatal("reports with different create time should not be equal")
+		}
+	})
+	t.Run("host", func(t *testing.T) {
+		r2 := report.New()
+		r2.Host.OS = "modified"
+		if r1.Equal(r2) {
+			t.Fatal("reports with different host should not be equal")
+		}
+	})
+	t.Run("build", func(t *testing.T) {
+		r2 := report.New()
+		// Build is either nil or have version and commit, empty Build cannot match.
+		r2.Build = &report.Build{}
+		if r1.Equal(r2) {
+			t.Fatal("reports with different host should not be equal")
+		}
+	})
+}
+
 var fakeNow = time.Now()
 
 func fakeTime(t *testing.T) {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -128,6 +128,13 @@ func TestReportNotEqual(t *testing.T) {
 			t.Fatal("reports with different host should not be equal")
 		}
 	})
+	t.Run("status", func(t *testing.T) {
+		r2 := report.New()
+		r2.Status = report.Failed
+		if r1.Equal(r2) {
+			t.Fatal("reports with different status should not be equal")
+		}
+	})
 }
 
 var fakeNow = time.Now()

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -30,10 +30,10 @@ func TestHost(t *testing.T) {
 func TestBuildInfo(t *testing.T) {
 	savedVersion := build.Version
 	savedCommit := build.Commit
-	defer func() {
+	t.Cleanup(func() {
 		build.Version = savedVersion
 		build.Commit = savedCommit
-	}()
+	})
 	t.Run("available", func(t *testing.T) {
 		build.Version = "fake-version"
 		build.Commit = "fake-commit"

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -5,6 +5,7 @@ package report_test
 
 import (
 	"runtime"
+	"slices"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -146,6 +147,551 @@ func TestReportNotEqual(t *testing.T) {
 		r2.Duration += 1.0
 		if r1.Equal(r2) {
 			t.Error("reports with different duration should not be equal")
+		}
+	})
+	t.Run("steps", func(t *testing.T) {
+		r2 := report.New("name")
+		r2.Steps = []*report.Step{
+			{Name: "new step", Status: report.Passed, Duration: 1.0},
+		}
+		if r1.Equal(r2) {
+			t.Error("reports with different step should not be equal")
+		}
+	})
+}
+
+func TestReportDuration(t *testing.T) {
+	r := report.New("name")
+	steps := []*report.Step{
+		{Name: "step1", Status: report.Passed, Duration: 1.0},
+		{Name: "step2", Status: report.Passed, Duration: 1.0},
+		{Name: "step3", Status: report.Skipped, Duration: 1.0},
+		{Name: "step4", Status: report.Failed, Duration: 1.0},
+		{Name: "step5", Status: report.Canceled, Duration: 1.0},
+	}
+	for _, step := range steps {
+		r.AddStep(step)
+	}
+	var expectedDuration float64
+	for _, s := range r.Steps {
+		expectedDuration += s.Duration
+	}
+	if r.Duration != expectedDuration {
+		t.Errorf("expected duration %f, got %f", expectedDuration, r.Duration)
+	}
+}
+
+func TestReportAddDuplicateStep(t *testing.T) {
+	r := report.New("name")
+	step := &report.Step{Name: "unique", Status: report.Passed, Duration: 1.0}
+	r.AddStep(step)
+
+	// Adding another step with the same name should panic.
+	dup := &report.Step{Name: "unique", Status: report.Failed, Duration: 1.0}
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("expected panic when adding duplicate step, but it didn't happen")
+		}
+	}()
+	r.AddStep(dup)
+}
+
+func TestReportAddPassedStep(t *testing.T) {
+	passedStep := &report.Step{Name: "ok", Status: report.Passed, Duration: 1.0}
+
+	// Adding a passed test should set the report status.
+	t.Run("empty", func(t *testing.T) {
+		r := report.New("name")
+		r.AddStep(passedStep)
+		if r.Status != report.Passed {
+			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
+
+	// Adding a passed test should not modify failed status.
+	t.Run("failed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Failed
+		r.AddStep(passedStep)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
+
+	// Adding a passed test should not modify canceled status.
+	t.Run("failed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Canceled
+		r.AddStep(passedStep)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{passedStep}) {
+			t.Errorf("expected steps to br equal, got %v", r.Steps)
+		}
+	})
+}
+
+func TestReportAddFailedStep(t *testing.T) {
+	failedStep := &report.Step{Name: "fail", Status: report.Failed, Duration: 1.0}
+
+	// Failed status should override existing Passed status.
+	t.Run("passed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Passed
+		r.AddStep(failedStep)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{failedStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+
+	// If a report is canceled, adding a failed test should not change the status.
+	t.Run("canceled", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Canceled
+		r.AddStep(failedStep)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{failedStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+}
+
+func TestReportAddCanceledStep(t *testing.T) {
+	canceledStep := &report.Step{Name: "cancel", Status: report.Canceled, Duration: 1.0}
+
+	// Adding canceled step mark the report as canceled.
+	t.Run("failed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Failed
+		r.AddStep(canceledStep)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{canceledStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+
+	// Adding canceled step mark the report as canceled.
+	t.Run("passed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Passed
+		r.AddStep(canceledStep)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{canceledStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+}
+
+func TestReportAddSkippedStep(t *testing.T) {
+	skippedStep := &report.Step{Name: "skip", Status: report.Skipped, Duration: 0.0}
+
+	// Skipped step with empty status should result in Passed.
+	t.Run("empty", func(t *testing.T) {
+		r := report.New("name")
+		r.AddStep(skippedStep)
+		if r.Status != report.Passed {
+			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{skippedStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+
+	// Failed status should not be overridden by Skipped.
+	t.Run("failed", func(t *testing.T) {
+		r := report.New("name")
+		r.Status = report.Failed
+		r.AddStep(skippedStep)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
+		}
+		if !slices.Equal(r.Steps, []*report.Step{skippedStep}) {
+			t.Errorf("expected steps to be equal, got %v", r.Steps)
+		}
+	})
+}
+
+func TestStepAddPassedStep(t *testing.T) {
+	passedStep := &report.Step{
+		Status:   report.Passed,
+		Duration: 6.0,
+		Items: []*report.Step{
+			{Name: "deploy", Status: report.Passed, Duration: 1.0},
+			{Name: "protect", Status: report.Passed, Duration: 1.0},
+			{Name: "failover", Status: report.Passed, Duration: 1.0},
+			{Name: "relocate", Status: report.Passed, Duration: 1.0},
+			{Name: "unprotect", Status: report.Passed, Duration: 1.0},
+			{Name: "undeploy", Status: report.Passed, Duration: 1.0},
+		},
+	}
+
+	// Adding passed step should set step status.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &report.Step{Name: "root"}
+		s1.AddStep(passedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Passed,
+			Items: []*report.Step{
+				{
+					Name:     passedStep.Name,
+					Status:   passedStep.Status,
+					Duration: passedStep.Duration,
+					Items:    passedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// If a report is failed adding new step should not change the status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Failed}
+		s1.AddStep(passedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Failed,
+			Items: []*report.Step{
+				{
+					Name:     passedStep.Name,
+					Status:   passedStep.Status,
+					Duration: passedStep.Duration,
+					Items:    passedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// If a report is failed adding new step should not change the status.
+	t.Run("canceled", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Canceled}
+		s1.AddStep(passedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Canceled,
+			Items: []*report.Step{
+				{
+					Name:     passedStep.Name,
+					Status:   passedStep.Status,
+					Duration: passedStep.Duration,
+					Items:    passedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+}
+
+func TestStepAddFailedStep(t *testing.T) {
+	failedStep := &report.Step{
+		Status:   report.Failed,
+		Duration: 1.0,
+		Items: []*report.Step{
+			{Name: "undeploy", Status: report.Failed, Duration: 1.0},
+		},
+	}
+
+	// Adding failed test should set report status.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &report.Step{Name: "root"}
+		s1.AddStep(failedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Failed,
+			Items: []*report.Step{
+				{
+					Name:     failedStep.Name,
+					Status:   failedStep.Status,
+					Duration: failedStep.Duration,
+					Items:    failedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// Adding failed tests shuuld change report status.
+	t.Run("passed", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Passed}
+		s1.AddStep(failedStep)
+		s2 := &report.Step{
+			Name: s1.Name,
+			// Passed status should be changed to Failed
+			Status: report.Failed,
+			Items: []*report.Step{
+				{
+					Name:     failedStep.Name,
+					Status:   failedStep.Status,
+					Duration: failedStep.Duration,
+					Items:    failedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// Adding failed step should not change canceled report.
+	t.Run("canceled", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Canceled}
+		s1.AddStep(failedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Canceled,
+			Items: []*report.Step{
+				{
+					Name:     failedStep.Name,
+					Status:   failedStep.Status,
+					Duration: failedStep.Duration,
+					Items:    failedStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+}
+
+func TestStepAddCanceledStep(t *testing.T) {
+	canceledStep := &report.Step{
+		Status:   report.Canceled,
+		Duration: 1.0,
+		Items: []*report.Step{
+			{Name: "deploy", Status: report.Canceled, Duration: 1.0},
+		},
+	}
+
+	// Adding canceled test should override failed status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Failed}
+		s1.AddStep(canceledStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Canceled,
+			Items: []*report.Step{
+				{
+					Name:     canceledStep.Name,
+					Status:   canceledStep.Status,
+					Duration: canceledStep.Duration,
+					Items:    canceledStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// Adding canceled test should override passed status.
+	t.Run("passed", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Passed}
+		s1.AddStep(canceledStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Canceled,
+			Items: []*report.Step{
+				{
+					Name:     canceledStep.Name,
+					Status:   canceledStep.Status,
+					Duration: canceledStep.Duration,
+					Items:    canceledStep.Items,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+}
+
+func TestStepAddSkippedStep(t *testing.T) {
+	skippedStep := &report.Step{
+		Status:   report.Skipped,
+		Duration: 0.0,
+	}
+
+	// Adding skipped test should set status to passed.
+	t.Run("empty", func(t *testing.T) {
+		s1 := &report.Step{Name: "root"}
+		s1.AddStep(skippedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Passed,
+			Items: []*report.Step{
+				{
+					Name:     skippedStep.Name,
+					Status:   skippedStep.Status,
+					Duration: skippedStep.Duration,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+
+	// Adding skipped test should not modify failed status.
+	t.Run("failed", func(t *testing.T) {
+		s1 := &report.Step{Name: "root", Status: report.Failed}
+		s1.AddStep(skippedStep)
+		s2 := &report.Step{
+			Name:   s1.Name,
+			Status: report.Failed,
+			Items: []*report.Step{
+				{
+					Name:     skippedStep.Name,
+					Status:   skippedStep.Status,
+					Duration: skippedStep.Duration,
+				},
+			},
+		}
+		if !s1.Equal(s2) {
+			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
+		}
+	})
+}
+
+func TestStepMarshal(t *testing.T) {
+	step := &report.Step{
+		Name:     "test",
+		Status:   report.Passed,
+		Duration: 2.0,
+		Items: []*report.Step{
+			{Name: "subtest1", Status: report.Passed, Duration: 1.0},
+			{Name: "subtest2", Status: report.Failed, Duration: 1.0},
+		},
+	}
+
+	// Marshal and unmarshal the step
+	bytes, err := yaml.Marshal(step)
+	if err != nil {
+		t.Fatalf("failed to marshal step: %v", err)
+	}
+	unmarshaledStep := &report.Step{}
+	if err := yaml.Unmarshal(bytes, unmarshaledStep); err != nil {
+		t.Fatalf("failed to unmarshal step: %v", err)
+	}
+	if !step.Equal(unmarshaledStep) {
+		t.Fatalf("unmarshalled step %+v, got %+v", step, unmarshaledStep)
+	}
+}
+
+func TestStepEqual(t *testing.T) {
+	s1 := report.Step{Name: "base_test", Status: report.Passed, Duration: 1.0}
+
+	t.Run("equal to self", func(t *testing.T) {
+		if !s1.Equal(&s1) {
+			t.Fatalf("step should be equal to itself")
+		}
+	})
+
+	t.Run("not equal to nil", func(t *testing.T) {
+		if s1.Equal(nil) {
+			t.Fatalf("step should not be equal to nil")
+		}
+	})
+
+	t.Run("different name", func(t *testing.T) {
+		s2 := s1
+		s2.Name = "new_test"
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different names should not be equal")
+		}
+	})
+
+	t.Run("different status", func(t *testing.T) {
+		s2 := s1
+		s2.Status = report.Failed
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different status should not be equal")
+		}
+	})
+
+	t.Run("different duration", func(t *testing.T) {
+		s2 := s1
+		s2.Duration = 2.0
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different duration should not be equal")
+		}
+	})
+
+	t.Run("equal subitems", func(t *testing.T) {
+		s1 := report.Step{
+			Name:     "parent",
+			Status:   report.Passed,
+			Duration: 1.0,
+			Items: []*report.Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
+		}
+		s2 := s1
+		if !s1.Equal(&s2) {
+			t.Fatalf("steps with equal subitems should be equal")
+		}
+	})
+
+	t.Run("different subitem name", func(t *testing.T) {
+		s1 := report.Step{
+			Name:     "parent",
+			Status:   report.Passed,
+			Duration: 1.0,
+			Items: []*report.Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
+		}
+		s2 := s1
+		s2.Items = []*report.Step{
+			{Name: "child1", Status: report.Passed},
+			{Name: "different", Status: report.Failed},
+		}
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different subitem names should not be equal")
+		}
+	})
+
+	t.Run("different number of subitems", func(t *testing.T) {
+		s1 := report.Step{
+			Name:     "parent",
+			Status:   report.Passed,
+			Duration: 1.0,
+			Items: []*report.Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
+		}
+		s2 := s1
+		s2.Items = []*report.Step{{Name: "child1", Status: report.Passed}}
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different number of subitems should not be equal")
 		}
 	})
 }

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -4,7 +4,6 @@
 package report_test
 
 import (
-	"reflect"
 	"runtime"
 	"testing"
 
@@ -22,7 +21,7 @@ func TestHost(t *testing.T) {
 		Arch: runtime.GOARCH,
 		Cpus: runtime.NumCPU(),
 	}
-	if !reflect.DeepEqual(r.Host, expected) {
+	if r.Host != expected {
 		t.Fatalf("expected host %+v, got %+v", expected, r.Host)
 	}
 }
@@ -41,11 +40,11 @@ func TestBuildInfo(t *testing.T) {
 		if r.Build == nil {
 			t.Fatalf("build info omitted")
 		}
-		expected := &report.Build{
+		expected := report.Build{
 			Version: build.Version,
 			Commit:  build.Commit,
 		}
-		if !reflect.DeepEqual(r.Build, expected) {
+		if *r.Build != expected {
 			t.Fatalf("expected build info %+v, got %+v", expected, r.Build)
 		}
 	})

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -141,6 +141,13 @@ func TestReportNotEqual(t *testing.T) {
 			t.Fatal("reports with different status should not be equal")
 		}
 	})
+	t.Run("duration", func(t *testing.T) {
+		r2 := report.New("name")
+		r2.Duration += 1.0
+		if r1.Equal(r2) {
+			t.Error("reports with different duration should not be equal")
+		}
+	})
 }
 
 var fakeNow = time.Now()

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -56,7 +56,7 @@ type Command struct {
 	tests []*Test
 
 	// current test step
-	current *Step
+	current *report.Step
 
 	// Command report, stored at the output directory on completion.
 	report *Report
@@ -225,7 +225,7 @@ func (c *Command) passed() {
 }
 
 func (c *Command) startStep(name string) {
-	c.current = &Step{Name: name}
+	c.current = &report.Step{Name: name}
 	c.stepStarted = time.Now()
 	c.Logger().Infof("Step %q started", c.current.Name)
 }
@@ -276,7 +276,13 @@ func (c *Command) runFlowFunc(f flowFunc) bool {
 	wg.Wait()
 
 	for _, test := range c.tests {
-		c.current.AddTest(test)
+		step := &report.Step{
+			Name:     test.Name(),
+			Status:   test.Status,
+			Duration: test.Duration,
+			Items:    test.Steps,
+		}
+		c.current.AddStep(step)
 	}
 
 	res := c.finishStep()

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
 	"github.com/ramendr/ramenctl/pkg/gather"
+	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
@@ -232,10 +233,10 @@ func (c *Command) startStep(name string) {
 func (c *Command) failStep(err error) bool {
 	c.current.Duration = time.Since(c.stepStarted).Seconds()
 	if errors.Is(err, context.Canceled) {
-		c.current.Status = Canceled
+		c.current.Status = report.Canceled
 		console.Error("Canceled %s", c.current.Name)
 	} else {
-		c.current.Status = Failed
+		c.current.Status = report.Failed
 		console.Error("Failed to %s", c.current.Name)
 	}
 	c.Logger().Errorf("Step %q %s: %s", c.current.Name, c.current.Status, err)
@@ -246,7 +247,7 @@ func (c *Command) failStep(err error) bool {
 
 func (c *Command) passStep() bool {
 	c.current.Duration = time.Since(c.stepStarted).Seconds()
-	c.current.Status = Passed
+	c.current.Status = report.Passed
 	c.Logger().Infof("Step %q passed", c.current.Name)
 	c.report.AddStep(c.current)
 	c.current = nil
@@ -258,7 +259,7 @@ func (c *Command) finishStep() bool {
 	c.Logger().Infof("Step %q finished", c.current.Name)
 	c.report.AddStep(c.current)
 	c.current = nil
-	return c.report.Status == Passed
+	return c.report.Status == report.Passed
 }
 
 func (c *Command) runFlowFunc(f flowFunc) bool {
@@ -279,7 +280,7 @@ func (c *Command) runFlowFunc(f flowFunc) bool {
 	}
 
 	res := c.finishStep()
-	if c.report.Status == Failed && c.options.GatherData {
+	if c.report.Status == report.Failed && c.options.GatherData {
 		c.gatherData()
 	}
 	return res
@@ -317,7 +318,7 @@ func (c *Command) namespacesToGather() []string {
 
 	// Add application resources for failed tests.
 	for _, test := range c.tests {
-		if test.Status == Failed {
+		if test.Status == report.Failed {
 			seen[test.AppNamespace()] = struct{}{}
 			seen[test.ManagementNamespace()] = struct{}{}
 		}

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ramendr/ramen/e2e/types"
 
 	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/report"
 )
 
 var testConfig = e2econfig.Config{
@@ -139,19 +140,19 @@ func TestRunPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkReport(t, test.report, Passed, Summary{Passed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Passed, Summary{Passed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Passed)
+	checkStep(t, setup, SetupStep, report.Passed)
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, Passed)
+	checkStep(t, tests, TestsStep, report.Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Passed, runFlow...)
+		checkTest(t, result, tc, report.Passed, runFlow...)
 	}
 }
 
@@ -163,12 +164,12 @@ func TestRunValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{})
+	checkReport(t, test.report, report.Failed, Summary{})
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Failed)
+	checkStep(t, validate, ValidateStep, report.Failed)
 }
 
 func TestRunValidateCanceled(t *testing.T) {
@@ -179,12 +180,12 @@ func TestRunValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{})
+	checkReport(t, test.report, report.Canceled, Summary{})
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Canceled)
+	checkStep(t, validate, ValidateStep, report.Canceled)
 }
 
 func TestRunSetupFailed(t *testing.T) {
@@ -195,14 +196,14 @@ func TestRunSetupFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{})
+	checkReport(t, test.report, report.Failed, Summary{})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Failed)
+	checkStep(t, setup, SetupStep, report.Failed)
 }
 
 func TestRunSetupCanceled(t *testing.T) {
@@ -213,14 +214,14 @@ func TestRunSetupCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{})
+	checkReport(t, test.report, report.Canceled, Summary{})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Canceled)
+	checkStep(t, setup, SetupStep, report.Canceled)
 }
 
 func TestRunTestsFailed(t *testing.T) {
@@ -231,19 +232,19 @@ func TestRunTestsFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Failed, Summary{Failed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Passed)
+	checkStep(t, setup, SetupStep, report.Passed)
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, Failed)
+	checkStep(t, tests, TestsStep, report.Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Failed, "deploy", "protect", "failover")
+		checkTest(t, result, tc, report.Failed, "deploy", "protect", "failover")
 	}
 }
 
@@ -255,22 +256,22 @@ func TestRunDisappFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{Passed: 4, Failed: 2})
+	checkReport(t, test.report, report.Failed, Summary{Passed: 4, Failed: 2})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Passed)
+	checkStep(t, setup, SetupStep, report.Passed)
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, Failed)
+	checkStep(t, tests, TestsStep, report.Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		if tc.Deployer == "disapp" {
-			checkTest(t, result, tc, Failed, "deploy", "protect", "failover")
+			checkTest(t, result, tc, report.Failed, "deploy", "protect", "failover")
 		} else {
-			checkTest(t, result, tc, Passed, runFlow...)
+			checkTest(t, result, tc, report.Passed, runFlow...)
 		}
 	}
 }
@@ -283,19 +284,19 @@ func TestRunTestsCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Canceled, Summary{Canceled: len(testConfig.Tests)})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, Passed)
+	checkStep(t, setup, SetupStep, report.Passed)
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, Canceled)
+	checkStep(t, tests, TestsStep, report.Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Canceled, "deploy", "protect", "failover")
+		checkTest(t, result, tc, report.Canceled, "deploy", "protect", "failover")
 	}
 }
 
@@ -307,20 +308,20 @@ func TestCleanPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkReport(t, test.report, Passed, Summary{Passed: 6})
+	checkReport(t, test.report, report.Passed, Summary{Passed: 6})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Passed)
+	checkStep(t, tests, TestsStep, report.Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Passed, "cleanup")
+		checkTest(t, result, tc, report.Passed, "cleanup")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, Passed)
+	checkStep(t, cleanup, CleanupStep, report.Passed)
 }
 
 func TestCleanValidateFailed(t *testing.T) {
@@ -331,12 +332,12 @@ func TestCleanValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{})
+	checkReport(t, test.report, report.Failed, Summary{})
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Failed)
+	checkStep(t, validate, ValidateStep, report.Failed)
 }
 
 func TestCleanValidateCanceled(t *testing.T) {
@@ -347,12 +348,12 @@ func TestCleanValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{})
+	checkReport(t, test.report, report.Canceled, Summary{})
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Canceled)
+	checkStep(t, validate, ValidateStep, report.Canceled)
 }
 
 func TestCleanUnprotectFailed(t *testing.T) {
@@ -363,17 +364,17 @@ func TestCleanUnprotectFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Failed, Summary{Failed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Failed)
+	checkStep(t, tests, TestsStep, report.Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Failed, "cleanup")
+		checkTest(t, result, tc, report.Failed, "cleanup")
 	}
 }
 
@@ -385,17 +386,17 @@ func TestCleanUndeployFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{Failed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Failed, Summary{Failed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Failed)
+	checkStep(t, tests, TestsStep, report.Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Failed, "cleanup")
+		checkTest(t, result, tc, report.Failed, "cleanup")
 	}
 }
 
@@ -407,17 +408,17 @@ func TestCleanUnprotectCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Canceled, Summary{Canceled: len(testConfig.Tests)})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Canceled)
+	checkStep(t, tests, TestsStep, report.Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Canceled, "cleanup")
+		checkTest(t, result, tc, report.Canceled, "cleanup")
 	}
 }
 
@@ -429,17 +430,17 @@ func TestCleanUndeployCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{Canceled: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Canceled, Summary{Canceled: len(testConfig.Tests)})
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Canceled)
+	checkStep(t, tests, TestsStep, report.Canceled)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Canceled, "cleanup")
+		checkTest(t, result, tc, report.Canceled, "cleanup")
 	}
 }
 
@@ -451,20 +452,20 @@ func TestCleanCleanupFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Failed, Summary{Passed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Failed, Summary{Passed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Passed)
+	checkStep(t, tests, TestsStep, report.Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Passed, "cleanup")
+		checkTest(t, result, tc, report.Passed, "cleanup")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, Failed)
+	checkStep(t, cleanup, CleanupStep, report.Failed)
 }
 
 func TestCleanCleanupCanceled(t *testing.T) {
@@ -475,23 +476,23 @@ func TestCleanCleanupCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 
-	checkReport(t, test.report, Canceled, Summary{Passed: len(testConfig.Tests)})
+	checkReport(t, test.report, report.Canceled, Summary{Passed: len(testConfig.Tests)})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, Passed)
+	checkStep(t, validate, ValidateStep, report.Passed)
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, Passed)
+	checkStep(t, tests, TestsStep, report.Passed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		checkTest(t, result, tc, Passed, "cleanup")
+		checkTest(t, result, tc, report.Passed, "cleanup")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, Canceled)
+	checkStep(t, cleanup, CleanupStep, report.Canceled)
 }
 
-func checkReport(t *testing.T, report *Report, status Status, summary Summary) {
+func checkReport(t *testing.T, report *Report, status report.Status, summary Summary) {
 	if report.Status != status {
 		t.Errorf("expected status %q, got %q", status, report.Status)
 	}
@@ -504,7 +505,7 @@ func checkReport(t *testing.T, report *Report, status Status, summary Summary) {
 	}
 }
 
-func checkStep(t *testing.T, step *Step, name string, status Status) {
+func checkStep(t *testing.T, step *Step, name string, status report.Status) {
 	if name != step.Name {
 		t.Fatalf("expected step %q, got %q", name, step.Name)
 	}
@@ -514,7 +515,7 @@ func checkStep(t *testing.T, step *Step, name string, status Status) {
 	// We cannot check duration since it may be zero on windows.
 }
 
-func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status Status, flow ...string) {
+func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status report.Status, flow ...string) {
 	name := fmt.Sprintf("%s-%s-%s", tc.Deployer, tc.Workload, tc.PVCSpec)
 	if name != test.Name {
 		t.Fatalf("expected step %q, got %q", name, test.Name)
@@ -534,7 +535,7 @@ func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status Status, flow 
 	}
 	last := len(flow) - 1
 	for i, name := range flow[:last] {
-		checkStep(t, test.Items[i], name, Passed)
+		checkStep(t, test.Items[i], name, report.Passed)
 	}
 	checkStep(t, test.Items[last], flow[last], test.Status)
 }

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -520,9 +520,6 @@ func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status report.Status
 	if name != test.Name {
 		t.Fatalf("expected step %q, got %q", name, test.Name)
 	}
-	if test.Config == nil || tc != *test.Config {
-		t.Fatalf("expected config %+v, got %+v", tc, test.Config)
-	}
 	if status != test.Status {
 		t.Fatalf("expected status %q, got %q", status, test.Status)
 	}

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -505,7 +505,7 @@ func checkReport(t *testing.T, report *Report, status report.Status, summary Sum
 	}
 }
 
-func checkStep(t *testing.T, step *Step, name string, status report.Status) {
+func checkStep(t *testing.T, step *report.Step, name string, status report.Status) {
 	if name != step.Name {
 		t.Fatalf("expected step %q, got %q", name, step.Name)
 	}
@@ -515,7 +515,13 @@ func checkStep(t *testing.T, step *Step, name string, status report.Status) {
 	// We cannot check duration since it may be zero on windows.
 }
 
-func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status report.Status, flow ...string) {
+func checkTest(
+	t *testing.T,
+	test *report.Step,
+	tc e2econfig.Test,
+	status report.Status,
+	flow ...string,
+) {
 	name := fmt.Sprintf("%s-%s-%s", tc.Deployer, tc.Workload, tc.PVCSpec)
 	if name != test.Name {
 		t.Fatalf("expected step %q, got %q", name, test.Name)
@@ -537,7 +543,7 @@ func checkTest(t *testing.T, test *Step, tc e2econfig.Test, status report.Status
 	checkStep(t, test.Items[last], flow[last], test.Status)
 }
 
-func totalDuration(steps []*Step) float64 {
+func totalDuration(steps []*report.Step) float64 {
 	var total float64
 	for _, step := range steps {
 		total += step.Duration

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -41,10 +41,9 @@ type Summary struct {
 // Report created by test sub commands.
 type Report struct {
 	*report.Report
-	Config   *e2econfig.Config `json:"config"`
-	Steps    []*Step           `json:"steps"`
-	Summary  Summary           `json:"summary"`
-	Duration float64           `json:"duration,omitempty"`
+	Config  *e2econfig.Config `json:"config"`
+	Steps   []*Step           `json:"steps"`
+	Summary Summary           `json:"summary"`
 }
 
 func newReport(commandName string, config *e2econfig.Config) *Report {
@@ -105,9 +104,6 @@ func (r *Report) Equal(o *Report) bool {
 		return false
 	}
 	if r.Summary != o.Summary {
-		return false
-	}
-	if r.Duration != o.Duration {
 		return false
 	}
 	return slices.EqualFunc(r.Steps, o.Steps, func(a *Step, b *Step) bool {

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -15,13 +15,6 @@ import (
 type Status string
 
 const (
-	Passed   = Status("passed")
-	Failed   = Status("failed")
-	Skipped  = Status("skipped")
-	Canceled = Status("canceled")
-)
-
-const (
 	ValidateStep = "validate"
 	SetupStep    = "setup"
 	TestsStep    = "tests"
@@ -31,7 +24,7 @@ const (
 // A step is a test command step.
 type Step struct {
 	Name     string          `json:"name"`
-	Status   Status          `json:"status,omitempty"`
+	Status   report.Status   `json:"status,omitempty"`
 	Duration float64         `json:"duration,omitempty"`
 	Config   *e2econfig.Test `json:"config,omitempty"`
 	Items    []*Step         `json:"items,omitempty"`
@@ -52,7 +45,6 @@ type Report struct {
 	Config   *e2econfig.Config `json:"config"`
 	Steps    []*Step           `json:"steps"`
 	Summary  Summary           `json:"summary"`
-	Status   Status            `json:"status,omitempty"`
 	Duration float64           `json:"duration,omitempty"`
 }
 
@@ -76,15 +68,15 @@ func (r *Report) AddStep(step *Step) {
 	r.Duration += step.Duration
 
 	switch step.Status {
-	case Passed, Skipped:
+	case report.Passed, report.Skipped:
 		if r.Status == "" {
-			r.Status = Passed
+			r.Status = report.Passed
 		}
-	case Failed:
-		if r.Status != Canceled {
+	case report.Failed:
+		if r.Status != report.Canceled {
 			r.Status = step.Status
 		}
-	case Canceled:
+	case report.Canceled:
 		r.Status = step.Status
 	}
 
@@ -115,9 +107,6 @@ func (r *Report) Equal(o *Report) bool {
 			return false
 		}
 	} else if r.Config != o.Config {
-		return false
-	}
-	if r.Status != o.Status {
 		return false
 	}
 	if r.Summary != o.Summary {
@@ -153,15 +142,15 @@ func (s *Step) AddTest(t *Test) {
 	s.Items = append(s.Items, result)
 
 	switch t.Status {
-	case Passed, Skipped:
+	case report.Passed, report.Skipped:
 		if s.Status == "" {
-			s.Status = Passed
+			s.Status = report.Passed
 		}
-	case Failed:
-		if s.Status != Canceled {
+	case report.Failed:
+		if s.Status != report.Canceled {
 			s.Status = t.Status
 		}
-	case Canceled:
+	case report.Canceled:
 		s.Status = t.Status
 	}
 }
@@ -201,13 +190,13 @@ func (s *Step) Equal(o *Step) bool {
 
 func (s *Summary) AddTest(t *Step) {
 	switch t.Status {
-	case Passed:
+	case report.Passed:
 		s.Passed++
-	case Failed:
+	case report.Failed:
 		s.Failed++
-	case Skipped:
+	case report.Skipped:
 		s.Skipped++
-	case Canceled:
+	case report.Canceled:
 		s.Canceled++
 	}
 }

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -23,11 +23,10 @@ const (
 
 // A step is a test command step.
 type Step struct {
-	Name     string          `json:"name"`
-	Status   report.Status   `json:"status,omitempty"`
-	Duration float64         `json:"duration,omitempty"`
-	Config   *e2econfig.Test `json:"config,omitempty"`
-	Items    []*Step         `json:"items,omitempty"`
+	Name     string        `json:"name"`
+	Status   report.Status `json:"status,omitempty"`
+	Duration float64       `json:"duration,omitempty"`
+	Items    []*Step       `json:"items,omitempty"`
 }
 
 // Summary summaries a test run or clean.
@@ -124,7 +123,6 @@ func (r *Report) findStep(name string) *Step {
 func (s *Step) AddTest(t *Test) {
 	result := &Step{
 		Name:     t.Name(),
-		Config:   t.Config,
 		Status:   t.Status,
 		Items:    t.Steps,
 		Duration: t.Duration,
@@ -162,14 +160,6 @@ func (s *Step) Equal(o *Step) bool {
 	}
 	if s.Duration != o.Duration {
 		return false
-	}
-	if s.Config != o.Config {
-		if s.Config == nil || o.Config == nil {
-			return false
-		}
-		if *s.Config != *o.Config {
-			return false
-		}
 	}
 	return slices.EqualFunc(s.Items, o.Items, func(a *Step, b *Step) bool {
 		if a == nil {

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -41,7 +41,6 @@ type Summary struct {
 // Report created by test sub commands.
 type Report struct {
 	*report.Report
-	Name     string            `json:"name"`
 	Config   *e2econfig.Config `json:"config"`
 	Steps    []*Step           `json:"steps"`
 	Summary  Summary           `json:"summary"`
@@ -53,8 +52,7 @@ func newReport(commandName string, config *e2econfig.Config) *Report {
 		panic("config must not be nil")
 	}
 	return &Report{
-		Report: report.New(),
-		Name:   commandName,
+		Report: report.New(commandName),
 		Config: config,
 	}
 }
@@ -97,9 +95,6 @@ func (r *Report) Equal(o *Report) bool {
 		return false
 	}
 	if !r.Report.Equal(o.Report) {
-		return false
-	}
-	if r.Name != o.Name {
 		return false
 	}
 	if r.Config != nil && o.Config != nil {

--- a/pkg/test/report.go
+++ b/pkg/test/report.go
@@ -110,13 +110,12 @@ func (r *Report) Equal(o *Report) bool {
 	if r.Name != o.Name {
 		return false
 	}
-	if r.Config != o.Config {
-		if r.Config == nil || o.Config == nil {
-			return false
-		}
+	if r.Config != nil && o.Config != nil {
 		if !r.Config.Equal(o.Config) {
 			return false
 		}
+	} else if r.Config != o.Config {
+		return false
 	}
 	if r.Status != o.Status {
 		return false

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -77,10 +77,9 @@ func TestReportEqual(t *testing.T) {
 
 	r1 := createReport()
 
-	// Intentionally comparing report to itself
-	//nolint:gocritic
 	t.Run("equal to self", func(t *testing.T) {
-		if !r1.Equal(r1) {
+		r2 := r1
+		if !r1.Equal(r2) {
 			t.Error("report should be equal itself")
 		}
 	})

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -388,7 +388,6 @@ func TestStepAddPassedTest(t *testing.T) {
 	passedTest := &Test{
 		Context:  &Context{name: "passing_test"},
 		Status:   report.Passed,
-		Config:   &reportConfig.Tests[0],
 		Duration: 6.0,
 		Steps: []*Step{
 			{Name: "deploy", Status: report.Passed, Duration: 1.0},
@@ -412,7 +411,6 @@ func TestStepAddPassedTest(t *testing.T) {
 					Name:     passedTest.Name(),
 					Status:   passedTest.Status,
 					Duration: passedTest.Duration,
-					Config:   passedTest.Config,
 					Items:    passedTest.Steps,
 				},
 			},
@@ -434,7 +432,6 @@ func TestStepAddPassedTest(t *testing.T) {
 					Name:     passedTest.Name(),
 					Status:   passedTest.Status,
 					Duration: passedTest.Duration,
-					Config:   passedTest.Config,
 					Items:    passedTest.Steps,
 				},
 			},
@@ -456,7 +453,6 @@ func TestStepAddPassedTest(t *testing.T) {
 					Name:     passedTest.Name(),
 					Status:   passedTest.Status,
 					Duration: passedTest.Duration,
-					Config:   passedTest.Config,
 					Items:    passedTest.Steps,
 				},
 			},
@@ -471,7 +467,6 @@ func TestStepAddFailedTest(t *testing.T) {
 	failedTest := &Test{
 		Context:  &Context{name: "failing_test"},
 		Status:   report.Failed,
-		Config:   &reportConfig.Tests[0],
 		Duration: 1.0,
 		Steps: []*Step{
 			{Name: "undeploy", Status: report.Failed, Duration: 1.0},
@@ -490,7 +485,6 @@ func TestStepAddFailedTest(t *testing.T) {
 					Name:     failedTest.Name(),
 					Status:   failedTest.Status,
 					Duration: failedTest.Duration,
-					Config:   failedTest.Config,
 					Items:    failedTest.Steps,
 				},
 			},
@@ -513,7 +507,6 @@ func TestStepAddFailedTest(t *testing.T) {
 					Name:     failedTest.Name(),
 					Status:   failedTest.Status,
 					Duration: failedTest.Duration,
-					Config:   failedTest.Config,
 					Items:    failedTest.Steps,
 				},
 			},
@@ -535,7 +528,6 @@ func TestStepAddFailedTest(t *testing.T) {
 					Name:     failedTest.Name(),
 					Status:   failedTest.Status,
 					Duration: failedTest.Duration,
-					Config:   failedTest.Config,
 					Items:    failedTest.Steps,
 				},
 			},
@@ -651,7 +643,6 @@ func TestStepMarshal(t *testing.T) {
 		Name:     "test",
 		Status:   report.Passed,
 		Duration: 2.0,
-		Config:   &reportConfig.Tests[0],
 		Items: []*Step{
 			{Name: "subtest1", Status: report.Passed, Duration: 1.0},
 			{Name: "subtest2", Status: report.Failed, Duration: 1.0},
@@ -673,12 +664,7 @@ func TestStepMarshal(t *testing.T) {
 }
 
 func TestStepEqual(t *testing.T) {
-	s1 := Step{
-		Name:     "base_test",
-		Status:   report.Passed,
-		Duration: 1.0,
-		Config:   &reportConfig.Tests[0],
-	}
+	s1 := Step{Name: "base_test", Status: report.Passed, Duration: 1.0}
 
 	t.Run("equal to self", func(t *testing.T) {
 		if !s1.Equal(&s1) {
@@ -713,30 +699,6 @@ func TestStepEqual(t *testing.T) {
 		s2.Duration = 2.0
 		if s1.Equal(&s2) {
 			t.Fatalf("steps with different duration should not be equal")
-		}
-	})
-
-	t.Run("different config", func(t *testing.T) {
-		s2 := s1
-		s2.Config = &reportConfig.Tests[1]
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different config should not be equal")
-		}
-	})
-
-	t.Run("one nil config", func(t *testing.T) {
-		s2 := s1
-		s2.Config = nil
-		if s1.Equal(&s2) {
-			t.Fatalf("step with config should not be equal to step without config")
-		}
-	})
-
-	t.Run("both nil config", func(t *testing.T) {
-		s1 := Step{Name: "test", Status: report.Passed, Duration: 1.0, Config: nil}
-		s2 := s1
-		if !s1.Equal(&s2) {
-			t.Fatalf("steps with nil config should be equal")
 		}
 	})
 

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -51,7 +51,7 @@ func TestReportEmpty(t *testing.T) {
 	r := newReport("test-run", reportConfig)
 
 	// Host and ramenctl info is ready.
-	expectedReport := report.New()
+	expectedReport := report.New("test-run")
 	if !r.Report.Equal(expectedReport) {
 		t.Errorf("expected report %+v, got %+v", expectedReport, r.Report)
 	}
@@ -299,14 +299,6 @@ func TestReportEqual(t *testing.T) {
 		r2 := createReport()
 		if !r1.Equal(r2) {
 			t.Error("reports with identical content should be equal")
-		}
-	})
-
-	t.Run("different name", func(t *testing.T) {
-		r2 := createReport()
-		r2.Name = "different-command"
-		if r1.Equal(r2) {
-			t.Error("reports with different names should not be equal")
 		}
 	})
 

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -335,14 +335,6 @@ func TestReportEqual(t *testing.T) {
 		}
 	})
 
-	t.Run("different duration", func(t *testing.T) {
-		r2 := createReport()
-		r2.Duration += 1.0
-		if r1.Equal(r2) {
-			t.Error("reports with different duration should not be equal")
-		}
-	})
-
 	t.Run("different step length", func(t *testing.T) {
 		r2 := createReport()
 		r2.Steps = []*Step{

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -4,7 +4,6 @@
 package test
 
 import (
-	"slices"
 	"testing"
 
 	"sigs.k8s.io/yaml"
@@ -46,210 +45,13 @@ var reportConfig = &e2econfig.Config{
 	},
 }
 
-func TestReportEmpty(t *testing.T) {
-	fakeTime(t)
-	r := newReport("test-run", reportConfig)
-
-	// Host and ramenctl info is ready.
-	expectedReport := report.New("test-run")
-	if !r.Report.Equal(expectedReport) {
-		t.Errorf("expected report %+v, got %+v", expectedReport, r.Report)
-	}
-
-	// Otherwise nothing was added so the status and steps should be empty, and summary should be
-	// all zero.
-	if r.Status != "" {
-		t.Errorf("non-empty status: %q", r.Status)
-	}
-	if len(r.Steps) != 0 {
-		t.Errorf("unexpected steps %+v", r.Steps)
-	}
-	if r.Summary.Passed != 0 || r.Summary.Failed != 0 || r.Summary.Skipped != 0 {
-		t.Errorf("unexpected summary: %+v", r.Summary)
-	}
-
-	// We can marshal and unmarshal the report
-	checkRoundtrip(t, r)
-}
-
-func TestReportAddPassedStep(t *testing.T) {
-	fakeTime(t)
-	passedStep := &Step{Name: "passed_step", Status: report.Passed, Duration: 1.0}
-
-	// Adding a passed test should set the report status.
-	t.Run("empty", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.AddStep(passedStep)
-		if r.Status != report.Passed {
-			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{passedStep}) {
-			t.Errorf("expected steps to br equal, got %v", r.Steps)
-		}
-	})
-
-	// Adding a passed test should not modify failed status.
-	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Failed
-		r.AddStep(passedStep)
-		if r.Status != report.Failed {
-			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{passedStep}) {
-			t.Errorf("expected steps to br equal, got %v", r.Steps)
-		}
-	})
-
-	// Adding a passed test should not modify canceled status.
-	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Canceled
-		r.AddStep(passedStep)
-		if r.Status != report.Canceled {
-			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{passedStep}) {
-			t.Errorf("expected steps to br equal, got %v", r.Steps)
-		}
-	})
-}
-
-func TestReportAddFailedStep(t *testing.T) {
-	fakeTime(t)
-	failedStep := &Step{Name: "failed_step", Status: report.Failed, Duration: 1.0}
-
-	// Failed status should override existing Passed status.
-	t.Run("passed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Passed
-		r.AddStep(failedStep)
-		if r.Status != report.Failed {
-			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{failedStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-
-	// If a report is canceled, adding a failed test should not change the status.
-	t.Run("canceled", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Canceled
-		r.AddStep(failedStep)
-		if r.Status != report.Canceled {
-			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{failedStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-}
-
-func TestReportAddCanceledStep(t *testing.T) {
-	fakeTime(t)
-	canceledStep := &Step{Name: "canceled_step", Status: report.Canceled, Duration: 1.0}
-
-	// Adding canceled step mark the report as canceled.
-	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Failed
-		r.AddStep(canceledStep)
-		if r.Status != report.Canceled {
-			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{canceledStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-
-	// Adding canceled step mark the report as canceled.
-	t.Run("passed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Passed
-		r.AddStep(canceledStep)
-		if r.Status != report.Canceled {
-			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{canceledStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-}
-
-func TestReportAddSkippedStep(t *testing.T) {
-	fakeTime(t)
-	skippedStep := &Step{Name: "skipped-step", Status: report.Skipped, Duration: 0.0}
-
-	// Skipped step with empty status should result in Passed.
-	t.Run("empty", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.AddStep(skippedStep)
-		if r.Status != report.Passed {
-			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-
-	// Failed status should not be overridden by Skipped.
-	t.Run("failed", func(t *testing.T) {
-		r := newReport("test-command", reportConfig)
-		r.Status = report.Failed
-		r.AddStep(skippedStep)
-		if r.Status != report.Failed {
-			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
-		}
-		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
-			t.Errorf("expected steps to be equal, got %v", r.Steps)
-		}
-	})
-}
-
-func TestReportDuration(t *testing.T) {
-	r := newReport("test-command", reportConfig)
-	steps := []*Step{
-		{Name: "step1", Status: report.Passed, Duration: 1.0},
-		{Name: "step2", Status: report.Passed, Duration: 1.0},
-		{Name: "step3", Status: report.Skipped, Duration: 1.0},
-		{Name: "step4", Status: report.Failed, Duration: 1.0},
-		{Name: "step5", Status: report.Canceled, Duration: 1.0},
-	}
-	for _, step := range steps {
-		r.AddStep(step)
-	}
-	var expectedDuration float64
-	for _, s := range r.Steps {
-		expectedDuration += s.Duration
-	}
-	if r.Duration != expectedDuration {
-		t.Errorf("expected duration %f, got %f", expectedDuration, r.Duration)
-	}
-}
-
-func TestReportAddDuplicateStep(t *testing.T) {
-	r := newReport("test-command", reportConfig)
-	step := &Step{Name: "unique-step", Status: report.Passed, Duration: 1.0}
-	r.AddStep(step)
-
-	// Adding another step with the same name should panic.
-	dup := &Step{Name: "unique-step", Status: report.Failed, Duration: 1.0}
-	defer func() {
-		if r := recover(); r == nil {
-			t.Errorf("expected panic when adding duplicate step, but it didn't happen")
-		}
-	}()
-	r.AddStep(dup)
-}
-
 func TestReportSummary(t *testing.T) {
 	r := newReport("test-command", reportConfig)
-	testsStep := &Step{
+	testsStep := &report.Step{
 		Name:     TestsStep,
 		Status:   report.Passed,
 		Duration: 1.0,
-		Items: []*Step{
+		Items: []*report.Step{
 			{Name: "test1", Status: report.Passed, Duration: 1.0},
 			{Name: "test2", Status: report.Failed, Duration: 1.0},
 			{Name: "test3", Status: report.Skipped, Duration: 1.0},
@@ -269,12 +71,6 @@ func TestReportEqual(t *testing.T) {
 	// Helper function to create a standard report
 	createReport := func() *Report {
 		r := newReport("test-command", reportConfig)
-		r.Status = report.Passed
-		r.Duration = 1.0
-		r.Steps = []*Step{
-			{Name: "step1", Status: report.Passed, Duration: 1.0},
-			{Name: "step2", Status: report.Passed, Duration: 1.0},
-		}
 		r.Summary = Summary{Passed: 2}
 		return r
 	}
@@ -299,13 +95,6 @@ func TestReportEqual(t *testing.T) {
 		r2 := createReport()
 		if !r1.Equal(r2) {
 			t.Error("reports with identical content should be equal")
-		}
-	})
-
-	t.Run("same config reference", func(t *testing.T) {
-		r2 := createReport()
-		if !r1.Equal(r2) {
-			t.Error("reports with equal configs should be equal")
 		}
 	})
 
@@ -334,27 +123,6 @@ func TestReportEqual(t *testing.T) {
 			t.Error("reports with different summary should not be equal")
 		}
 	})
-
-	t.Run("different step length", func(t *testing.T) {
-		r2 := createReport()
-		r2.Steps = []*Step{
-			{Name: "step1", Status: report.Passed, Duration: 1.0},
-		}
-		if r1.Equal(r2) {
-			t.Error("reports with different step counts should not be equal")
-		}
-	})
-
-	t.Run("different steps content", func(t *testing.T) {
-		r2 := createReport()
-		r2.Steps = []*Step{
-			{Name: "step1", Status: report.Passed, Duration: 1.0},
-			{Name: "different", Status: report.Passed, Duration: 2.0},
-		}
-		if r1.Equal(r2) {
-			t.Error("reports with different step content should not be equal")
-		}
-	})
 }
 
 func TestReportMarshaling(t *testing.T) {
@@ -362,12 +130,12 @@ func TestReportMarshaling(t *testing.T) {
 	r := newReport("test-command", reportConfig)
 	r.Status = report.Failed
 	r.Duration = 2.0
-	r.Steps = []*Step{
+	r.Steps = []*report.Step{
 		{
 			Name:     "step1",
 			Status:   report.Passed,
 			Duration: 1.0,
-			Items: []*Step{
+			Items: []*report.Step{
 				{Name: "subitem1", Status: report.Passed, Duration: 1.0},
 				{Name: "subitem2", Status: report.Passed, Duration: 1.0},
 			},
@@ -382,378 +150,6 @@ func TestReportMarshaling(t *testing.T) {
 
 	// Test roundtrip marshaling/unmarshaling
 	checkRoundtrip(t, r)
-}
-
-func TestStepAddPassedTest(t *testing.T) {
-	passedTest := &Test{
-		Context:  &Context{name: "passing_test"},
-		Status:   report.Passed,
-		Duration: 6.0,
-		Steps: []*Step{
-			{Name: "deploy", Status: report.Passed, Duration: 1.0},
-			{Name: "protect", Status: report.Passed, Duration: 1.0},
-			{Name: "failover", Status: report.Passed, Duration: 1.0},
-			{Name: "relocate", Status: report.Passed, Duration: 1.0},
-			{Name: "unprotect", Status: report.Passed, Duration: 1.0},
-			{Name: "undeploy", Status: report.Passed, Duration: 1.0},
-		},
-	}
-
-	// Adding passed step should set step status.
-	t.Run("empty", func(t *testing.T) {
-		s1 := &Step{Name: "root"}
-		s1.AddTest(passedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Passed,
-			Items: []*Step{
-				{
-					Name:     passedTest.Name(),
-					Status:   passedTest.Status,
-					Duration: passedTest.Duration,
-					Items:    passedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// If a report is failed adding new step should not change the status.
-	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Failed}
-		s1.AddTest(passedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Failed,
-			Items: []*Step{
-				{
-					Name:     passedTest.Name(),
-					Status:   passedTest.Status,
-					Duration: passedTest.Duration,
-					Items:    passedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// If a report is failed adding new step should not change the status.
-	t.Run("canceled", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Canceled}
-		s1.AddTest(passedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Canceled,
-			Items: []*Step{
-				{
-					Name:     passedTest.Name(),
-					Status:   passedTest.Status,
-					Duration: passedTest.Duration,
-					Items:    passedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-}
-
-func TestStepAddFailedTest(t *testing.T) {
-	failedTest := &Test{
-		Context:  &Context{name: "failing_test"},
-		Status:   report.Failed,
-		Duration: 1.0,
-		Steps: []*Step{
-			{Name: "undeploy", Status: report.Failed, Duration: 1.0},
-		},
-	}
-
-	// Adding failed test should set report status.
-	t.Run("empty", func(t *testing.T) {
-		s1 := &Step{Name: "root"}
-		s1.AddTest(failedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Failed,
-			Items: []*Step{
-				{
-					Name:     failedTest.Name(),
-					Status:   failedTest.Status,
-					Duration: failedTest.Duration,
-					Items:    failedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// Adding failed tests shuuld change report status.
-	t.Run("passed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Passed}
-		s1.AddTest(failedTest)
-		s2 := &Step{
-			Name: s1.Name,
-			// Passed status should be changed to Failed
-			Status: report.Failed,
-			Items: []*Step{
-				{
-					Name:     failedTest.Name(),
-					Status:   failedTest.Status,
-					Duration: failedTest.Duration,
-					Items:    failedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// Adding failed step should not change canceled report.
-	t.Run("canceled", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Canceled}
-		s1.AddTest(failedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Canceled,
-			Items: []*Step{
-				{
-					Name:     failedTest.Name(),
-					Status:   failedTest.Status,
-					Duration: failedTest.Duration,
-					Items:    failedTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-}
-
-func TestStepAddCanceledTest(t *testing.T) {
-	canceledTest := &Test{
-		Context:  &Context{name: "canceled_test"},
-		Status:   report.Canceled,
-		Duration: 1.0,
-		Steps: []*Step{
-			{Name: "deploy", Status: report.Canceled, Duration: 1.0},
-		},
-	}
-
-	// Adding canceled test should override failed status.
-	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Failed}
-		s1.AddTest(canceledTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Canceled,
-			Items: []*Step{
-				{
-					Name:     canceledTest.Name(),
-					Status:   canceledTest.Status,
-					Duration: canceledTest.Duration,
-					Items:    canceledTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// Adding canceled test should override passed status.
-	t.Run("passed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Passed}
-		s1.AddTest(canceledTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Canceled,
-			Items: []*Step{
-				{
-					Name:     canceledTest.Name(),
-					Status:   canceledTest.Status,
-					Duration: canceledTest.Duration,
-					Items:    canceledTest.Steps,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-}
-
-func TestStepAddSkippedTest(t *testing.T) {
-	skippedTest := &Test{
-		Context:  &Context{name: "skipped_test"},
-		Status:   report.Skipped,
-		Duration: 0.0,
-	}
-
-	// Adding skipped test should set status to passed.
-	t.Run("empty", func(t *testing.T) {
-		s1 := &Step{Name: "root"}
-		s1.AddTest(skippedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Passed,
-			Items: []*Step{
-				{
-					Name:     skippedTest.Name(),
-					Status:   skippedTest.Status,
-					Duration: skippedTest.Duration,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-
-	// Adding skipped test should not modify failed status.
-	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: report.Failed}
-		s1.AddTest(skippedTest)
-		s2 := &Step{
-			Name:   s1.Name,
-			Status: report.Failed,
-			Items: []*Step{
-				{
-					Name:     skippedTest.Name(),
-					Status:   skippedTest.Status,
-					Duration: skippedTest.Duration,
-				},
-			},
-		}
-		if !s1.Equal(s2) {
-			t.Errorf("rootStep %+v doesn't match expectedStep %+v", s1, s2)
-		}
-	})
-}
-func TestStepMarshal(t *testing.T) {
-	step := &Step{
-		Name:     "test",
-		Status:   report.Passed,
-		Duration: 2.0,
-		Items: []*Step{
-			{Name: "subtest1", Status: report.Passed, Duration: 1.0},
-			{Name: "subtest2", Status: report.Failed, Duration: 1.0},
-		},
-	}
-
-	// Marshal and unmarshal the step
-	bytes, err := yaml.Marshal(step)
-	if err != nil {
-		t.Fatalf("failed to marshal step: %v", err)
-	}
-	unmarshaledStep := &Step{}
-	if err := yaml.Unmarshal(bytes, unmarshaledStep); err != nil {
-		t.Fatalf("failed to unmarshal step: %v", err)
-	}
-	if !step.Equal(unmarshaledStep) {
-		t.Fatalf("unmarshalled step %+v, got %+v", step, unmarshaledStep)
-	}
-}
-
-func TestStepEqual(t *testing.T) {
-	s1 := Step{Name: "base_test", Status: report.Passed, Duration: 1.0}
-
-	t.Run("equal to self", func(t *testing.T) {
-		if !s1.Equal(&s1) {
-			t.Fatalf("step should be equal to itself")
-		}
-	})
-
-	t.Run("not equal to nil", func(t *testing.T) {
-		if s1.Equal(nil) {
-			t.Fatalf("step should not be equal to nil")
-		}
-	})
-
-	t.Run("different name", func(t *testing.T) {
-		s2 := s1
-		s2.Name = "new_test"
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different names should not be equal")
-		}
-	})
-
-	t.Run("different status", func(t *testing.T) {
-		s2 := s1
-		s2.Status = report.Failed
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different status should not be equal")
-		}
-	})
-
-	t.Run("different duration", func(t *testing.T) {
-		s2 := s1
-		s2.Duration = 2.0
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different duration should not be equal")
-		}
-	})
-
-	t.Run("equal subitems", func(t *testing.T) {
-		s1 := Step{
-			Name:     "parent",
-			Status:   report.Passed,
-			Duration: 1.0,
-			Items: []*Step{
-				{Name: "child1", Status: report.Passed},
-				{Name: "child2", Status: report.Failed},
-			},
-		}
-		s2 := s1
-		if !s1.Equal(&s2) {
-			t.Fatalf("steps with equal subitems should be equal")
-		}
-	})
-
-	t.Run("different subitem name", func(t *testing.T) {
-		s1 := Step{
-			Name:     "parent",
-			Status:   report.Passed,
-			Duration: 1.0,
-			Items: []*Step{
-				{Name: "child1", Status: report.Passed},
-				{Name: "child2", Status: report.Failed},
-			},
-		}
-		s2 := s1
-		s2.Items = []*Step{
-			{Name: "child1", Status: report.Passed},
-			{Name: "different", Status: report.Failed},
-		}
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different subitem names should not be equal")
-		}
-	})
-
-	t.Run("different number of subitems", func(t *testing.T) {
-		s1 := Step{
-			Name:     "parent",
-			Status:   report.Passed,
-			Duration: 1.0,
-			Items: []*Step{
-				{Name: "child1", Status: report.Passed},
-				{Name: "child2", Status: report.Failed},
-			},
-		}
-		s2 := s1
-		s2.Items = []*Step{{Name: "child1", Status: report.Passed}}
-		if s1.Equal(&s2) {
-			t.Fatalf("steps with different number of subitems should not be equal")
-		}
-	})
 }
 
 func TestSummaryString(t *testing.T) {
@@ -787,12 +183,12 @@ func TestSummaryCount(t *testing.T) {
 	summary := Summary{}
 
 	// Add multiple tests of different status
-	summary.AddTest(&Step{Status: report.Passed})
-	summary.AddTest(&Step{Status: report.Passed})
-	summary.AddTest(&Step{Status: report.Failed})
-	summary.AddTest(&Step{Status: report.Skipped})
-	summary.AddTest(&Step{Status: report.Canceled})
-	summary.AddTest(&Step{Status: report.Passed})
+	summary.AddTest(&report.Step{Status: report.Passed})
+	summary.AddTest(&report.Step{Status: report.Passed})
+	summary.AddTest(&report.Step{Status: report.Failed})
+	summary.AddTest(&report.Step{Status: report.Skipped})
+	summary.AddTest(&report.Step{Status: report.Canceled})
+	summary.AddTest(&report.Step{Status: report.Passed})
 
 	expectedSummary := Summary{Passed: 3, Failed: 1, Skipped: 1, Canceled: 1}
 	if summary != expectedSummary {

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -74,14 +74,14 @@ func TestReportEmpty(t *testing.T) {
 
 func TestReportAddPassedStep(t *testing.T) {
 	fakeTime(t)
-	passedStep := &Step{Name: "passed_step", Status: Passed, Duration: 1.0}
+	passedStep := &Step{Name: "passed_step", Status: report.Passed, Duration: 1.0}
 
 	// Adding a passed test should set the report status.
 	t.Run("empty", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
 		r.AddStep(passedStep)
-		if r.Status != Passed {
-			t.Errorf("expected status %s, got %s", Passed, r.Status)
+		if r.Status != report.Passed {
+			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{passedStep}) {
 			t.Errorf("expected steps to br equal, got %v", r.Steps)
@@ -91,10 +91,10 @@ func TestReportAddPassedStep(t *testing.T) {
 	// Adding a passed test should not modify failed status.
 	t.Run("failed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Failed
+		r.Status = report.Failed
 		r.AddStep(passedStep)
-		if r.Status != Failed {
-			t.Errorf("expected status %s, got %s", Failed, r.Status)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{passedStep}) {
 			t.Errorf("expected steps to br equal, got %v", r.Steps)
@@ -104,10 +104,10 @@ func TestReportAddPassedStep(t *testing.T) {
 	// Adding a passed test should not modify canceled status.
 	t.Run("failed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Canceled
+		r.Status = report.Canceled
 		r.AddStep(passedStep)
-		if r.Status != Canceled {
-			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{passedStep}) {
 			t.Errorf("expected steps to br equal, got %v", r.Steps)
@@ -117,15 +117,15 @@ func TestReportAddPassedStep(t *testing.T) {
 
 func TestReportAddFailedStep(t *testing.T) {
 	fakeTime(t)
-	failedStep := &Step{Name: "failed_step", Status: Failed, Duration: 1.0}
+	failedStep := &Step{Name: "failed_step", Status: report.Failed, Duration: 1.0}
 
 	// Failed status should override existing Passed status.
 	t.Run("passed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Passed
+		r.Status = report.Passed
 		r.AddStep(failedStep)
-		if r.Status != Failed {
-			t.Errorf("expected status %s, got %s", Failed, r.Status)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{failedStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -135,10 +135,10 @@ func TestReportAddFailedStep(t *testing.T) {
 	// If a report is canceled, adding a failed test should not change the status.
 	t.Run("canceled", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Canceled
+		r.Status = report.Canceled
 		r.AddStep(failedStep)
-		if r.Status != Canceled {
-			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{failedStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -148,15 +148,15 @@ func TestReportAddFailedStep(t *testing.T) {
 
 func TestReportAddCanceledStep(t *testing.T) {
 	fakeTime(t)
-	canceledStep := &Step{Name: "canceled_step", Status: Canceled, Duration: 1.0}
+	canceledStep := &Step{Name: "canceled_step", Status: report.Canceled, Duration: 1.0}
 
 	// Adding canceled step mark the report as canceled.
 	t.Run("failed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Failed
+		r.Status = report.Failed
 		r.AddStep(canceledStep)
-		if r.Status != Canceled {
-			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{canceledStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -166,10 +166,10 @@ func TestReportAddCanceledStep(t *testing.T) {
 	// Adding canceled step mark the report as canceled.
 	t.Run("passed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Passed
+		r.Status = report.Passed
 		r.AddStep(canceledStep)
-		if r.Status != Canceled {
-			t.Errorf("expected status %s, got %s", Canceled, r.Status)
+		if r.Status != report.Canceled {
+			t.Errorf("expected status %s, got %s", report.Canceled, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{canceledStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -179,14 +179,14 @@ func TestReportAddCanceledStep(t *testing.T) {
 
 func TestReportAddSkippedStep(t *testing.T) {
 	fakeTime(t)
-	skippedStep := &Step{Name: "skipped-step", Status: Skipped, Duration: 0.0}
+	skippedStep := &Step{Name: "skipped-step", Status: report.Skipped, Duration: 0.0}
 
 	// Skipped step with empty status should result in Passed.
 	t.Run("empty", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
 		r.AddStep(skippedStep)
-		if r.Status != Passed {
-			t.Errorf("expected status %s, got %s", Passed, r.Status)
+		if r.Status != report.Passed {
+			t.Errorf("expected status %s, got %s", report.Passed, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -196,10 +196,10 @@ func TestReportAddSkippedStep(t *testing.T) {
 	// Failed status should not be overridden by Skipped.
 	t.Run("failed", func(t *testing.T) {
 		r := newReport("test-command", reportConfig)
-		r.Status = Failed
+		r.Status = report.Failed
 		r.AddStep(skippedStep)
-		if r.Status != Failed {
-			t.Errorf("expected status %s, got %s", Failed, r.Status)
+		if r.Status != report.Failed {
+			t.Errorf("expected status %s, got %s", report.Failed, r.Status)
 		}
 		if !slices.Equal(r.Steps, []*Step{skippedStep}) {
 			t.Errorf("expected steps to be equal, got %v", r.Steps)
@@ -210,11 +210,11 @@ func TestReportAddSkippedStep(t *testing.T) {
 func TestReportDuration(t *testing.T) {
 	r := newReport("test-command", reportConfig)
 	steps := []*Step{
-		{Name: "step1", Status: Passed, Duration: 1.0},
-		{Name: "step2", Status: Passed, Duration: 1.0},
-		{Name: "step3", Status: Skipped, Duration: 1.0},
-		{Name: "step4", Status: Failed, Duration: 1.0},
-		{Name: "step5", Status: Canceled, Duration: 1.0},
+		{Name: "step1", Status: report.Passed, Duration: 1.0},
+		{Name: "step2", Status: report.Passed, Duration: 1.0},
+		{Name: "step3", Status: report.Skipped, Duration: 1.0},
+		{Name: "step4", Status: report.Failed, Duration: 1.0},
+		{Name: "step5", Status: report.Canceled, Duration: 1.0},
 	}
 	for _, step := range steps {
 		r.AddStep(step)
@@ -230,11 +230,11 @@ func TestReportDuration(t *testing.T) {
 
 func TestReportAddDuplicateStep(t *testing.T) {
 	r := newReport("test-command", reportConfig)
-	step := &Step{Name: "unique-step", Status: Passed, Duration: 1.0}
+	step := &Step{Name: "unique-step", Status: report.Passed, Duration: 1.0}
 	r.AddStep(step)
 
 	// Adding another step with the same name should panic.
-	dup := &Step{Name: "unique-step", Status: Failed, Duration: 1.0}
+	dup := &Step{Name: "unique-step", Status: report.Failed, Duration: 1.0}
 	defer func() {
 		if r := recover(); r == nil {
 			t.Errorf("expected panic when adding duplicate step, but it didn't happen")
@@ -247,13 +247,13 @@ func TestReportSummary(t *testing.T) {
 	r := newReport("test-command", reportConfig)
 	testsStep := &Step{
 		Name:     TestsStep,
-		Status:   Passed,
+		Status:   report.Passed,
 		Duration: 1.0,
 		Items: []*Step{
-			{Name: "test1", Status: Passed, Duration: 1.0},
-			{Name: "test2", Status: Failed, Duration: 1.0},
-			{Name: "test3", Status: Skipped, Duration: 1.0},
-			{Name: "test4", Status: Canceled, Duration: 1.0},
+			{Name: "test1", Status: report.Passed, Duration: 1.0},
+			{Name: "test2", Status: report.Failed, Duration: 1.0},
+			{Name: "test3", Status: report.Skipped, Duration: 1.0},
+			{Name: "test4", Status: report.Canceled, Duration: 1.0},
 		},
 	}
 	r.AddStep(testsStep)
@@ -269,11 +269,11 @@ func TestReportEqual(t *testing.T) {
 	// Helper function to create a standard report
 	createReport := func() *Report {
 		r := newReport("test-command", reportConfig)
-		r.Status = Passed
+		r.Status = report.Passed
 		r.Duration = 1.0
 		r.Steps = []*Step{
-			{Name: "step1", Status: Passed, Duration: 1.0},
-			{Name: "step2", Status: Passed, Duration: 1.0},
+			{Name: "step1", Status: report.Passed, Duration: 1.0},
+			{Name: "step2", Status: report.Passed, Duration: 1.0},
 		}
 		r.Summary = Summary{Passed: 2}
 		return r
@@ -335,14 +335,6 @@ func TestReportEqual(t *testing.T) {
 		}
 	})
 
-	t.Run("different status", func(t *testing.T) {
-		r2 := createReport()
-		r2.Status = Failed
-		if r1.Equal(r2) {
-			t.Error("reports with different status should not be equal")
-		}
-	})
-
 	t.Run("different summary", func(t *testing.T) {
 		r2 := createReport()
 		r2.Summary = Summary{Passed: 1, Failed: 1}
@@ -362,7 +354,7 @@ func TestReportEqual(t *testing.T) {
 	t.Run("different step length", func(t *testing.T) {
 		r2 := createReport()
 		r2.Steps = []*Step{
-			{Name: "step1", Status: Passed, Duration: 1.0},
+			{Name: "step1", Status: report.Passed, Duration: 1.0},
 		}
 		if r1.Equal(r2) {
 			t.Error("reports with different step counts should not be equal")
@@ -372,8 +364,8 @@ func TestReportEqual(t *testing.T) {
 	t.Run("different steps content", func(t *testing.T) {
 		r2 := createReport()
 		r2.Steps = []*Step{
-			{Name: "step1", Status: Passed, Duration: 1.0},
-			{Name: "different", Status: Passed, Duration: 2.0},
+			{Name: "step1", Status: report.Passed, Duration: 1.0},
+			{Name: "different", Status: report.Passed, Duration: 2.0},
 		}
 		if r1.Equal(r2) {
 			t.Error("reports with different step content should not be equal")
@@ -384,21 +376,21 @@ func TestReportEqual(t *testing.T) {
 func TestReportMarshaling(t *testing.T) {
 	fakeTime(t)
 	r := newReport("test-command", reportConfig)
-	r.Status = Failed
+	r.Status = report.Failed
 	r.Duration = 2.0
 	r.Steps = []*Step{
 		{
 			Name:     "step1",
-			Status:   Passed,
+			Status:   report.Passed,
 			Duration: 1.0,
 			Items: []*Step{
-				{Name: "subitem1", Status: Passed, Duration: 1.0},
-				{Name: "subitem2", Status: Passed, Duration: 1.0},
+				{Name: "subitem1", Status: report.Passed, Duration: 1.0},
+				{Name: "subitem2", Status: report.Passed, Duration: 1.0},
 			},
 		},
 		{
 			Name:     "step2",
-			Status:   Failed,
+			Status:   report.Failed,
 			Duration: 1.0,
 		},
 	}
@@ -411,16 +403,16 @@ func TestReportMarshaling(t *testing.T) {
 func TestStepAddPassedTest(t *testing.T) {
 	passedTest := &Test{
 		Context:  &Context{name: "passing_test"},
-		Status:   Passed,
+		Status:   report.Passed,
 		Config:   &reportConfig.Tests[0],
 		Duration: 6.0,
 		Steps: []*Step{
-			{Name: "deploy", Status: Passed, Duration: 1.0},
-			{Name: "protect", Status: Passed, Duration: 1.0},
-			{Name: "failover", Status: Passed, Duration: 1.0},
-			{Name: "relocate", Status: Passed, Duration: 1.0},
-			{Name: "unprotect", Status: Passed, Duration: 1.0},
-			{Name: "undeploy", Status: Passed, Duration: 1.0},
+			{Name: "deploy", Status: report.Passed, Duration: 1.0},
+			{Name: "protect", Status: report.Passed, Duration: 1.0},
+			{Name: "failover", Status: report.Passed, Duration: 1.0},
+			{Name: "relocate", Status: report.Passed, Duration: 1.0},
+			{Name: "unprotect", Status: report.Passed, Duration: 1.0},
+			{Name: "undeploy", Status: report.Passed, Duration: 1.0},
 		},
 	}
 
@@ -430,7 +422,7 @@ func TestStepAddPassedTest(t *testing.T) {
 		s1.AddTest(passedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Passed,
+			Status: report.Passed,
 			Items: []*Step{
 				{
 					Name:     passedTest.Name(),
@@ -448,11 +440,11 @@ func TestStepAddPassedTest(t *testing.T) {
 
 	// If a report is failed adding new step should not change the status.
 	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Failed}
+		s1 := &Step{Name: "root", Status: report.Failed}
 		s1.AddTest(passedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Failed,
+			Status: report.Failed,
 			Items: []*Step{
 				{
 					Name:     passedTest.Name(),
@@ -470,11 +462,11 @@ func TestStepAddPassedTest(t *testing.T) {
 
 	// If a report is failed adding new step should not change the status.
 	t.Run("canceled", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Canceled}
+		s1 := &Step{Name: "root", Status: report.Canceled}
 		s1.AddTest(passedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Canceled,
+			Status: report.Canceled,
 			Items: []*Step{
 				{
 					Name:     passedTest.Name(),
@@ -494,11 +486,11 @@ func TestStepAddPassedTest(t *testing.T) {
 func TestStepAddFailedTest(t *testing.T) {
 	failedTest := &Test{
 		Context:  &Context{name: "failing_test"},
-		Status:   Failed,
+		Status:   report.Failed,
 		Config:   &reportConfig.Tests[0],
 		Duration: 1.0,
 		Steps: []*Step{
-			{Name: "undeploy", Status: Failed, Duration: 1.0},
+			{Name: "undeploy", Status: report.Failed, Duration: 1.0},
 		},
 	}
 
@@ -508,7 +500,7 @@ func TestStepAddFailedTest(t *testing.T) {
 		s1.AddTest(failedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Failed,
+			Status: report.Failed,
 			Items: []*Step{
 				{
 					Name:     failedTest.Name(),
@@ -526,12 +518,12 @@ func TestStepAddFailedTest(t *testing.T) {
 
 	// Adding failed tests shuuld change report status.
 	t.Run("passed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Passed}
+		s1 := &Step{Name: "root", Status: report.Passed}
 		s1.AddTest(failedTest)
 		s2 := &Step{
 			Name: s1.Name,
 			// Passed status should be changed to Failed
-			Status: Failed,
+			Status: report.Failed,
 			Items: []*Step{
 				{
 					Name:     failedTest.Name(),
@@ -549,11 +541,11 @@ func TestStepAddFailedTest(t *testing.T) {
 
 	// Adding failed step should not change canceled report.
 	t.Run("canceled", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Canceled}
+		s1 := &Step{Name: "root", Status: report.Canceled}
 		s1.AddTest(failedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Canceled,
+			Status: report.Canceled,
 			Items: []*Step{
 				{
 					Name:     failedTest.Name(),
@@ -573,20 +565,20 @@ func TestStepAddFailedTest(t *testing.T) {
 func TestStepAddCanceledTest(t *testing.T) {
 	canceledTest := &Test{
 		Context:  &Context{name: "canceled_test"},
-		Status:   Canceled,
+		Status:   report.Canceled,
 		Duration: 1.0,
 		Steps: []*Step{
-			{Name: "deploy", Status: Canceled, Duration: 1.0},
+			{Name: "deploy", Status: report.Canceled, Duration: 1.0},
 		},
 	}
 
 	// Adding canceled test should override failed status.
 	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Failed}
+		s1 := &Step{Name: "root", Status: report.Failed}
 		s1.AddTest(canceledTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Canceled,
+			Status: report.Canceled,
 			Items: []*Step{
 				{
 					Name:     canceledTest.Name(),
@@ -603,11 +595,11 @@ func TestStepAddCanceledTest(t *testing.T) {
 
 	// Adding canceled test should override passed status.
 	t.Run("passed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Passed}
+		s1 := &Step{Name: "root", Status: report.Passed}
 		s1.AddTest(canceledTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Canceled,
+			Status: report.Canceled,
 			Items: []*Step{
 				{
 					Name:     canceledTest.Name(),
@@ -626,7 +618,7 @@ func TestStepAddCanceledTest(t *testing.T) {
 func TestStepAddSkippedTest(t *testing.T) {
 	skippedTest := &Test{
 		Context:  &Context{name: "skipped_test"},
-		Status:   Skipped,
+		Status:   report.Skipped,
 		Duration: 0.0,
 	}
 
@@ -636,7 +628,7 @@ func TestStepAddSkippedTest(t *testing.T) {
 		s1.AddTest(skippedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Passed,
+			Status: report.Passed,
 			Items: []*Step{
 				{
 					Name:     skippedTest.Name(),
@@ -652,11 +644,11 @@ func TestStepAddSkippedTest(t *testing.T) {
 
 	// Adding skipped test should not modify failed status.
 	t.Run("failed", func(t *testing.T) {
-		s1 := &Step{Name: "root", Status: Failed}
+		s1 := &Step{Name: "root", Status: report.Failed}
 		s1.AddTest(skippedTest)
 		s2 := &Step{
 			Name:   s1.Name,
-			Status: Failed,
+			Status: report.Failed,
 			Items: []*Step{
 				{
 					Name:     skippedTest.Name(),
@@ -673,12 +665,12 @@ func TestStepAddSkippedTest(t *testing.T) {
 func TestStepMarshal(t *testing.T) {
 	step := &Step{
 		Name:     "test",
-		Status:   Passed,
+		Status:   report.Passed,
 		Duration: 2.0,
 		Config:   &reportConfig.Tests[0],
 		Items: []*Step{
-			{Name: "subtest1", Status: Passed, Duration: 1.0},
-			{Name: "subtest2", Status: Failed, Duration: 1.0},
+			{Name: "subtest1", Status: report.Passed, Duration: 1.0},
+			{Name: "subtest2", Status: report.Failed, Duration: 1.0},
 		},
 	}
 
@@ -697,7 +689,12 @@ func TestStepMarshal(t *testing.T) {
 }
 
 func TestStepEqual(t *testing.T) {
-	s1 := Step{Name: "base_test", Status: Passed, Duration: 1.0, Config: &reportConfig.Tests[0]}
+	s1 := Step{
+		Name:     "base_test",
+		Status:   report.Passed,
+		Duration: 1.0,
+		Config:   &reportConfig.Tests[0],
+	}
 
 	t.Run("equal to self", func(t *testing.T) {
 		if !s1.Equal(&s1) {
@@ -721,7 +718,7 @@ func TestStepEqual(t *testing.T) {
 
 	t.Run("different status", func(t *testing.T) {
 		s2 := s1
-		s2.Status = Failed
+		s2.Status = report.Failed
 		if s1.Equal(&s2) {
 			t.Fatalf("steps with different status should not be equal")
 		}
@@ -752,7 +749,7 @@ func TestStepEqual(t *testing.T) {
 	})
 
 	t.Run("both nil config", func(t *testing.T) {
-		s1 := Step{Name: "test", Status: Passed, Duration: 1.0, Config: nil}
+		s1 := Step{Name: "test", Status: report.Passed, Duration: 1.0, Config: nil}
 		s2 := s1
 		if !s1.Equal(&s2) {
 			t.Fatalf("steps with nil config should be equal")
@@ -762,9 +759,12 @@ func TestStepEqual(t *testing.T) {
 	t.Run("equal subitems", func(t *testing.T) {
 		s1 := Step{
 			Name:     "parent",
-			Status:   Passed,
+			Status:   report.Passed,
 			Duration: 1.0,
-			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
+			Items: []*Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
 		}
 		s2 := s1
 		if !s1.Equal(&s2) {
@@ -775,12 +775,18 @@ func TestStepEqual(t *testing.T) {
 	t.Run("different subitem name", func(t *testing.T) {
 		s1 := Step{
 			Name:     "parent",
-			Status:   Passed,
+			Status:   report.Passed,
 			Duration: 1.0,
-			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
+			Items: []*Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
 		}
 		s2 := s1
-		s2.Items = []*Step{{Name: "child1", Status: Passed}, {Name: "different", Status: Failed}}
+		s2.Items = []*Step{
+			{Name: "child1", Status: report.Passed},
+			{Name: "different", Status: report.Failed},
+		}
 		if s1.Equal(&s2) {
 			t.Fatalf("steps with different subitem names should not be equal")
 		}
@@ -789,12 +795,15 @@ func TestStepEqual(t *testing.T) {
 	t.Run("different number of subitems", func(t *testing.T) {
 		s1 := Step{
 			Name:     "parent",
-			Status:   Passed,
+			Status:   report.Passed,
 			Duration: 1.0,
-			Items:    []*Step{{Name: "child1", Status: Passed}, {Name: "child2", Status: Failed}},
+			Items: []*Step{
+				{Name: "child1", Status: report.Passed},
+				{Name: "child2", Status: report.Failed},
+			},
 		}
 		s2 := s1
-		s2.Items = []*Step{{Name: "child1", Status: Passed}}
+		s2.Items = []*Step{{Name: "child1", Status: report.Passed}}
 		if s1.Equal(&s2) {
 			t.Fatalf("steps with different number of subitems should not be equal")
 		}
@@ -832,12 +841,12 @@ func TestSummaryCount(t *testing.T) {
 	summary := Summary{}
 
 	// Add multiple tests of different status
-	summary.AddTest(&Step{Status: Passed})
-	summary.AddTest(&Step{Status: Passed})
-	summary.AddTest(&Step{Status: Failed})
-	summary.AddTest(&Step{Status: Skipped})
-	summary.AddTest(&Step{Status: Canceled})
-	summary.AddTest(&Step{Status: Passed})
+	summary.AddTest(&Step{Status: report.Passed})
+	summary.AddTest(&Step{Status: report.Passed})
+	summary.AddTest(&Step{Status: report.Failed})
+	summary.AddTest(&Step{Status: report.Skipped})
+	summary.AddTest(&Step{Status: report.Canceled})
+	summary.AddTest(&Step{Status: report.Passed})
 
 	expectedSummary := Summary{Passed: 3, Failed: 1, Skipped: 1, Canceled: 1}
 	if summary != expectedSummary {

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -25,7 +25,7 @@ type Test struct {
 	*Context
 	Backend     e2e.Testing
 	Status      report.Status
-	Steps       []*Step
+	Steps       []*report.Step
 	Duration    float64
 	stepStarted time.Time
 }
@@ -148,7 +148,7 @@ func (t *Test) Cleanup() bool {
 }
 
 func (t *Test) startStep(name string) {
-	step := &Step{Name: name}
+	step := &report.Step{Name: name}
 	t.stepStarted = time.Now()
 	t.Steps = append(t.Steps, step)
 	t.Logger().Infof("Step %q started", step.Name)

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/e2e"
+	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
@@ -23,7 +24,7 @@ import (
 type Test struct {
 	*Context
 	Backend     e2e.Testing
-	Status      Status
+	Status      report.Status
 	Config      *e2econfig.Test
 	Steps       []*Step
 	Duration    float64
@@ -50,7 +51,7 @@ func newTest(tc e2econfig.Test, cmd *Command) *Test {
 	return &Test{
 		Context: newContext(cmd, workload, deployer),
 		Backend: cmd.backend,
-		Status:  Passed,
+		Status:  report.Passed,
 		Config:  &tc,
 	}
 }
@@ -160,10 +161,10 @@ func (t *Test) failStep(err error) bool {
 	step.Duration = time.Since(t.stepStarted).Seconds()
 	t.Duration += step.Duration
 	if errors.Is(err, context.Canceled) {
-		step.Status = Canceled
+		step.Status = report.Canceled
 		console.Error("Canceled application %q %s", t.Name(), step.Name)
 	} else {
-		step.Status = Failed
+		step.Status = report.Failed
 		console.Error("Failed to %s application %q", step.Name, t.Name())
 	}
 	t.Status = step.Status
@@ -175,7 +176,7 @@ func (t *Test) passStep() bool {
 	step := t.Steps[len(t.Steps)-1]
 	step.Duration = time.Since(t.stepStarted).Seconds()
 	t.Duration += step.Duration
-	step.Status = Passed
+	step.Status = report.Passed
 	t.Logger().Infof("Step %q passed", step.Name)
 	return true
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -25,7 +25,6 @@ type Test struct {
 	*Context
 	Backend     e2e.Testing
 	Status      report.Status
-	Config      *e2econfig.Test
 	Steps       []*Step
 	Duration    float64
 	stepStarted time.Time
@@ -52,7 +51,6 @@ func newTest(tc e2econfig.Test, cmd *Command) *Test {
 		Context: newContext(cmd, workload, deployer),
 		Backend: cmd.backend,
 		Status:  report.Passed,
-		Config:  &tc,
 	}
 }
 


### PR DESCRIPTION
Move state and code to the generic report package so we can use it for all commands. The test.Report is minimized to add the test specific state and code for managing tests steps.

This change drops the test config, since it is not generic, and makes it harder to create the generic report. We can consider adding it later in a more generic way.

Testing
- [x] drenv

Fixes #194