### PR TITLE
deps: update ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,9 @@ toolchain go1.23.8
 require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409
+	github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee
 	github.com/spf13/cobra v1.9.1
+	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.13.0
 	k8s.io/client-go v0.31.1
@@ -58,7 +59,6 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
-	github.com/spf13/viper v1.19.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409 h1:Vhe5JON3byxEMj9f9JczwYNQBb8BpdA5JSAR/lbRqRM=
-github.com/ramendr/ramen/e2e v0.0.0-20250616093913-0ea235b82409/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee h1:95/kDm+iuhI0+yPaUWqTeVbkPDVj7ntIyJN2ucUbOKM=
+github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Consuming fix for workload discovery for discovered applications in deployment and protection ops:
- RamenDR/ramen#2092

Issues fixed in ramen e2e:
- RamenDR/ramen#2063
- RamenDR/ramen#2062

Fixes #92 