### PR TITLE
deps: update ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.23.8
 require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.7.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee
+	github.com/ramendr/ramen/e2e v0.0.0-20250624154824-2360ce66e713
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee h1:95/kDm+iuhI0+yPaUWqTeVbkPDVj7ntIyJN2ucUbOKM=
-github.com/ramendr/ramen/e2e v0.0.0-20250619213430-783ca28df3ee/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250624154824-2360ce66e713 h1:HBh3VrMp0vHabC0/+AoucBSSow3H2MyHcwzw0jvA15E=
+github.com/ramendr/ramen/e2e v0.0.0-20250624154824-2360ce66e713/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -24,7 +24,7 @@ func Namespaces(env *types.Env, namespaces []string, outputDir string, log *zap.
 	log.Infof("Gather namespaces %q from all clusters", namespaces)
 
 	var wg sync.WaitGroup
-	for _, cluster := range []*types.Cluster{&env.Hub, &env.C1, &env.C2} {
+	for _, cluster := range []*types.Cluster{env.Hub, env.C1, env.C2} {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -32,9 +32,9 @@ var testConfig = e2econfig.Config{
 }
 
 var testEnv = types.Env{
-	Hub: types.Cluster{Name: "hub"},
-	C1:  types.Cluster{Name: "c1"},
-	C2:  types.Cluster{Name: "c2"},
+	Hub: &types.Cluster{Name: "hub"},
+	C1:  &types.Cluster{Name: "c1"},
+	C2:  &types.Cluster{Name: "c2"},
 }
 
 var testOptions Options


### PR DESCRIPTION
Consuming fix for env package refactoring and converting env struct fields from Cluster to *Cluster in preparation for adding optional passive hub:

- RamenDR/ramen#2108

Updated ramenctl code to work with pointer-based Env struct fields.