### PR TITLE
Implement config validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,8 +14,11 @@ require (
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.13.0
+	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
 	k8s.io/klog/v2 v2.130.1
+	open-cluster-management.io/api v0.15.0
+	sigs.k8s.io/controller-runtime v0.19.0
 	sigs.k8s.io/yaml v1.4.0
 )
 
@@ -75,16 +78,13 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.31.1 // indirect
-	k8s.io/apimachinery v0.31.1 // indirect
 	k8s.io/cli-runtime v0.31.1 // indirect
 	k8s.io/component-base v0.31.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240816214639-573285566f34 // indirect
 	k8s.io/kubectl v0.31.1 // indirect
 	k8s.io/utils v0.0.0-20240711033017-18e509b52bc8 // indirect
-	open-cluster-management.io/api v0.15.0 // indirect
 	open-cluster-management.io/multicloud-operators-channel v0.15.0 // indirect
 	open-cluster-management.io/multicloud-operators-subscription v0.15.0 // indirect
-	sigs.k8s.io/controller-runtime v0.19.0 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -105,6 +105,18 @@ func (c *Config) Equal(o *Config) bool {
 	return maps.Equal(c.Clusters, o.Clusters)
 }
 
+func (c *Config) SetDistro(d string) {
+	switch d {
+	case config.DistroOcp:
+		c.Namespaces = config.OcpNamespaces
+	case config.DistroK8s:
+		c.Namespaces = config.K8sNamespaces
+	default:
+		panic(fmt.Sprintf("invalid distro: %q", d))
+	}
+	c.Distro = d
+}
+
 func (c *Config) validateDistro() error {
 	if c.Distro == "" {
 		// Will be detected when accessing the clusters.

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -5,7 +5,7 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/e2e"
+	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
 func Clean(configFile string, outputDir string) error {
@@ -20,6 +20,6 @@ func Clean(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, cfg, e2e.Backend{}, Options{GatherData: true})
+	test := newCommand(cmd, cfg, testing.Backend{}, Options{GatherData: true})
 	return test.Clean()
 }

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -18,9 +18,9 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
-	"github.com/ramendr/ramenctl/pkg/e2e"
 	"github.com/ramendr/ramenctl/pkg/gather"
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/testing"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
@@ -44,7 +44,7 @@ type Command struct {
 	context context.Context
 
 	// backend is used to perform testing operations.
-	backend e2e.Testing
+	backend testing.Testing
 
 	// options for test commands.
 	options Options
@@ -74,7 +74,7 @@ type flowFunc func(t *Test)
 func newCommand(
 	cmd *command.Command,
 	cfg *e2econfig.Config,
-	backend e2e.Testing,
+	backend testing.Testing,
 	options Options,
 ) *Command {
 	// This is not user configurable. We use the same prefix for all namespaces created by the test.

--- a/pkg/test/mock.go
+++ b/pkg/test/mock.go
@@ -6,14 +6,14 @@ package test
 import (
 	"github.com/ramendr/ramen/e2e/types"
 
-	"github.com/ramendr/ramenctl/pkg/e2e"
+	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
 type ContextFunc func(types.Context) error
 type TestContextFunc func(types.TestContext) error
 
-// MockBackend implements the e2e.Testing interface. All operations succeed without accessing the
-// clusters. To cause operations to fail, set a function returning an error.
+// MockBackend implements the testing.Testing interface. All operations succeed without accessing
+// the clusters. To cause operations to fail, set a function returning an error.
 type MockBackend struct {
 	// Operations on types.Context
 	ValidateFunc ContextFunc
@@ -29,7 +29,7 @@ type MockBackend struct {
 	RelocateFunc  TestContextFunc
 }
 
-var _ e2e.Testing = &MockBackend{}
+var _ testing.Testing = &MockBackend{}
 
 func (m *MockBackend) Validate(ctx types.Context) error {
 	if m.ValidateFunc != nil {

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -5,7 +5,7 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/e2e"
+	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
 func Run(configFile string, outputDir string) error {
@@ -20,6 +20,6 @@ func Run(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	test := newCommand(cmd, cfg, e2e.Backend{}, Options{GatherData: true})
+	test := newCommand(cmd, cfg, testing.Backend{}, Options{GatherData: true})
 	return test.Run()
 }

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -15,15 +15,15 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/ramendr/ramenctl/pkg/console"
-	"github.com/ramendr/ramenctl/pkg/e2e"
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/testing"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
 // Test perform DR opetaions for testing DR flow.
 type Test struct {
 	*Context
-	Backend     e2e.Testing
+	Backend     testing.Testing
 	Status      report.Status
 	Steps       []*report.Step
 	Duration    float64

--- a/pkg/testing/backend.go
+++ b/pkg/testing/backend.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package testing
 
 import (
 	"github.com/ramendr/ramen/e2e/dractions"

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package e2e
+package testing
 
 import "github.com/ramendr/ramen/e2e/types"
 

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -6,6 +6,7 @@ package validate
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/validation"
 )
 
 func Clusters(configFile string, outputDir string) error {
@@ -20,6 +21,6 @@ func Clusters(configFile string, outputDir string) error {
 	}
 	defer cmd.Close()
 
-	validate := newCommand(cmd, cfg)
+	validate := newCommand(cmd, cfg, validation.Backend{})
 	return validate.Clusters()
 }

--- a/pkg/validation/backend.go
+++ b/pkg/validation/backend.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+type Backend struct{}
+
+var _ Validation = &Backend{}
+
+func (b Backend) Validate(ctx Context) error {
+	if err := detectDistro(ctx); err != nil {
+		return err
+	}
+	if err := validateClusterset(ctx); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/validation/distro.go
+++ b/pkg/validation/distro.go
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	e2econfig "github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+// detectDistro detects the cluster distribution. If distro is set in config, it uses the user
+// provided distro. Otherwise, it determines the distro, sets config.Distro and config.Namespaces.
+// Returns an error if distro detection fails or if clusters have inconsistent distributions.
+func detectDistro(ctx Context) error {
+	cfg := ctx.Config()
+	env := ctx.Env()
+	log := ctx.Logger()
+
+	if cfg.Distro != "" {
+		return nil
+	}
+
+	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
+	if env.PassiveHub != nil {
+		clusters = append(clusters, env.PassiveHub)
+	}
+
+	var detectedDistro string
+	for _, cluster := range clusters {
+		distro, err := probeDistro(ctx, cluster)
+		if err != nil {
+			return fmt.Errorf("failed to determine distro for cluster %q: %w", cluster.Name, err)
+		}
+
+		if detectedDistro == "" {
+			detectedDistro = distro
+		} else if detectedDistro != distro {
+			return fmt.Errorf("clusters have inconsistent distributions, cluster %q has distro %q, expected %q",
+				cluster.Name, distro, detectedDistro)
+		}
+	}
+
+	cfg.SetDistro(detectedDistro)
+
+	log.Infof("Detected kubernetes distribution: %q", cfg.Distro)
+	log.Infof("Using namespaces: %+v", cfg.Namespaces)
+
+	return nil
+}
+
+// probeDistro determines the distribution of the given Kubernetes cluster.
+// Returns the detected distribution name ("ocp" or "k8s") or an error if detection fails.
+func probeDistro(ctx Context, cluster *types.Cluster) (string, error) {
+	list := &unstructured.Unstructured{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "config.openshift.io",
+		Version: "v1",
+		Kind:    "ClusterVersion",
+	})
+	err := cluster.Client.List(ctx.Context(), list)
+	if err != nil {
+		if !meta.IsNoMatchError(err) {
+			return "", err
+		}
+		// api server says no match for OpenShift only resource type,
+		// it is not OpenShift
+		return e2econfig.DistroK8s, nil
+	}
+	// found OpenShift only resource type, it is OpenShift
+	return e2econfig.DistroOcp, nil
+}

--- a/pkg/validation/ocm.go
+++ b/pkg/validation/ocm.go
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"fmt"
+	"slices"
+
+	ocmv1 "open-cluster-management.io/api/cluster/v1"
+	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ramendr/ramen/e2e/types"
+)
+
+func validateClusterset(ctx Context) error {
+	env := ctx.Env()
+	cfg := ctx.Config()
+	log := ctx.Logger()
+	if _, err := getClusterSet(ctx, cfg.ClusterSet); err != nil {
+		return err
+	}
+	clusterNames, err := listManagedClustersForClusterSet(ctx, cfg.ClusterSet)
+	if err != nil {
+		return err
+	}
+	clusters := []*types.Cluster{env.C1, env.C2}
+	for _, cluster := range clusters {
+		if !slices.Contains(clusterNames, cluster.Name) {
+			return fmt.Errorf(
+				"cluster %q is not defined in clusterSet %q, clusters in ClusterSet: %q",
+				cluster.Name,
+				cfg.ClusterSet,
+				clusterNames,
+			)
+		}
+	}
+	log.Infof(
+		"Validated clusters [%q, %q] in clusterSet %q",
+		clusters[0].Name,
+		clusters[1].Name,
+		cfg.ClusterSet,
+	)
+	return nil
+}
+
+func getClusterSet(ctx Context, clusterSetName string) (*ocmv1b2.ManagedClusterSet, error) {
+	hub := ctx.Env().Hub
+	clusterSet := &ocmv1b2.ManagedClusterSet{}
+	key := client.ObjectKey{Name: clusterSetName}
+	if err := hub.Client.Get(ctx.Context(), key, clusterSet); err != nil {
+		return nil, fmt.Errorf("failed to get clusterSet %q: %w", clusterSetName, err)
+	}
+	return clusterSet, nil
+}
+
+func listManagedClustersForClusterSet(ctx Context, clusterSetName string) ([]string, error) {
+	hub := ctx.Env().Hub
+	list := &ocmv1.ManagedClusterList{}
+	labelSelector := client.MatchingLabels{
+		"cluster.open-cluster-management.io/clusterset": clusterSetName,
+	}
+	if err := hub.Client.List(ctx.Context(), list, labelSelector); err != nil {
+		return nil, fmt.Errorf(
+			"failed to list ManagedClusters for clusterSet %q: %w",
+			clusterSetName,
+			err,
+		)
+	}
+	if len(list.Items) == 0 {
+		return nil, fmt.Errorf("no clusters found for clusterSet %q", clusterSetName)
+	}
+	clusterNames := make([]string, 0, len(list.Items))
+	for _, cluster := range list.Items {
+		clusterNames = append(clusterNames, cluster.Name)
+	}
+	return clusterNames, nil
+}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package validation
+
+import (
+	"context"
+
+	"github.com/ramendr/ramen/e2e/types"
+	"go.uber.org/zap"
+
+	"github.com/ramendr/ramenctl/pkg/config"
+)
+
+// Context is validation context, decoupling the ramenctl command from the backend implementation.
+type Context interface {
+	Env() *types.Env
+	Config() *config.Config
+	Logger() *zap.SugaredLogger
+	Context() context.Context
+}
+
+// Validation provides the validation operations.
+type Validation interface {
+	// Validate the environment. Must be called once before calling other functions.
+	Validate(Context) error
+}


### PR DESCRIPTION
Add validation package for decoupling the command from the actual validation code. The package provides a Validation interface and a Backend implementing the interface.

The validate.Command uses now the backend to implement config validation.

Todo:
- [ ] validate.Command tests

Fixes #203 