### PR TITLE
cmd: add gather command

### DIFF
--- a/cmd/commands/gather.go
+++ b/cmd/commands/gather.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gather"
+)
+
+var GatherCmd = &cobra.Command{
+	Use:   "gather",
+	Short: "Collect diagnostic data from your clusters",
+}
+
+var GatherApplicationCmd = &cobra.Command{
+	Use:   "application",
+	Short: "Collect data based on application",
+	Run: func(c *cobra.Command, args []string) {
+		if err := gather.Gather(configFile, outputDir, drpcName, drpcNamespace); err != nil {
+			console.Fatal(err)
+		}
+	},
+}
+
+func init() {
+	addOutputFlags(GatherCmd)
+	addDRPCFlags(GatherApplicationCmd)
+	GatherCmd.AddCommand(GatherApplicationCmd)
+}

--- a/cmd/ramenctl.go
+++ b/cmd/ramenctl.go
@@ -15,6 +15,7 @@ func main() {
 	commands.RootCmd.AddCommand(
 		commands.InitCmd,
 		commands.TestCmd,
+		commands.GatherCmd,
 		commands.ValidateCmd,
 	)
 

--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"path/filepath"
+	"slices"
+	stdtime "time"
+
+	"github.com/ramendr/ramen/e2e/types"
+	"go.uber.org/zap"
+
+	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gathering"
+	"github.com/ramendr/ramenctl/pkg/logging"
+	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/time"
+	"github.com/ramendr/ramenctl/pkg/validation"
+)
+
+type Command struct {
+	// command is the generic command used by all ramenctl commands.
+	command *command.Command
+
+	// config is the config for this command.
+	config *config.Config
+
+	// backend implementing the validation interface.
+	backend validation.Validation
+
+	// content is used to set deadlines.
+	context context.Context
+
+	// report describes the command execution.
+	report *report.Report
+
+	// current validation step.
+	current        *report.Step
+	currentStarted time.Time
+}
+
+// Ensure that command implements validation.Context.
+var _ validation.Context = &Command{}
+
+// validation.Context interface.
+
+func (c *Command) Env() *types.Env {
+	return c.command.Env()
+}
+
+func (c *Command) Config() *config.Config {
+	return c.config
+}
+
+func (c *Command) Logger() *zap.SugaredLogger {
+	return c.command.Logger()
+}
+
+func (c *Command) Context() context.Context {
+	return c.context
+}
+
+func newCommand(cmd *command.Command, cfg *config.Config, backend validation.Validation) *Command {
+	return &Command{
+		command: cmd,
+		config:  cfg,
+		backend: backend,
+		context: cmd.Context(),
+		report:  report.NewReport(cmd.Name(), cfg),
+	}
+}
+
+func (c *Command) Application(drpcName string, drpcNamespace string) error {
+	c.report.Application = &report.Application{
+		Name:      drpcName,
+		Namespace: drpcNamespace,
+	}
+	if !c.validateConfig() {
+		return c.failed()
+	}
+	if !c.gatherData(drpcName, drpcNamespace) {
+		return c.failed()
+	}
+	c.passed()
+	return nil
+}
+
+func (c *Command) validateConfig() bool {
+	console.Step("Validate config")
+	c.startStep("validate config")
+	timedCmd, cancel := c.withTimeout(30 * stdtime.Second)
+	defer cancel()
+	if err := c.backend.Validate(timedCmd); err != nil {
+		return c.failStep(err)
+	}
+	c.passStep()
+	console.Pass("Config validated")
+	return true
+}
+
+func (c *Command) gatherData(drpcName string, drpcNamespace string) bool {
+	console.Step("Gather application data")
+	c.startStep("gather data")
+
+	namespaces, ok := c.inspectApplication(drpcName, drpcNamespace)
+	if !ok {
+		return c.finishStep()
+	}
+
+	if !c.gatherApplication(namespaces) {
+		return c.finishStep()
+	}
+
+	c.finishStep()
+	return true
+}
+
+func (c *Command) inspectApplication(drpcName, drpcNamespace string) ([]string, bool) {
+	start := time.Now()
+	step := &report.Step{Name: "inspect application"}
+	c.Logger().Infof("Step %q started", step.Name)
+
+	namespaces, err := c.namespacesToGather(drpcName, drpcNamespace)
+	if err != nil {
+		step.Duration = time.Since(start).Seconds()
+		if errors.Is(err, context.Canceled) {
+			console.Error("Canceled %s", step.Name)
+			step.Status = report.Canceled
+		} else {
+			console.Error("Failed to %s", step.Name)
+			step.Status = report.Failed
+		}
+		c.Logger().Errorf("Step %q %s: %s", c.current.Name, step.Status, err)
+		c.current.AddStep(step)
+
+		return nil, false
+	}
+
+	step.Duration = time.Since(start).Seconds()
+	step.Status = report.Passed
+	c.current.AddStep(step)
+
+	console.Pass("Inspected application")
+	c.Logger().Infof("Step %q passed", step.Name)
+
+	return namespaces, true
+}
+
+func (c *Command) gatherApplication(namespaces []string) bool {
+	start := time.Now()
+	env := c.Env()
+	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
+	outputDir := filepath.Join(c.command.OutputDir(), c.command.Name()+".data")
+
+	c.Logger().Infof("Gathering namespaces %q from clusters %q",
+		namespaces, logging.ClusterNames(clusters))
+
+	for r := range gathering.Namespaces(clusters, namespaces, outputDir, c.Logger()) {
+		step := &report.Step{Name: fmt.Sprintf("gather %q", r.Name), Duration: r.Duration}
+		if r.Err != nil {
+			msg := fmt.Sprintf("Failed to gather data from cluster %q", r.Name)
+			console.Error(msg)
+			c.Logger().Errorf("%s: %s", msg, r.Err)
+			step.Status = report.Failed
+			c.current.AddStep(step)
+		} else {
+			step.Status = report.Passed
+			c.current.AddStep(step)
+			console.Pass("Gathered data from cluster %q", r.Name)
+		}
+	}
+
+	c.Logger().Infof("Gathered clusters in %.2f seconds", time.Since(start).Seconds())
+
+	return c.current.Status == report.Passed
+}
+
+// withTimeout returns a derived command with a deadline. Call cancel to release resources
+// associated with the context as soon as the operation running in the context complete.
+func (c Command) withTimeout(d stdtime.Duration) (*Command, context.CancelFunc) {
+	ctx, cancel := context.WithTimeout(c.context, d)
+	c.context = ctx
+	return &c, cancel
+}
+
+func (c *Command) failed() error {
+	if err := c.command.WriteReport(c.report); err != nil {
+		console.Error("failed to write report: %s", err)
+	}
+	return fmt.Errorf("Gather %s", c.report.Status)
+}
+
+func (c *Command) passed() {
+	if err := c.command.WriteReport(c.report); err != nil {
+		console.Error("failed to write report: %s", err)
+	}
+	console.Completed("Gather completed")
+}
+
+func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]string, error) {
+	seen := map[string]struct{}{
+		// Gather ramen namespaces to get ramen hub and dr-cluster logs and related resources.
+		c.config.Namespaces.RamenHubNamespace:       {},
+		c.config.Namespaces.RamenDRClusterNamespace: {},
+	}
+
+	appNamespaces, err := c.backend.ApplicationNamespaces(c, drpcName, drpcNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ns := range appNamespaces {
+		seen[ns] = struct{}{}
+	}
+
+	namespaces := slices.Collect(maps.Keys(seen))
+	slices.Sort(namespaces)
+
+	return namespaces, nil
+
+}
+
+// Managing steps.
+
+func (c *Command) startStep(name string) {
+	c.current = &report.Step{Name: name}
+	c.currentStarted = time.Now()
+	c.command.Logger().Infof("Step %q started", c.current.Name)
+}
+
+func (c *Command) passStep() bool {
+	c.current.Duration = time.Since(c.currentStarted).Seconds()
+	c.current.Status = report.Passed
+	c.command.Logger().Infof("Step %q passed", c.current.Name)
+	c.report.AddStep(c.current)
+	c.current = nil
+	return true
+}
+
+func (c *Command) failStep(err error) bool {
+	c.current.Duration = time.Since(c.currentStarted).Seconds()
+	if errors.Is(err, context.Canceled) {
+		c.current.Status = report.Canceled
+		console.Error("Canceled %s", c.current.Name)
+	} else {
+		c.current.Status = report.Failed
+		console.Error("Failed to %s", c.current.Name)
+	}
+	c.command.Logger().Errorf("Step %q %s: %s", c.current.Name, c.current.Status, err)
+	c.report.AddStep(c.current)
+	c.current = nil
+	return false
+}
+
+func (c *Command) finishStep() bool {
+	c.current.Duration = time.Since(c.currentStarted).Seconds()
+	c.command.Logger().Infof("Step %q finished", c.current.Name)
+	c.report.AddStep(c.current)
+	c.current = nil
+	return c.report.Status == report.Passed
+}

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package gather
+
+import (
+	"fmt"
+
+	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/validation"
+)
+
+func Gather(configFile string, outputDir string, drpcName string, drpcNamespace string) error {
+	config, err := config.ReadConfig(configFile)
+	if err != nil {
+		return fmt.Errorf("unable to read config: %w", err)
+	}
+
+	cmd, err := command.New("gather-application", config.Clusters, outputDir)
+	if err != nil {
+		return err
+	}
+	defer cmd.Close()
+
+	gather := newCommand(cmd, config, validation.Backend{})
+	return gather.Application(drpcName, drpcNamespace)
+}


### PR DESCRIPTION
this commit adds the gather command
infrastructure to collection

```console
$ ./ramenctl gather application --help
Collect data based on application

Usage:
  ramenctl gather application [flags]

Flags:
  -h, --help               help for application
      --name string        drpc name
  -n, --namespace string   drpc namespace

Global Flags:
  -c, --config string   configuration file (default "config.yaml")
  -o, --output string   output directory
```

```console
yatipadia:ramenctl$ ./ramenctl gather application -o gather -c ocp.yaml --name test-ns --namespace openshift-dr-ops
⭐ Using config "ocp.yaml"
⭐ Using report "gather"

🔎 Validate config ...
   ✅ Config validated

🔎 Gather Application data ...
   ✅ Inspected application
   ✅ Gathered data from cluster "prsurve-c2-7j"
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "prsurve-c1-7j"

✅ Gather completed

```