### PR TITLE
deps: Update ramen/e2e to latest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.23.8
 require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.8.0
-	github.com/ramendr/ramen/e2e v0.0.0-20250709222238-987a6b3e182f
+	github.com/ramendr/ramen/e2e v0.0.0-20250710152106-9a4f493138c5
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929 h1:yW5QWX4InhtZJd2KhBS57/1uIpRpFSMbg58Ac7wfKpo=
 github.com/ramendr/ramen/api v0.0.0-20250313143647-8dd671566929/go.mod h1:ZRq9Ep/AMWPB9U8bi2mxmcU5nYnmfuK5OY2NVwj4xdA=
-github.com/ramendr/ramen/e2e v0.0.0-20250709222238-987a6b3e182f h1:8TtgfUz9XskupxztrU+tWAnEkY/InmcpxEMG8Gr8ryw=
-github.com/ramendr/ramen/e2e v0.0.0-20250709222238-987a6b3e182f/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250710152106-9a4f493138c5 h1:yABS4o5Rsqk0oDZO7gsqxgyOoahjbT7fjWp3bQVGDFc=
+github.com/ramendr/ramen/e2e v0.0.0-20250710152106-9a4f493138c5/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
To consume the following fixes:
- e2e disapp tests delete real managedclustersetbinding, breaking discovered apps in the cluster https://github.com/RamenDR/ramen/issues/2147

Main outcomes:
- We don't delete ramen-ops/openshift-dr-ops ManageClusterSetBinding during the tests.
- If the ManageClusterSetBinding is missing, disapp tests will fail.