### PR TITLE
deps: update ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.8.0
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
-	github.com/ramendr/ramen/e2e v0.0.0-20250714115418-cdd609356182
+	github.com/ramendr/ramen/e2e v0.0.0-20250715090459-dd53d4ff7c92
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -111,8 +111,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250714115418-cdd609356182 h1:WGNptS+fY03YLgFFy+bWIwdK4wxF1Jh80TtoxP5N1dQ=
-github.com/ramendr/ramen/e2e v0.0.0-20250714115418-cdd609356182/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
+github.com/ramendr/ramen/e2e v0.0.0-20250715090459-dd53d4ff7c92 h1:yLnuF3Q+o4/Wp9FkdaKwjFquVRE5HzQr6waeTgGY7ZA=
+github.com/ramendr/ramen/e2e v0.0.0-20250715090459-dd53d4ff7c92/go.mod h1:fPaZRvx6wnY2HvOzrMgXiZVgRX4DaINvmTqgnP8Ppvs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
Consuming fix for adding annotation to the drpc with "drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: true" during DisableProtection and wait for propagation to primary VRG before deleting protection resources:

- RamenDR/ramen#2157