### PR TITLE
validate: Gather ramen namespaces for cluster validation

### DIFF
--- a/pkg/validate/command.go
+++ b/pkg/validate/command.go
@@ -132,7 +132,7 @@ func (c *Command) validateClusters() bool {
 	c.startStep("validate clusters")
 
 	namespaces := c.clustersNamespacesToGather()
-	if !c.gatherApplicationNamespaces(namespaces) {
+	if !c.gatherNamespaces(namespaces) {
 		return c.finishStep()
 	}
 
@@ -172,11 +172,11 @@ func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
 		return c.finishStep()
 	}
 
-	if !c.gatherApplicationNamespaces(namespaces) {
+	if !c.gatherNamespaces(namespaces) {
 		return c.finishStep()
 	}
 
-	if !c.validateGatheredData(drpcName, drpcNamespace) {
+	if !c.validateGatheredApplicationData(drpcName, drpcNamespace) {
 		return c.finishStep()
 	}
 
@@ -218,7 +218,7 @@ func (c *Command) inspectApplication(drpcName, drpcNamespace string) ([]string, 
 	return namespaces, true
 }
 
-func (c *Command) gatherApplicationNamespaces(namespaces []string) bool {
+func (c *Command) gatherNamespaces(namespaces []string) bool {
 	start := time.Now()
 	env := c.Env()
 	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
@@ -246,7 +246,7 @@ func (c *Command) gatherApplicationNamespaces(namespaces []string) bool {
 	return c.current.Status == report.Passed
 }
 
-func (c *Command) validateGatheredData(drpcName, drpcNamespace string) bool {
+func (c *Command) validateGatheredApplicationData(drpcName, drpcNamespace string) bool {
 	// TODO: Validate gathered data.
 	step := &report.Step{Name: "validate data", Status: report.Passed}
 	c.current.AddStep(step)


### PR DESCRIPTION
This change implements gathering cluster resources, and adds stub for validating gathered cluster data.
Gatherring only the namespaces related to ramen ie hub and DR cluster namespaces, which contain the ramen resources needed for cluster validation.

## validate cluster on drenv

```
./ramenctl validate clusters -o val
⭐ Using config "config.yaml"
⭐ Using report "val"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Clusters validated

✅ Validation completed
```

report:

```
build:
  commit: a026a7b375dbc79ec3de5153798a88fae7b5c8b7
  version: v0.8.0-28-ga026a7b
config:
  clusterSet: default
  clusters:
    c1:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr1
    c2:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/dr2
    hub:
      kubeconfig: /Users/pari/.config/drenv/rdr/kubeconfigs/hub
    passive-hub:
      kubeconfig: ""
  distro: k8s
  namespaces:
    argocdNamespace: argocd
    ramenDRClusterNamespace: ramen-system
    ramenHubNamespace: ramen-system
    ramenOpsNamespace: ramen-ops
created: "2025-07-17T15:27:22.96334+05:30"
duration: 0.097454416
host:
  arch: arm64
  cpus: 12
  os: darwin
name: validate-clusters
status: passed
steps:
- duration: 0.013020875
  name: validate config
  status: passed
- duration: 0.084433541
  items:
  - duration: 0.071681292
    name: gather "dr2"
    status: passed
  - duration: 0.078383666
    name: gather "hub"
    status: passed
  - duration: 0.084380542
    name: gather "dr1"
    status: passed
  - name: validate cluster data
    status: passed
  name: validate clusters
  status: passed
```

gathered data:

```
tree -L3 val/validate-clusters.data
val/validate-clusters.data
├── dr1
│   ├── cluster
│   │   └── namespaces
│   └── namespaces
│       └── ramen-system
├── dr2
│   ├── cluster
│   │   └── namespaces
│   └── namespaces
│       └── ramen-system
└── hub
    ├── cluster
    │   └── namespaces
    └── namespaces
        └── ramen-system
```

Fixes #164 
Fixes #165 