### PR TITLE
add namespaces to gather to the report

### DIFF
--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -112,6 +112,7 @@ func (c *Command) gatherData(drpcName string, drpcNamespace string) bool {
 	if !ok {
 		return c.finishStep()
 	}
+	c.report.Namespaces = namespaces
 
 	if !c.gatherApplication(namespaces) {
 		return c.finishStep()

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -63,6 +63,7 @@ type Report struct {
 	*Base
 	Config      *config.Config `json:"config"`
 	Application *Application   `json:"application,omitempty"`
+	Namespaces  []string       `json:"namespaces,omitempty"`
 }
 
 // NewBase create a new base report for ramenctl commands reports.
@@ -176,6 +177,9 @@ func (r *Report) Equal(o *Report) bool {
 			return false
 		}
 	} else if r.Application != o.Application {
+		return false
+	}
+	if !slices.Equal(r.Namespaces, o.Namespaces) {
 		return false
 	}
 	return true

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -383,6 +383,22 @@ func TestReportNotEqual(t *testing.T) {
 			t.Fatal("reports with different application should not be equal")
 		}
 	})
+	t.Run("nil vs empty namespaces are equal", func(t *testing.T) {
+		r2 := report.NewReport("name", testConfig)
+		r2.Namespaces = []string{}
+		if !r1.Equal(r2) {
+			t.Fatalf("expected reports with nil and empty namespaces to be equal")
+		}
+	})
+	t.Run("different namespaces are not equal", func(t *testing.T) {
+		r1 := report.NewReport("name", testConfig)
+		r1.Namespaces = []string{"ns1", "ns2"}
+		r2 := report.NewReport("name", testConfig)
+		r2.Namespaces = []string{"ns1", "ns3"}
+		if r1.Equal(r2) {
+			t.Fatalf("reports with different namespaces should not be equal")
+		}
+	})
 }
 
 func TestStepAddPassedStep(t *testing.T) {


### PR DESCRIPTION
this commit adds namespaces to be gathered
by gather command to the report

Fixes: #179