### PR TITLE
go: update the go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/ramendr/ramenctl
 
 // Required minimum version, must be available in downstream builders.
-go 1.23.5
+go 1.24.0
 
-// Recommended version: latest go 1.23 release.
-toolchain go1.23.8
+// Recommended version: latest go 1.24 release.
+toolchain go1.24.5
 
 require (
 	github.com/go-logr/zapr v1.3.0


### PR DESCRIPTION
Update to go 1.24, same as the e2e pkg version in ramen.