### PR TITLE
gitignore: add .vscode to editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ cover.out
 
 # Editor files
 /.zed
+/.vscode
 
 # Test results
 /.test


### PR DESCRIPTION
Remove project-wide editor configuration to avoid maintenance overhead and keep personal editor settings local.