### PR TITLE
release: Use go version from go.mod

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,7 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
+        goversion: go.mod
         md5sum: FALSE
         compress_assets: OFF
         build_command: make ramenctl


### PR DESCRIPTION
The default is latest which is not bad, but let's have more predictable version by using the version specified in go.mod. This is also how we build in the test workflow.

Pre-release for testing: https://github.com/nirs/ramenctl/releases/tag/v0.9.0-pre1