### PR TITLE
ci: Use latest golangci-lint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: v2.0
+          version: latest
 
   build-matrix:
     name: Build


### PR DESCRIPTION
So we don't need to maintain the version.