### PR TITLE
report: Add application status

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package report
+
+import (
+	"maps"
+	"slices"
+)
+
+// ProtectedPVCSummary is the summary of a protected PVC.
+type ProtectedPVCSummary struct {
+	Name       string            `json:"name"`
+	Namespace  string            `json:"namespace"`
+	Deleted    bool              `json:"deleted,omitempty"`
+	Phase      string            `json:"phase,omitempty"`
+	Conditions map[string]string `json:"conditions,omitempty"`
+}
+
+// DRPCSummary is the summary of a DRPC.
+type DRPCSummary struct {
+	Name        string            `json:"name"`
+	Namespace   string            `json:"namespace"`
+	Deleted     bool              `json:"deleted,omitempty"`
+	DRPolicy    string            `json:"drPolicy"`
+	Action      string            `json:"action,omitempty"`
+	Phase       string            `json:"phase"`
+	Progression string            `json:"progression"`
+	Conditions  map[string]string `json:"conditions,omitempty"`
+}
+
+// VRGSummary is the summary of a VRG.
+type VRGSummary struct {
+	Name          string                `json:"name"`
+	Namespace     string                `json:"namespace"`
+	Deleted       bool                  `json:"deleted,omitempty"`
+	State         string                `json:"state"`
+	Conditions    map[string]string     `json:"conditions,omitempty"`
+	ProtectedPVCs []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
+}
+
+// ApplicationHubStaus is the application status on the hub.
+type HubApplicationStatus struct {
+	DRPC DRPCSummary `json:"drpc"`
+}
+
+// ApplicationHubStaus is the application status on a managed cluster.
+type ClusterApplicationStatus struct {
+	Name string     `json:"name"`
+	VRG  VRGSummary `json:"vrg"`
+}
+
+// ApplicationStatus is protected application status in multi-cluster environment.
+type ApplicationStatus struct {
+	Hub              HubApplicationStatus     `json:"hub"`
+	PrimaryCluster   ClusterApplicationStatus `json:"primaryCluster"`
+	SecondaryCluster ClusterApplicationStatus `json:"secondaryCluster"`
+}
+
+func (a *ApplicationStatus) Equal(o *ApplicationStatus) bool {
+	if a == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if !a.Hub.Equal(&o.Hub) {
+		return false
+	}
+	if !a.PrimaryCluster.Equal(&o.PrimaryCluster) {
+		return false
+	}
+	if !a.SecondaryCluster.Equal(&o.SecondaryCluster) {
+		return false
+	}
+	return true
+}
+
+func (h *HubApplicationStatus) Equal(o *HubApplicationStatus) bool {
+	if h == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if !h.DRPC.Equal(&o.DRPC) {
+		return false
+	}
+	return true
+}
+
+func (c *ClusterApplicationStatus) Equal(o *ClusterApplicationStatus) bool {
+	if c == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if c.Name != o.Name {
+		return false
+	}
+	if !c.VRG.Equal(&o.VRG) {
+		return false
+	}
+	return true
+}
+
+func (d *DRPCSummary) Equal(o *DRPCSummary) bool {
+	if d == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if d.Name != o.Name {
+		return false
+	}
+	if d.Namespace != o.Namespace {
+		return false
+	}
+	if d.Deleted != o.Deleted {
+		return false
+	}
+	if d.DRPolicy != o.DRPolicy {
+		return false
+	}
+	if d.Action != o.Action {
+		return false
+	}
+	if d.Phase != o.Phase {
+		return false
+	}
+	if d.Progression != o.Progression {
+		return false
+	}
+	if !maps.Equal(d.Conditions, o.Conditions) {
+		return false
+	}
+	return true
+}
+
+func (v *VRGSummary) Equal(o *VRGSummary) bool {
+	if v == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if v.Name != o.Name {
+		return false
+	}
+	if v.Namespace != o.Namespace {
+		return false
+	}
+	if v.Deleted != o.Deleted {
+		return false
+	}
+	if v.State != o.State {
+		return false
+	}
+	if !maps.Equal(v.Conditions, o.Conditions) {
+		return false
+	}
+	if !slices.EqualFunc(
+		v.ProtectedPVCs,
+		o.ProtectedPVCs,
+		func(a ProtectedPVCSummary, b ProtectedPVCSummary) bool {
+			return a.Equal(&b)
+		},
+	) {
+		return false
+	}
+	return true
+}
+
+func (p *ProtectedPVCSummary) Equal(o *ProtectedPVCSummary) bool {
+	if p == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if p.Name != o.Name {
+		return false
+	}
+	if p.Namespace != o.Namespace {
+		return false
+	}
+	if p.Deleted != o.Deleted {
+		return false
+	}
+	if p.Phase != o.Phase {
+		return false
+	}
+	if !maps.Equal(p.Conditions, o.Conditions) {
+		return false
+	}
+	return true
+}

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package report_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ramendr/ramenctl/pkg/report"
+	"sigs.k8s.io/yaml"
+)
+
+const (
+	modified = "modified"
+)
+
+func TestReportApplicationStatusEqual(t *testing.T) {
+	a1 := testApplicationStatus()
+	t.Run("equal to self", func(t *testing.T) {
+		a2 := a1
+		checkApplicationsEqual(t, a1, a2)
+	})
+	t.Run("equal applications", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		checkApplicationsEqual(t, a1, a2)
+	})
+}
+
+func TestReportApplicationStatusNotEqual(t *testing.T) {
+	a1 := testApplicationStatus()
+	t.Run("not equal to nil", func(t *testing.T) {
+		var a2 *report.ApplicationStatus
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc namespace", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Namespace = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc deleted", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Deleted = true
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc action", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Action = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc drPolicy", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.DRPolicy = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc phase", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Phase = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc progression", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Progression = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc conditions nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Conditions = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc conditions", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.Conditions["Protected"] = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg namespace", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.Namespace = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg deleted", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.Deleted = true
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg state", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.State = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg conditions nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.Conditions = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg conditions", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.Conditions["dataReady"] = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs namespace", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Namespace = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs phase", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Phase = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs conditions nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Conditions = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg protectedpvcs conditions", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Conditions["dataReady"] = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg name", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.Name = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg namespace", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.Namespace = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg deleted", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.Deleted = true
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg state", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.State = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg conditions nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.Conditions = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("secondary cluster vrg conditions", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.Conditions["noClusterDataConflict"] = modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+}
+
+func TestReportApplicationStatusMarshaling(t *testing.T) {
+	a1 := testApplicationStatus()
+	data, err := yaml.Marshal(a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// For inspecting the generated yaml.
+	fmt.Print(string(data))
+	a2 := &report.ApplicationStatus{}
+	if err := yaml.Unmarshal(data, a2); err != nil {
+		t.Fatal(err)
+	}
+	checkApplicationsEqual(t, a1, a2)
+}
+
+func testApplicationStatus() *report.ApplicationStatus {
+	a := &report.ApplicationStatus{
+		Hub: report.HubApplicationStatus{
+			DRPC: report.DRPCSummary{
+				Name:        "drpc-name",
+				Namespace:   "drpc-namespace",
+				DRPolicy:    "dr-policy-1m",
+				Phase:       "Deployed",
+				Progression: "completed",
+				Conditions: map[string]string{
+					"available": "ok",
+					"peerReady": "ok",
+					"protected": "ok",
+				},
+			},
+		},
+		PrimaryCluster: report.ClusterApplicationStatus{
+			Name: "dr1",
+			VRG: report.VRGSummary{
+				Name:      "vrg-name",
+				Namespace: "vrg-namespace",
+				State:     "Primary",
+				Conditions: map[string]string{
+					"dataReady":             "ok",
+					"dataProtected":         "ok",
+					"clusterDataReady":      "ok",
+					"clusterDataProtected":  "ok",
+					"kubeObjectsReady":      "ok",
+					"noClusterDataConflict": "ok",
+				},
+				ProtectedPVCs: []report.ProtectedPVCSummary{
+					{
+						Name:      "pvc-name",
+						Namespace: "app-namespace",
+						Phase:     "Bound",
+						Conditions: map[string]string{
+							"dataReady":            "ok",
+							"clusterDataProtected": "ok",
+							"dataProtected":        "ok",
+						},
+					},
+				},
+			},
+		},
+		SecondaryCluster: report.ClusterApplicationStatus{
+			Name: "dr2",
+			VRG: report.VRGSummary{
+				Name:      "vrg-name",
+				Namespace: "vrg-namespace",
+				State:     "Secondary",
+				Conditions: map[string]string{
+					"noClusterDataConflict": "ok",
+				},
+			},
+		},
+	}
+	return a
+}
+
+func checkApplicationsEqual(t *testing.T, a, b *report.ApplicationStatus) {
+	if !a.Equal(b) {
+		t.Fatalf("applications are not equal\n%s\n%s", marshal(t, a), marshal(t, b))
+	}
+}
+
+func checkApplicationsNotEqual(t *testing.T, a, b *report.ApplicationStatus) {
+	if a.Equal(b) {
+		t.Fatalf("applications are equal\n%s\n%s", marshal(t, a), marshal(t, b))
+	}
+}
+
+func marshal(t *testing.T, a any) string {
+	data, err := yaml.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -53,6 +53,7 @@ type Base struct {
 	Steps    []*Step   `json:"steps"`
 }
 
+// Application is application info.
 type Application struct {
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
@@ -61,9 +62,16 @@ type Application struct {
 // Report is used by all ramenctl commands except the test commands.
 type Report struct {
 	*Base
-	Config      *config.Config `json:"config"`
-	Application *Application   `json:"application,omitempty"`
-	Namespaces  []string       `json:"namespaces,omitempty"`
+	Config *config.Config `json:"config"`
+
+	// Namespaces is set by `validate` and `gather` commands.
+	Namespaces []string `json:"namespaces,omitempty"`
+
+	// Application is set by `validate application` and `gather application` commands.
+	Application *Application `json:"application,omitempty"`
+
+	// ApplicationStatus is set by the `validate application` commmnad.
+	ApplicationStatus *ApplicationStatus `json:"applicationStatus,omitempty"`
 }
 
 // NewBase create a new base report for ramenctl commands reports.


### PR DESCRIPTION
The validate application command will add application status on the hub
and managed clusters.

## Example application

```yaml
hub:
  drpc:
    conditions:
      available: ok
      peerReady: ok
      protected: ok
    drPolicy: dr-policy-1m
    phase: Deployed
    progression: completed
name: drpc
namespace: drpc-namespace
primary-cluster:
  name: dr1
  vrg:
    conditions:
      clusterDataProtected: ok
      clusterDataReady: ok
      dataProtected: ok
      dataReady: ok
      kubeObjectsReady: ok
      noClusterDataConflict: ok
    namespace: app-namespace
    protectedPVCs:
    - conditions:
        clusterDataProtected: ok
        dataProtected: ok
        dataReady: ok
      name: pvc1
      namespace: app-namespace
      pahse: Bound
    state: Primary
secondary-cluster:
  name: dr2
  vrg:
    conditions:
      noClusterDataConflict: ok
    namespace: app-namespace
    state: Secondary
```

Fixes #104