### PR TITLE
Report gathered namespaces in validate commands and unify namespaces handling

### DIFF
--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -205,7 +205,7 @@ func (c *Command) passed() {
 }
 
 func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]string, error) {
-	seen := map[string]struct{}{
+	set := map[string]struct{}{
 		// Gather ramen namespaces to get ramen hub and dr-cluster logs and related resources.
 		c.config.Namespaces.RamenHubNamespace:       {},
 		c.config.Namespaces.RamenDRClusterNamespace: {},
@@ -217,14 +217,10 @@ func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]s
 	}
 
 	for _, ns := range appNamespaces {
-		seen[ns] = struct{}{}
+		set[ns] = struct{}{}
 	}
 
-	namespaces := slices.Collect(maps.Keys(seen))
-	slices.Sort(namespaces)
-
-	return namespaces, nil
-
+	return slices.Sorted(maps.Keys(set)), nil
 }
 
 // Managing steps.

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -27,30 +27,36 @@ var (
 	testConfig = &config.Config{
 		Namespaces: e2econfig.K8sNamespaces,
 	}
+
 	testEnv = &types.Env{
 		Hub: &types.Cluster{Name: "hub"},
 		C1:  &types.Cluster{Name: "c1"},
 		C2:  &types.Cluster{Name: "c2"},
 	}
+
 	testApplication = &report.Application{
 		Name:      drpcName,
 		Namespace: drpcNamespace,
 	}
+
 	validateConfigFailed = &validation.Mock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return errors.New("No validate for you!")
 		},
 	}
+
 	validateConfigCanceled = &validation.Mock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return context.Canceled
 		},
 	}
+
 	inspectApplicationFailed = &validation.Mock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return nil, errors.New("No namespaces for you!")
 		},
 	}
+
 	gatherClusterFailed = &validation.Mock{
 		GatherFunc: func(ctx validation.Context, clusters []*types.Cluster, namespaces []string, outputDir string) <-chan gathering.Result {
 			results := make(chan gathering.Result, 3)

--- a/pkg/sets/sets.go
+++ b/pkg/sets/sets.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package sets
+
+import (
+	"maps"
+	"slices"
+)
+
+// Sorted returns sorted set of values removing duplicates.
+func Sorted(values []string) []string {
+	set := map[string]struct{}{}
+	for _, v := range values {
+		set[v] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(set))
+}

--- a/pkg/validate/application.go
+++ b/pkg/validate/application.go
@@ -37,6 +37,8 @@ func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
 		return c.finishStep()
 	}
 
+	c.report.Namespaces = namespaces
+
 	if !c.gatherNamespaces(namespaces) {
 		return c.finishStep()
 	}

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -27,6 +27,8 @@ func (c *Command) validateClusters() bool {
 	c.startStep("validate clusters")
 
 	namespaces := c.clustersNamespacesToGather()
+	c.report.Namespaces = namespaces
+
 	if !c.gatherNamespaces(namespaces) {
 		return c.finishStep()
 	}

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -4,11 +4,9 @@
 package validate
 
 import (
-	"maps"
-	"slices"
-
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/sets"
 )
 
 func (c *Command) Clusters() error {
@@ -42,14 +40,10 @@ func (c *Command) validateClusters() bool {
 }
 
 func (c *Command) clustersNamespacesToGather() []string {
-	seen := map[string]struct{}{
-		c.config.Namespaces.RamenHubNamespace:       {},
-		c.config.Namespaces.RamenDRClusterNamespace: {},
-	}
-
-	namespaces := slices.Collect(maps.Keys(seen))
-	slices.Sort(namespaces)
-	return namespaces
+	return sets.Sorted([]string{
+		c.config.Namespaces.RamenHubNamespace,
+		c.config.Namespaces.RamenDRClusterNamespace,
+	})
 }
 
 func (c *Command) validateGatheredClusterData() bool {


### PR DESCRIPTION
Like `gather application` command, `validate application` and `validated clusters` commands report now the gathered namespaces.
    
Add set.Sorted() helper to create sorted set of values, needed when building namespaces list to gather and for testing the gathered namespaces. We used this now in many commands and tests.

In cases when we must build sets dynamically we create a sorted slices using slices.Sorted().