### PR TITLE
deps: Update kubectl-gather to 0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ toolchain go1.24.5
 
 require (
 	github.com/go-logr/zapr v1.3.0
-	github.com/nirs/kubectl-gather v0.9.0
+	github.com/nirs/kubectl-gather v0.10.0
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
 	github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94
 	github.com/spf13/cobra v1.9.1

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirs/kubectl-gather v0.9.0 h1:GSrkd9n85z3Zb0o3ji1NW+TtSAdR8myq2SV+MQbQpek=
-github.com/nirs/kubectl-gather v0.9.0/go.mod h1:i6GaOi/I6imJ+8U8NLoEsp9Ukn/4kzXZx2ei6Af8MeI=
+github.com/nirs/kubectl-gather v0.10.0 h1:cjfiiA8EVnv88EubSJ2+Bekd7SgNXnrv3AlU2tATF4Y=
+github.com/nirs/kubectl-gather v0.10.0/go.mod h1:i6GaOi/I6imJ+8U8NLoEsp9Ukn/4kzXZx2ei6Af8MeI=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
This version introduced --cluster for for gathering only cluster scoped resources. Which will be used for validate cluster command.