### PR TITLE
Gather cluster scoped resources to validate clusters

### DIFF
--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -72,7 +72,11 @@ var (
 	}
 
 	gatherClusterFailed = &validation.Mock{
-		GatherFunc: func(ctx validation.Context, clusters []*types.Cluster, namespaces []string, outputDir string) <-chan gathering.Result {
+		GatherFunc: func(
+			ctx validation.Context,
+			clusters []*types.Cluster,
+			options gathering.Options,
+		) <-chan gathering.Result {
 			results := make(chan gathering.Result, 3)
 			for _, cluster := range clusters {
 				if cluster.Name == "hub" {

--- a/pkg/gathering/gathering.go
+++ b/pkg/gathering/gathering.go
@@ -24,6 +24,7 @@ type Result struct {
 
 type Options struct {
 	Namespaces []string
+	Cluster    bool
 	OutputDir  string
 }
 
@@ -80,6 +81,7 @@ func gatherCluster(ctx Context, cluster *types.Cluster, options Options) error {
 	gatherOptions := gather.Options{
 		Kubeconfig: cluster.Kubeconfig,
 		Namespaces: options.Namespaces,
+		Cluster:    options.Cluster,
 		Log:        log.Named(cluster.Name),
 	}
 

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/logging"
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/testing"
@@ -200,14 +201,16 @@ func (c *Command) gatherData() {
 	console.Step("Gather data")
 	env := c.Env()
 	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
-	namespaces := c.namespacesToGather()
-	outputDir := filepath.Join(c.command.OutputDir(), c.command.Name()+".gather")
+	options := gathering.Options{
+		Namespaces: c.namespacesToGather(),
+		OutputDir:  filepath.Join(c.command.OutputDir(), c.command.Name()+".gather"),
+	}
 	start := time.Now()
 
-	c.Logger().Infof("Gathering namespaces %q from clusters %q",
-		namespaces, logging.ClusterNames(clusters))
+	c.Logger().Infof("Gathering from clusters %q with options %+v",
+		logging.ClusterNames(clusters), options)
 
-	for r := range c.backend.Gather(c, clusters, namespaces, outputDir) {
+	for r := range c.backend.Gather(c, clusters, options) {
 		if r.Err != nil {
 			msg := fmt.Sprintf("Failed to gather data from cluster %q", r.Name)
 			console.Error(msg)

--- a/pkg/testing/backend.go
+++ b/pkg/testing/backend.go
@@ -59,8 +59,7 @@ func (Backend) Purge(ctx types.TestContext) error {
 func (b Backend) Gather(
 	ctx types.Context,
 	clusters []*types.Cluster,
-	namespaces []string,
-	outputDir string,
+	options gathering.Options,
 ) <-chan gathering.Result {
-	return gathering.Namespaces(ctx, clusters, namespaces, outputDir)
+	return gathering.Namespaces(ctx, clusters, options)
 }

--- a/pkg/testing/backend.go
+++ b/pkg/testing/backend.go
@@ -62,5 +62,5 @@ func (b Backend) Gather(
 	namespaces []string,
 	outputDir string,
 ) <-chan gathering.Result {
-	return gathering.Namespaces(clusters, namespaces, outputDir, ctx.Logger())
+	return gathering.Namespaces(ctx, clusters, namespaces, outputDir)
 }

--- a/pkg/testing/mock.go
+++ b/pkg/testing/mock.go
@@ -30,7 +30,7 @@ type Mock struct {
 	PurgeFunc     TestContextFunc
 
 	// Handling failures.
-	GatherFunc func(ctx types.Context, clsuters []*types.Cluster, namespaces []string, outputDir string) <-chan gathering.Result
+	GatherFunc func(ctx types.Context, clsuters []*types.Cluster, options gathering.Options) <-chan gathering.Result
 }
 
 var _ Testing = &Mock{}
@@ -108,11 +108,10 @@ func (m *Mock) Purge(ctx types.TestContext) error {
 func (m *Mock) Gather(
 	ctx types.Context,
 	clusters []*types.Cluster,
-	namespaces []string,
-	outputDir string,
+	options gathering.Options,
 ) <-chan gathering.Result {
 	if m.GatherFunc != nil {
-		return m.GatherFunc(ctx, clusters, namespaces, outputDir)
+		return m.GatherFunc(ctx, clusters, options)
 	}
 
 	results := make(chan gathering.Result, len(clusters))

--- a/pkg/testing/testing.go
+++ b/pkg/testing/testing.go
@@ -29,7 +29,6 @@ type Testing interface {
 	Gather(
 		ctx types.Context,
 		clusters []*types.Cluster,
-		namespaces []string,
-		outputDir string,
+		options gathering.Options,
 	) <-chan gathering.Result
 }

--- a/pkg/validate/application.go
+++ b/pkg/validate/application.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"
 )
@@ -39,7 +40,11 @@ func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
 
 	c.report.Namespaces = namespaces
 
-	if !c.gatherNamespaces(namespaces) {
+	options := gathering.Options{
+		Namespaces: namespaces,
+		OutputDir:  c.dataDir(),
+	}
+	if !c.gatherNamespaces(options) {
 		return c.finishStep()
 	}
 

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -5,6 +5,7 @@ package validate
 
 import (
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/sets"
 )
@@ -27,7 +28,11 @@ func (c *Command) validateClusters() bool {
 	namespaces := c.clustersNamespacesToGather()
 	c.report.Namespaces = namespaces
 
-	if !c.gatherNamespaces(namespaces) {
+	options := gathering.Options{
+		Namespaces: namespaces,
+		OutputDir:  c.dataDir(),
+	}
+	if !c.gatherNamespaces(options) {
 		return c.finishStep()
 	}
 

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -30,6 +30,7 @@ func (c *Command) validateClusters() bool {
 
 	options := gathering.Options{
 		Namespaces: namespaces,
+		Cluster:    true,
 		OutputDir:  c.dataDir(),
 	}
 	if !c.gatherNamespaces(options) {

--- a/pkg/validate/command.go
+++ b/pkg/validate/command.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/logging"
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"
@@ -99,15 +100,15 @@ func (c *Command) validateConfig() bool {
 
 // Gathering data.
 
-func (c *Command) gatherNamespaces(namespaces []string) bool {
+func (c *Command) gatherNamespaces(options gathering.Options) bool {
 	start := time.Now()
 	env := c.Env()
 	clusters := []*types.Cluster{env.Hub, env.C1, env.C2}
 
-	c.Logger().Infof("Gathering namespaces %q from clusters %q",
-		namespaces, logging.ClusterNames(clusters))
+	c.Logger().Infof("Gathering from clusters %q with options %+v",
+		logging.ClusterNames(clusters), options)
 
-	for r := range c.backend.Gather(c, clusters, namespaces, c.dataDir()) {
+	for r := range c.backend.Gather(c, clusters, options) {
 		step := &report.Step{Name: fmt.Sprintf("gather %q", r.Name), Duration: r.Duration}
 		if r.Err != nil {
 			msg := fmt.Sprintf("Failed to gather data from cluster %q", r.Name)

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -97,8 +97,7 @@ var (
 		GatherFunc: func(
 			ctx validation.Context,
 			clusters []*types.Cluster,
-			namespaces []string,
-			outputDir string,
+			options gathering.Options,
 		) <-chan gathering.Result {
 			results := make(chan gathering.Result, 3)
 			for _, cluster := range clusters {

--- a/pkg/validation/backend.go
+++ b/pkg/validation/backend.go
@@ -36,8 +36,7 @@ func (b Backend) ApplicationNamespaces(
 func (b Backend) Gather(
 	ctx Context,
 	clusters []*types.Cluster,
-	namespaces []string,
-	outputDir string,
+	options gathering.Options,
 ) <-chan gathering.Result {
-	return gathering.Namespaces(ctx, clusters, namespaces, outputDir)
+	return gathering.Namespaces(ctx, clusters, options)
 }

--- a/pkg/validation/backend.go
+++ b/pkg/validation/backend.go
@@ -39,5 +39,5 @@ func (b Backend) Gather(
 	namespaces []string,
 	outputDir string,
 ) <-chan gathering.Result {
-	return gathering.Namespaces(clusters, namespaces, outputDir, ctx.Logger())
+	return gathering.Namespaces(ctx, clusters, namespaces, outputDir)
 }

--- a/pkg/validation/mock.go
+++ b/pkg/validation/mock.go
@@ -15,7 +15,7 @@ type ContextFunc func(Context) error
 type Mock struct {
 	ValidateFunc              ContextFunc
 	ApplicationNamespacesFunc func(ctx Context, drpcName, drpcNamespace string) ([]string, error)
-	GatherFunc                func(ctx Context, clsuters []*types.Cluster, namespaces []string, outputDir string) <-chan gathering.Result
+	GatherFunc                func(ctx Context, clsuters []*types.Cluster, options gathering.Options) <-chan gathering.Result
 }
 
 var _ Validation = &Mock{}
@@ -40,11 +40,10 @@ func (m *Mock) ApplicationNamespaces(
 func (m *Mock) Gather(
 	ctx Context,
 	clusters []*types.Cluster,
-	namespaces []string,
-	outputDir string,
+	options gathering.Options,
 ) <-chan gathering.Result {
 	if m.GatherFunc != nil {
-		return m.GatherFunc(ctx, clusters, namespaces, outputDir)
+		return m.GatherFunc(ctx, clusters, options)
 	}
 
 	results := make(chan gathering.Result, len(clusters))

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -28,7 +28,6 @@ type Validation interface {
 	Gather(
 		ctx Context,
 		clusters []*types.Cluster,
-		namespaces []string,
-		outputDir string,
+		options gathering.Options,
 	) <-chan gathering.Result
 }


### PR DESCRIPTION
This PR address:

- adds Context interface with Logger() and Context() methods for gathering operations
- refactors by replacing individual parameters (namespaces, outputDir) with gathering.Options.
- add support for gather cluster scoped resources which will be used to validate clusters

Testing: 

```
./ramenctl validate clusters -o val
⭐ Using config "config.yaml"
⭐ Using report "val"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Clusters validated

✅ Validation completed

Gathers cluster scoped resources:

$ tree -L 4 val
val
├── validate-clusters.data
│   ├── dr1
│   │   ├── cluster
│   │   │   ├── apiextensions.k8s.io
│   │   │   ├── apiregistration.k8s.io
│   │   │   ├── certificates.k8s.io
│   │   │   ├── cluster.open-cluster-management.io
│   │   │   ├── flowcontrol.apiserver.k8s.io
│   │   │   ├── namespaces
│   │   │   ├── networking.k8s.io
│   │   │   ├── nodes
│   │   │   ├── operator.open-cluster-management.io
│   │   │   ├── operators.coreos.com
│   │   │   ├── persistentvolumes
│   │   │   ├── ramendr.openshift.io
│   │   │   ├── rbac.authorization.k8s.io
│   │   │   ├── replication.storage.openshift.io
│   │   │   ├── scheduling.k8s.io
│   │   │   ├── snapshot.storage.k8s.io
│   │   │   ├── storage.k8s.io
│   │   │   ├── submariner.io
│   │   │   └── work.open-cluster-management.io
│   │   └── namespaces
│   │       └── ramen-system
│   ├── dr2
│   │   ├── cluster
│   │   │   ├── apiextensions.k8s.io
│   │   │   ├── apiregistration.k8s.io
│   │   │   ├── certificates.k8s.io
│   │   │   ├── cluster.open-cluster-management.io
│   │   │   ├── flowcontrol.apiserver.k8s.io
│   │   │   ├── namespaces
│   │   │   ├── networking.k8s.io
│   │   │   ├── nodes
│   │   │   ├── operator.open-cluster-management.io
│   │   │   ├── operators.coreos.com
│   │   │   ├── persistentvolumes
│   │   │   ├── ramendr.openshift.io
│   │   │   ├── rbac.authorization.k8s.io
│   │   │   ├── replication.storage.openshift.io
│   │   │   ├── scheduling.k8s.io
│   │   │   ├── snapshot.storage.k8s.io
│   │   │   ├── storage.k8s.io
│   │   │   ├── submariner.io
│   │   │   └── work.open-cluster-management.io
│   │   └── namespaces
│   │       └── ramen-system
│   └── hub
│       ├── cluster
│       │   ├── addon.open-cluster-management.io
│       │   ├── admissionregistration.k8s.io
│       │   ├── apiextensions.k8s.io
│       │   ├── apiregistration.k8s.io
│       │   ├── certificates.k8s.io
│       │   ├── cluster.open-cluster-management.io
│       │   ├── flowcontrol.apiserver.k8s.io
│       │   ├── namespaces
│       │   ├── networking.k8s.io
│       │   ├── nodes
│       │   ├── operator.open-cluster-management.io
│       │   ├── operators.coreos.com
│       │   ├── ramendr.openshift.io
│       │   ├── rbac.authorization.k8s.io
│       │   ├── scheduling.k8s.io
│       │   └── storage.k8s.io
│       └── namespaces
│           └── ramen-system
├── validate-clusters.log
└── validate-clusters.yaml

68 directories, 2 files

Updated Logs:

2025-08-06T16:15:04.475+0530	INFO	validate/command.go:113	Gathering namespaces ["ramen-system"] from clusters ["hub" "dr1" "dr2"]
2025-08-06T16:15:04.475+0530	INFO	validate/command.go:117	Gathering cluster scoped resources from clusters ["hub" "dr1" "dr2"]
2025-08-06T16:15:04.475+0530	INFO	gathering/gathering.go:71	Gathering from cluster "hub"
2025-08-06T16:15:04.475+0530	INFO	gathering/gathering.go:71	Gathering from cluster "dr1"
2025-08-06T16:15:04.475+0530	INFO	gathering/gathering.go:71	Gathering from cluster "dr2"
```

Fixes #162 
Fixes #163 