### PR TITLE
validate: Add gathered data to tests

### DIFF
--- a/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/dr1/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
+++ b/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/dr1/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
@@ -1,0 +1,201 @@
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: VolumeReplicationGroup
+metadata:
+  annotations:
+    drplacementcontrol.ramendr.openshift.io/destination-cluster: dr1
+    drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: ""
+    drplacementcontrol.ramendr.openshift.io/drpc-uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
+    drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: ""
+  creationTimestamp: "2025-07-27T20:41:31Z"
+  finalizers:
+  - volumereplicationgroups.ramendr.openshift.io/vrg-protection
+  generation: 1
+  labels:
+    ramendr.openshift.io/created-by-ramen: "true"
+  managedFields:
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:finalizers:
+          .: {}
+          v:"volumereplicationgroups.ramendr.openshift.io/vrg-protection": {}
+    manager: manager
+    operation: Update
+    time: "2025-07-27T20:41:31Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:drplacementcontrol.ramendr.openshift.io/destination-cluster: {}
+          f:drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: {}
+          f:drplacementcontrol.ramendr.openshift.io/drpc-uid: {}
+          f:drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: {}
+        f:labels:
+          .: {}
+          f:ramendr.openshift.io/created-by-ramen: {}
+        f:ownerReferences:
+          .: {}
+          k:{"uid":"c94fea0f-df76-41ae-9760-c8ad82ff05db"}: {}
+      f:spec:
+        .: {}
+        f:async:
+          .: {}
+          f:peerClasses: {}
+          f:replicationClassSelector: {}
+          f:schedulingInterval: {}
+          f:volumeGroupSnapshotClassSelector: {}
+          f:volumeSnapshotClassSelector: {}
+        f:pvcSelector: {}
+        f:replicationState: {}
+        f:s3Profiles: {}
+        f:volSync: {}
+    manager: work-agent
+    operation: Update
+    time: "2025-07-27T20:41:31Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        .: {}
+        f:conditions: {}
+        f:kubeObjectProtection: {}
+        f:lastGroupSyncBytes: {}
+        f:lastGroupSyncDuration: {}
+        f:lastGroupSyncTime: {}
+        f:lastUpdateTime: {}
+        f:observedGeneration: {}
+        f:protectedPVCs: {}
+        f:state: {}
+    manager: manager
+    operation: Update
+    subresource: status
+    time: "2025-07-29T17:23:40Z"
+  name: appset-deploy-rbd
+  namespace: e2e-appset-deploy-rbd
+  ownerReferences:
+  - apiVersion: work.open-cluster-management.io/v1
+    kind: AppliedManifestWork
+    name: 4fa096b11b4793f1f3c870c9ef0c7c4522a0eac36aa3d97077f9d6c247179787-appset-deploy-rbd-e2e-appset-deploy-rbd-vrg-mw
+    uid: c94fea0f-df76-41ae-9760-c8ad82ff05db
+  resourceVersion: "77146"
+  uid: 2ab631fe-deac-4875-aaf8-7c04aaafe57c
+spec:
+  async:
+    peerClasses:
+    - clusterIDs:
+      - 44c2d38b-4e97-4499-97d1-ddf214cfaa15
+      - 7854b457-d26d-489a-8ff1-c3db14c4811d
+      replicationID: rook-ceph-replication-1
+      storageClassName: rook-ceph-block
+      storageID:
+      - rook-ceph-block-dr1-1
+      - rook-ceph-block-dr2-1
+    - clusterIDs:
+      - 44c2d38b-4e97-4499-97d1-ddf214cfaa15
+      - 7854b457-d26d-489a-8ff1-c3db14c4811d
+      storageClassName: rook-cephfs-fs1
+      storageID:
+      - rook-cephfs-fs1-dr1-1
+      - rook-cephfs-fs1-dr2-1
+    replicationClassSelector: {}
+    schedulingInterval: 1m
+    volumeGroupSnapshotClassSelector: {}
+    volumeSnapshotClassSelector: {}
+  pvcSelector:
+    matchLabels:
+      appname: busybox
+  replicationState: primary
+  s3Profiles:
+  - minio-on-dr1
+  - minio-on-dr2
+  volSync: {}
+status:
+  conditions:
+  - lastTransitionTime: "2025-07-27T20:41:32Z"
+    message: PVCs in the VolumeReplicationGroup are ready for use
+    observedGeneration: 1
+    reason: Ready
+    status: "True"
+    type: DataReady
+  - lastTransitionTime: "2025-07-27T20:41:32Z"
+    message: VolumeReplicationGroup is replicating
+    observedGeneration: 1
+    reason: Replicating
+    status: "False"
+    type: DataProtected
+  - lastTransitionTime: "2025-07-27T20:41:31Z"
+    message: Nothing to restore
+    observedGeneration: 1
+    reason: Restored
+    status: "True"
+    type: ClusterDataReady
+  - lastTransitionTime: "2025-07-27T20:41:32Z"
+    message: Cluster data of all PVs are protected. VRG object protected
+    observedGeneration: 1
+    reason: Uploaded
+    status: "True"
+    type: ClusterDataProtected
+  - lastTransitionTime: "2025-07-27T20:41:32Z"
+    message: Kube objects restored
+    observedGeneration: 1
+    reason: KubeObjectsRestored
+    status: "True"
+    type: KubeObjectsReady
+  - lastTransitionTime: "2025-07-27T20:41:32Z"
+    message: No resource conflict
+    observedGeneration: 1
+    reason: ClusterDataConflictPrimary
+    status: "True"
+    type: NoClusterDataConflict
+  kubeObjectProtection: {}
+  lastGroupSyncBytes: 81920
+  lastGroupSyncDuration: 0s
+  lastGroupSyncTime: "2025-07-29T17:23:00Z"
+  lastUpdateTime: "2025-07-29T17:23:40Z"
+  observedGeneration: 1
+  protectedPVCs:
+  - accessModes:
+    - ReadWriteOnce
+    conditions:
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: PVC in the VolumeReplicationGroup is ready for use
+      observedGeneration: 1
+      reason: Ready
+      status: "True"
+      type: DataReady
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: PV cluster data already protected for PVC busybox-pvc
+      observedGeneration: 1
+      reason: Uploaded
+      status: "True"
+      type: ClusterDataProtected
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: PVC in the VolumeReplicationGroup is ready for use
+      observedGeneration: 1
+      reason: Replicating
+      status: "False"
+      type: DataProtected
+    csiProvisioner: rook-ceph.rbd.csi.ceph.com
+    labels:
+      app.kubernetes.io/instance: appset-deploy-rbd-dr1
+      appname: busybox
+      ramendr.openshift.io/owner-name: appset-deploy-rbd
+      ramendr.openshift.io/owner-namespace-name: e2e-appset-deploy-rbd
+    lastSyncBytes: 81920
+    lastSyncDuration: 0s
+    lastSyncTime: "2025-07-29T17:23:00Z"
+    name: busybox-pvc
+    namespace: e2e-appset-deploy-rbd
+    replicationID:
+      id: rook-ceph-replication-1
+    resources:
+      requests:
+        storage: 1Gi
+    storageClassName: rook-ceph-block
+    storageID:
+      id: rook-ceph-block-dr1-1
+    volumeMode: Filesystem
+  state: Primary

--- a/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/dr2/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
+++ b/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/dr2/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
@@ -1,0 +1,155 @@
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: VolumeReplicationGroup
+metadata:
+  annotations:
+    drplacementcontrol.ramendr.openshift.io/destination-cluster: dr2
+    drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: ""
+    drplacementcontrol.ramendr.openshift.io/drpc-uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
+    drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: ""
+  creationTimestamp: "2025-07-27T20:42:01Z"
+  finalizers:
+  - volumereplicationgroups.ramendr.openshift.io/vrg-protection
+  generation: 1
+  labels:
+    ramendr.openshift.io/created-by-ramen: "true"
+  managedFields:
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:finalizers:
+          .: {}
+          v:"volumereplicationgroups.ramendr.openshift.io/vrg-protection": {}
+    manager: manager
+    operation: Update
+    time: "2025-07-27T20:42:01Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:drplacementcontrol.ramendr.openshift.io/destination-cluster: {}
+          f:drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: {}
+          f:drplacementcontrol.ramendr.openshift.io/drpc-uid: {}
+          f:drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: {}
+        f:labels:
+          .: {}
+          f:ramendr.openshift.io/created-by-ramen: {}
+        f:ownerReferences:
+          .: {}
+          k:{"uid":"3e925b39-2d09-4b7f-b718-d00107c1c293"}: {}
+      f:spec:
+        .: {}
+        f:async:
+          .: {}
+          f:peerClasses: {}
+          f:replicationClassSelector: {}
+          f:schedulingInterval: {}
+          f:volumeGroupSnapshotClassSelector: {}
+          f:volumeSnapshotClassSelector: {}
+        f:pvcSelector: {}
+        f:replicationState: {}
+        f:s3Profiles: {}
+        f:volSync: {}
+    manager: work-agent
+    operation: Update
+    time: "2025-07-27T20:42:01Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        .: {}
+        f:conditions: {}
+        f:kubeObjectProtection: {}
+        f:lastUpdateTime: {}
+        f:observedGeneration: {}
+        f:state: {}
+    manager: manager
+    operation: Update
+    subresource: status
+    time: "2025-07-27T20:42:02Z"
+  name: appset-deploy-rbd
+  namespace: e2e-appset-deploy-rbd
+  ownerReferences:
+  - apiVersion: work.open-cluster-management.io/v1
+    kind: AppliedManifestWork
+    name: 4fa096b11b4793f1f3c870c9ef0c7c4522a0eac36aa3d97077f9d6c247179787-appset-deploy-rbd-e2e-appset-deploy-rbd-vrg-mw
+    uid: 3e925b39-2d09-4b7f-b718-d00107c1c293
+  resourceVersion: "23388"
+  uid: 77874d08-6d29-4ea5-9224-cb979cc8cbf3
+spec:
+  async:
+    peerClasses:
+    - clusterIDs:
+      - 44c2d38b-4e97-4499-97d1-ddf214cfaa15
+      - 7854b457-d26d-489a-8ff1-c3db14c4811d
+      replicationID: rook-ceph-replication-1
+      storageClassName: rook-ceph-block
+      storageID:
+      - rook-ceph-block-dr1-1
+      - rook-ceph-block-dr2-1
+    - clusterIDs:
+      - 44c2d38b-4e97-4499-97d1-ddf214cfaa15
+      - 7854b457-d26d-489a-8ff1-c3db14c4811d
+      storageClassName: rook-cephfs-fs1
+      storageID:
+      - rook-cephfs-fs1-dr1-1
+      - rook-cephfs-fs1-dr2-1
+    replicationClassSelector: {}
+    schedulingInterval: 1m
+    volumeGroupSnapshotClassSelector: {}
+    volumeSnapshotClassSelector: {}
+  pvcSelector:
+    matchLabels:
+      appname: busybox
+  replicationState: secondary
+  s3Profiles:
+  - minio-on-dr1
+  - minio-on-dr2
+  volSync: {}
+status:
+  conditions:
+  - lastTransitionTime: "2025-07-27T20:42:02Z"
+    message: No PVCs are protected using Volsync scheme. PVC protection as secondary
+      is complete, or no PVCs needed protection using VolumeReplication scheme
+    observedGeneration: 1
+    reason: Unused
+    status: "True"
+    type: DataReady
+  - lastTransitionTime: "2025-07-27T20:42:02Z"
+    message: No PVCs are protected using Volsync scheme. PVC protection as secondary
+      is complete, or no PVCs needed protection using VolumeReplication scheme
+    observedGeneration: 1
+    reason: Unused
+    status: "True"
+    type: DataProtected
+  - lastTransitionTime: "2025-07-27T20:42:01Z"
+    message: PV and PVC restore skipped as Secondary
+    observedGeneration: 1
+    reason: Unused
+    status: "True"
+    type: ClusterDataReady
+  - lastTransitionTime: "2025-07-27T20:42:02Z"
+    message: No PVCs are protected using Volsync scheme. Cluster data is not protected
+      as Secondary
+    observedGeneration: 1
+    reason: Unused
+    status: "True"
+    type: ClusterDataProtected
+  - lastTransitionTime: "2025-07-27T20:42:01Z"
+    message: k8s resource restore skipped as Secondary
+    observedGeneration: 1
+    reason: Unused
+    status: "True"
+    type: KubeObjectsReady
+  - lastTransitionTime: "2025-07-27T20:42:02Z"
+    message: No resource conflict
+    observedGeneration: 1
+    reason: ClusterDataConflictSecondary
+    status: "True"
+    type: NoClusterDataConflict
+  kubeObjectProtection: {}
+  lastUpdateTime: "2025-07-27T20:42:02Z"
+  observedGeneration: 1
+  state: Secondary

--- a/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
+++ b/pkg/validate/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
@@ -1,0 +1,184 @@
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPlacementControl
+metadata:
+  annotations:
+    drplacementcontrol.ramendr.openshift.io/app-namespace: e2e-appset-deploy-rbd
+    drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster: dr1
+  creationTimestamp: "2025-07-27T20:41:31Z"
+  finalizers:
+  - drpc.ramendr.openshift.io/finalizer
+  generation: 1
+  labels:
+    app: appset-deploy-rbd
+    cluster.open-cluster-management.io/backup: ramen
+  managedFields:
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:drplacementcontrol.ramendr.openshift.io/app-namespace: {}
+          f:drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster: {}
+        f:finalizers:
+          .: {}
+          v:"drpc.ramendr.openshift.io/finalizer": {}
+        f:labels:
+          f:cluster.open-cluster-management.io/backup: {}
+        f:ownerReferences:
+          .: {}
+          k:{"uid":"4eeecce4-e2d4-4638-a2a1-88e07148f27d"}: {}
+    manager: manager
+    operation: Update
+    time: "2025-07-27T20:41:31Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:labels:
+          .: {}
+          f:app: {}
+      f:spec:
+        .: {}
+        f:drPolicyRef: {}
+        f:placementRef: {}
+        f:preferredCluster: {}
+        f:pvcSelector: {}
+    manager: ramen-e2e
+    operation: Update
+    time: "2025-07-27T20:41:31Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        .: {}
+        f:actionDuration: {}
+        f:actionStartTime: {}
+        f:conditions: {}
+        f:lastGroupSyncBytes: {}
+        f:lastGroupSyncDuration: {}
+        f:lastGroupSyncTime: {}
+        f:lastUpdateTime: {}
+        f:observedGeneration: {}
+        f:phase: {}
+        f:preferredDecision:
+          .: {}
+          f:clusterName: {}
+          f:clusterNamespace: {}
+        f:progression: {}
+        f:resourceConditions:
+          .: {}
+          f:conditions: {}
+          f:resourceMeta:
+            .: {}
+            f:generation: {}
+            f:kind: {}
+            f:name: {}
+            f:namespace: {}
+            f:protectedpvcs: {}
+            f:resourceVersion: {}
+    manager: manager
+    operation: Update
+    subresource: status
+    time: "2025-07-29T17:23:46Z"
+  name: appset-deploy-rbd
+  namespace: argocd
+  ownerReferences:
+  - apiVersion: cluster.open-cluster-management.io/v1beta1
+    blockOwnerDeletion: true
+    controller: true
+    kind: Placement
+    name: appset-deploy-rbd
+    uid: 4eeecce4-e2d4-4638-a2a1-88e07148f27d
+  resourceVersion: "51679"
+  uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
+spec:
+  drPolicyRef:
+    name: dr-policy
+  placementRef:
+    kind: Placement
+    name: appset-deploy-rbd
+    namespace: argocd
+  preferredCluster: dr1
+  pvcSelector:
+    matchLabels:
+      appname: busybox
+status:
+  actionDuration: 21.070983011s
+  actionStartTime: "2025-07-27T20:41:40Z"
+  conditions:
+  - lastTransitionTime: "2025-07-27T20:41:31Z"
+    message: Initial deployment completed
+    observedGeneration: 1
+    reason: Deployed
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2025-07-27T20:41:31Z"
+    message: Ready
+    observedGeneration: 1
+    reason: Success
+    status: "True"
+    type: PeerReady
+  - lastTransitionTime: "2025-07-27T20:43:01Z"
+    message: VolumeReplicationGroup (e2e-appset-deploy-rbd/appset-deploy-rbd) on cluster
+      dr1 is protecting required resources and data
+    observedGeneration: 1
+    reason: Protected
+    status: "True"
+    type: Protected
+  lastGroupSyncBytes: 81920
+  lastGroupSyncDuration: 0s
+  lastGroupSyncTime: "2025-07-29T17:23:00Z"
+  lastUpdateTime: "2025-07-29T17:23:46Z"
+  observedGeneration: 1
+  phase: Deployed
+  preferredDecision:
+    clusterName: dr1
+    clusterNamespace: dr1
+  progression: Completed
+  resourceConditions:
+    conditions:
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: PVCs in the VolumeReplicationGroup are ready for use
+      observedGeneration: 1
+      reason: Ready
+      status: "True"
+      type: DataReady
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: VolumeReplicationGroup is replicating
+      observedGeneration: 1
+      reason: Replicating
+      status: "False"
+      type: DataProtected
+    - lastTransitionTime: "2025-07-27T20:41:31Z"
+      message: Nothing to restore
+      observedGeneration: 1
+      reason: Restored
+      status: "True"
+      type: ClusterDataReady
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: Cluster data of all PVs are protected. VRG object protected
+      observedGeneration: 1
+      reason: Uploaded
+      status: "True"
+      type: ClusterDataProtected
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: Kube objects restored
+      observedGeneration: 1
+      reason: KubeObjectsRestored
+      status: "True"
+      type: KubeObjectsReady
+    - lastTransitionTime: "2025-07-27T20:41:32Z"
+      message: No resource conflict
+      observedGeneration: 1
+      reason: ClusterDataConflictPrimary
+      status: "True"
+      type: NoClusterDataConflict
+    resourceMeta:
+      generation: 1
+      kind: VolumeReplicationGroup
+      name: appset-deploy-rbd
+      namespace: e2e-appset-deploy-rbd
+      protectedpvcs:
+      - busybox-pvc
+      resourceVersion: "77146"


### PR DESCRIPTION
We test using mock backed so nothing is gathered, but need gathered data for testing validation. Add partial gathered data from ramen testing environment from appset-deploy-rbd test. We may want to test more applications later.

The test data is stored at `testdata/appset-deploy-rbd` so we can easily add more applications or cluster data for validating cluster tests.

The test constants and variables were updated to to match the test data. To add more application we will need to use different names for each applications.