### PR TITLE
report: move marshal() test helper to helpers_test.go

### DIFF
--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -337,11 +337,3 @@ func checkApplicationsNotEqual(t *testing.T, a, b *report.ApplicationStatus) {
 		t.Fatalf("applications are equal\n%s\n%s", marshal(t, a), marshal(t, b))
 	}
 }
-
-func marshal(t *testing.T, a any) string {
-	data, err := yaml.Marshal(a)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return string(data)
-}

--- a/pkg/report/helpers_test.go
+++ b/pkg/report/helpers_test.go
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package report_test
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func marshal(t *testing.T, a any) string {
+	data, err := yaml.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
Relocated marshal() from application_test.go to helpers_test.go so it can be reused by multiple test files.