### PR TITLE
validate: Handle missing or deleted resources

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -20,7 +20,7 @@ type ProtectedPVCSummary struct {
 	Name        string               `json:"name"`
 	Namespace   string               `json:"namespace"`
 	Replication ReplicationType      `json:"replication,omitempty"`
-	Deleted     bool                 `json:"deleted,omitempty"`
+	Deleted     ValidatedBool        `json:"deleted"`
 	Phase       string               `json:"phase,omitempty"`
 	Conditions  []ValidatedCondition `json:"conditions,omitempty"`
 }
@@ -29,7 +29,7 @@ type ProtectedPVCSummary struct {
 type DRPCSummary struct {
 	Name        string               `json:"name"`
 	Namespace   string               `json:"namespace"`
-	Deleted     bool                 `json:"deleted,omitempty"`
+	Deleted     ValidatedBool        `json:"deleted"`
 	DRPolicy    string               `json:"drPolicy"`
 	Action      string               `json:"action,omitempty"`
 	Phase       string               `json:"phase"`
@@ -41,8 +41,8 @@ type DRPCSummary struct {
 type VRGSummary struct {
 	Name          string                `json:"name"`
 	Namespace     string                `json:"namespace"`
-	Deleted       bool                  `json:"deleted,omitempty"`
-	State         string                `json:"state"`
+	Deleted       ValidatedBool         `json:"deleted"`
+	State         string                `json:"state,omitempty"`
 	Conditions    []ValidatedCondition  `json:"conditions,omitempty"`
 	ProtectedPVCs []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
 }

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -42,7 +42,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("hub drpc deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.Hub.DRPC.Deleted = true
+		a2.Hub.DRPC.Deleted = report.ValidatedBool{
+			Value: true,
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "DRPC does not exist",
+			},
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("hub drpc action", func(t *testing.T) {
@@ -92,7 +98,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("primary cluster vrg deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.PrimaryCluster.VRG.Deleted = true
+		a2.PrimaryCluster.VRG.Deleted = report.ValidatedBool{
+			Value: true,
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "VRG does not exist",
+			},
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("primary cluster vrg state", func(t *testing.T) {
@@ -130,6 +142,17 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Replication = report.Volsync
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("primary cluster vrg protectedpvcs deleted", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Deleted = report.ValidatedBool{
+			Value: true,
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "PVC does not exist",
+			},
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("primary cluster vrg protectedpvcs phase", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Phase = modified
@@ -162,7 +185,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("secondary cluster vrg deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.SecondaryCluster.VRG.Deleted = true
+		a2.SecondaryCluster.VRG.Deleted = report.ValidatedBool{
+			Value: true,
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "VRG does not exist",
+			},
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("secondary cluster vrg state", func(t *testing.T) {
@@ -201,8 +230,13 @@ func testApplicationStatus() *report.ApplicationStatus {
 	a := &report.ApplicationStatus{
 		Hub: report.HubApplicationStatus{
 			DRPC: report.DRPCSummary{
-				Name:        "drpc-name",
-				Namespace:   "drpc-namespace",
+				Name:      "drpc-name",
+				Namespace: "drpc-namespace",
+				Deleted: report.ValidatedBool{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+				},
 				DRPolicy:    "dr-policy-1m",
 				Phase:       "Deployed",
 				Progression: "completed",
@@ -233,7 +267,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 			VRG: report.VRGSummary{
 				Name:      "vrg-name",
 				Namespace: "vrg-namespace",
-				State:     "Primary",
+				Deleted: report.ValidatedBool{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+				},
+				State: "Primary",
 				Conditions: []report.ValidatedCondition{
 					{
 						Type: "DataReady",
@@ -277,7 +316,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						Name:        "pvc-name",
 						Namespace:   "app-namespace",
 						Replication: report.Volrep,
-						Phase:       "Bound",
+						Deleted: report.ValidatedBool{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+						},
+						Phase: "Bound",
 						Conditions: []report.ValidatedCondition{
 							{
 								Type: "DataReady",
@@ -307,7 +351,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 			VRG: report.VRGSummary{
 				Name:      "vrg-name",
 				Namespace: "vrg-namespace",
-				State:     "Secondary",
+				Deleted: report.ValidatedBool{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+				},
+				State: "Secondary",
 				Conditions: []report.ValidatedCondition{
 					{
 						Type: "NoClusterDataConflict",

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -36,7 +36,7 @@ type ValidatedString struct {
 // ValidatedBool is a validated object bool property.
 type ValidatedBool struct {
 	Validated
-	Value bool `json:"value"`
+	Value bool `json:"value,omitempty"`
 }
 
 // ValidatedCondition is a validated condition.

--- a/pkg/validate/command.go
+++ b/pkg/validate/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/nirs/kubectl-gather/pkg/gather"
 	"github.com/ramendr/ramen/e2e/types"
 	"go.uber.org/zap"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
@@ -97,6 +98,28 @@ func (c *Command) validateConfig() bool {
 	c.passStep()
 	console.Pass("Config validated")
 	return true
+}
+
+func (c *Command) validatedDeleted(obj client.Object) report.ValidatedBool {
+	validated := report.ValidatedBool{}
+	if obj == nil {
+		// Resource is missing.
+		validated.Value = true
+		validated.State = report.Error
+		validated.Description = "Resource does not exist"
+	} else {
+		if isDeleted(obj) {
+			// Resource was deleted.
+			validated.Value = true
+			validated.State = report.Error
+			validated.Description = "Resource was deleted"
+		} else {
+			// Resource not deleted.
+			validated.State = report.OK
+		}
+	}
+	c.report.Summary.Add(&validated)
+	return validated
 }
 
 // Gathering data.


### PR DESCRIPTION
The deleted property of all resources is defined now as:

```go
Deleted ValidatedBool `json:"deleted"`
```

If an object is not deleted we show:

```yaml
deleted:
  state: ok ✅
```

If an object is missing we will see:

```yaml
deleted:
  value: true
  state: error ❌
  description: Resource does not exist
```

If an object was deleted but still exists we show:

```yaml
deleted:
  value: true
  state: error ❌
  description: Resource was deleted
```

I considered using *ValidatedBool so we don't show anything if the object is not deleted, but this does not add an OK validation to the summary, and does not show that we did any validation.

When handling a missing VRGs mark the VRG as deleted instead of aborting the validation. The validated step is marked as failed but we continue to validate all clusters. VRGSummary.State is omitted if empty to clean up display of a missing VRG.

When handling a missing PVC we mark the pvc as deleted instead of keeping zero value for Deleted and Phase.

Example run with a broken application:

```console
% ramenctl validate application --name rhel9-snapshot-vm-drpc --namespace openshift-dr-ops -c ocp.yaml -o out
⭐ Using config "ocp.yaml"
⭐ Using report "out"

🔎 Validate config ...
    ✅ Config validated

🔎 Validate application ...
    ✅ Inspected application
    ✅ Gathered data from cluster "hub"
    ✅ Gathered data from cluster "prsurve-c2-7j"
    ✅ Gathered data from cluster "prsurve-c1-7j"
    ❌ Problems found during validation

❌ validation failed (14 ok, 0 stale, 2 errors)
```

Example report:

```yaml
applicationStatus:
  hub:
    drpc:
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - description: VolumeReplicationGroup (openshift-dr-ops/rhel9-snapshot-vm-drpc)
          on cluster prsurve-c2-7j is not reporting any lastGroupSyncTime as primary,
          retrying till status is met
        state: error ❌
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy-4m
      name: rhel9-snapshot-vm-drpc
      namespace: openshift-dr-ops
      phase: Deployed
      progression: Completed
  primaryCluster:
    name: prsurve-c2-7j
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: DataProtected
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: rhel9-snapshot-vm-drpc
      namespace: openshift-dr-ops
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: DataReady
        - state: ok ✅
          type: DataProtected
        - state: ok ✅
          type: ClusterDataProtected
        deleted:
          state: ok ✅
        name: rhel-9-vm-from-snapshot-volume
        namespace: test-vm
        phase: Bound
        replication: volrep
      state: Primary
  secondaryCluster:
    name: prsurve-c1-7j
    vrg:
      deleted:
        description: Resource does not exist
        state: error ❌
        value: true
      name: rhel9-snapshot-vm-drpc
      namespace: openshift-dr-ops
```

Fixes: #260