### PR TITLE
validate: Validate drpc phase

### DIFF
--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -94,6 +94,19 @@ func primaryClusterName(drpc *ramenapi.DRPlacementControl) string {
 	return drpc.Spec.PreferredCluster
 }
 
+func StablePhase(action ramenapi.DRAction) (ramenapi.DRState, error) {
+	switch action {
+	case "":
+		return ramenapi.Deployed, nil
+	case ramenapi.ActionFailover:
+		return ramenapi.FailedOver, nil
+	case ramenapi.ActionRelocate:
+		return ramenapi.Relocated, nil
+	default:
+		return "", fmt.Errorf("unknown action %q", action)
+	}
+}
+
 func GetDRPC(ctx Context, drpcName, drpcNamespace string) (*ramenapi.DRPlacementControl, error) {
 	drpc := &ramenapi.DRPlacementControl{}
 	key := types.NamespacedName{Namespace: drpcNamespace, Name: drpcName}

--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -32,7 +32,7 @@ type DRPCSummary struct {
 	Deleted     ValidatedBool        `json:"deleted"`
 	DRPolicy    string               `json:"drPolicy"`
 	Action      ValidatedString      `json:"action"`
-	Phase       string               `json:"phase"`
+	Phase       ValidatedString      `json:"phase"`
 	Progression string               `json:"progression"`
 	Conditions  []ValidatedCondition `json:"conditions,omitempty"`
 }

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -69,7 +69,12 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("hub drpc phase", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.Hub.DRPC.Phase = modified
+		a2.Hub.DRPC.Phase = report.ValidatedString{
+			Value: string(ramenapi.FailedOver),
+			Validated: report.Validated{
+				State: report.OK,
+			},
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("hub drpc progression", func(t *testing.T) {
@@ -249,7 +254,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						State: report.OK,
 					},
 				},
-				Phase:       "Deployed",
+				Phase: report.ValidatedString{
+					Value: "Deployed",
+					Validated: report.Validated{
+						State: report.OK,
+					},
+				},
 				Progression: "completed",
 				Conditions: []report.ValidatedCondition{
 					{


### PR DESCRIPTION
Validating phase is more complicated, since it depends on the action. We simplify validation by marking the stable phase for every action as OK, and anything else as an error. The reason is that an application should not be in unstable phase (e.g. FailingOver) for long time. If it is stuck at unstable state for long time this is a problem and we need to investigate.

The unit test validate that we return the expected ValidatedString for every possible combination of action and phase.

Example report:

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - description: VolumeReplicationGroup (openshift-dr-ops/rhel9-snapshot-vm-drpc)
          on cluster prsurve-c2-7j is not reporting any lastGroupSyncTime as primary,
          retrying till status is met
        state: error ❌
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy-4m
      name: rhel9-snapshot-vm-drpc
      namespace: openshift-dr-ops
      phase:
        state: ok ✅
        value: Deployed
      progression: Completed
```

Part-of: #262