### PR TITLE
validate: Skip DataProtected condition

### DIFF
--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -531,12 +531,6 @@ func TestValidateApplicationPassed(t *testing.T) {
 						Validated: report.Validated{
 							State: report.OK,
 						},
-						Type: "DataProtected",
-					},
-					{
-						Validated: report.Validated{
-							State: report.OK,
-						},
 						Type: "ClusterDataReady",
 					},
 					{
@@ -582,12 +576,6 @@ func TestValidateApplicationPassed(t *testing.T) {
 								},
 								Type: "ClusterDataProtected",
 							},
-							{
-								Validated: report.Validated{
-									State: report.OK,
-								},
-								Type: "DataProtected",
-							},
 						},
 					},
 				},
@@ -617,7 +605,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 	}
 	checkApplicationStatus(t, validate.report, expectedStatus)
 
-	checkSummary(t, validate.report, Summary{OK: 19})
+	checkSummary(t, validate.report, Summary{OK: 17})
 }
 
 func TestValidateApplicationValidateFailed(t *testing.T) {


### PR DESCRIPTION
In the VRG this condition has incompatible behavior when using volsync
and volrep. With volrep it is False in stable state and True during some
part of Relocate flow. With volsync it is True in stable state.

For protected PVCs the condition appears only for volrep using the
confusing semantics.

Fixed by dropping the condition since we have no sane way to validate
the state. The condition is available in the gathered resource user need
to inspect the value.

## Example runs with volrep application

```console
% ramenctl validate application --name appset-deploy-rbd \
    --namespace argocd -o out/appset-deploy-rbd
⭐ Using config "config.yaml"
⭐ Using report "out/appset-deploy-rbd"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "hub"
   ✅ Application validated

✅ Validation completed (17 ok, 0 stale, 0 errors)
```

## Example volrep application status

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - state: ok ✅
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy
      name: appset-deploy-rbd
      namespace: argocd
      phase:
        state: ok ✅
        value: Deployed
      progression: Completed
  primaryCluster:
    name: dr1
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-rbd
      namespace: e2e-appset-deploy-rbd
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: DataReady
        - state: ok ✅
          type: ClusterDataProtected
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: e2e-appset-deploy-rbd
        phase: Bound
        replication: volrep
      state: Primary
  secondaryCluster:
    name: dr2
    vrg:
      conditions:
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-rbd
      namespace: e2e-appset-deploy-rbd
      state: Secondary
```

## Example run with volsync application

```console
% ramenctl validate application --name appset-deploy-cephfs \
    --namespace argocd -o out/appset-deploy-cephfs
⭐ Using config "config.yaml"
⭐ Using report "out/appset-deploy-cephfs"

🔎 Validate config ...
    ✅ Config validated

🔎 Validate application ...
    ✅ Inspected application
    ✅ Gathered data from cluster "hub"
    ✅ Gathered data from cluster "dr2"
    ✅ Gathered data from cluster "dr1"
    ✅ Application validated

✅ Validation completed (16 ok, 0 stale, 0 errors)
```

## Example volsync application status

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - state: ok ✅
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy
      name: appset-deploy-cephfs
      namespace: argocd
      phase:
        state: ok ✅
        value: Deployed
      progression: Completed
  primaryCluster:
    name: dr1
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-cephfs
      namespace: e2e-appset-deploy-cephfs
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: ReplicationSourceSetup
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: e2e-appset-deploy-cephfs
        phase: Bound
        replication: volsync
      state: Primary
  secondaryCluster:
    name: dr2
    vrg:
      conditions:
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-cephfs
      namespace: e2e-appset-deploy-cephfs
      state: Secondary
```

## Test output with all e2e applications
[out.tar.gz](https://github.com/user-attachments/files/21774934/out.tar.gz)

Fixes: #272