### PR TITLE
report: add RamenControllerType to ConfigMapSummary

### DIFF
--- a/pkg/report/clusters.go
+++ b/pkg/report/clusters.go
@@ -30,9 +30,10 @@ type S3StoreProfilesSummary struct {
 
 // ConfigMapSummary is the summary of a Ramen ConfigMap.
 type ConfigMapSummary struct {
-	Name            string                       `json:"name"`
-	Namespace       string                       `json:"namespace"`
-	S3StoreProfiles ValidatedS3StoreProfilesList `json:"s3StoreProfiles"`
+	Name                string                       `json:"name"`
+	Namespace           string                       `json:"namespace"`
+	RamenControllerType ValidatedString              `json:"ramenControllerType"`
+	S3StoreProfiles     ValidatedS3StoreProfilesList `json:"s3StoreProfiles"`
 }
 
 // DeploymentSummary is the summary of a Deployment
@@ -204,6 +205,9 @@ func (c *ConfigMapSummary) Equal(o *ConfigMapSummary) bool {
 		return false
 	}
 	if c.Namespace != o.Namespace {
+		return false
+	}
+	if c.RamenControllerType != o.RamenControllerType {
 		return false
 	}
 	if !c.S3StoreProfiles.Equal(&o.S3StoreProfiles) {

--- a/pkg/report/clusters_test.go
+++ b/pkg/report/clusters_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
@@ -112,6 +113,16 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 		c2.Hub.Ramen.ConfigMap.Namespace = modified
 		checkClustersNotEqual(t, c1, c2)
 	})
+	t.Run("hub ramen configmap ramen controller type state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.RamenControllerType.State = report.Error
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("hub ramen configmap ramen controller type", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.RamenControllerType.Value = modified
+		checkClustersNotEqual(t, c1, c2)
+	})
 	t.Run("hub ramen configmap s3storeprofiles state", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.State = report.Error
@@ -186,6 +197,16 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 	t.Run("cluster ramen configmap namespace", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Clusters[0].Ramen.ConfigMap.Namespace = modified
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap ramen controller type state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.RamenControllerType.State = report.Error
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap ramen controller type", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.RamenControllerType.Value = modified
 		checkClustersNotEqual(t, c1, c2)
 	})
 	t.Run("cluster ramen configmap s3storeprofiles state", func(t *testing.T) {
@@ -325,6 +346,12 @@ func testClusterStatus() *report.ClustersStatus {
 				ConfigMap: report.ConfigMapSummary{
 					Name:      "ramen-hub-operator-config",
 					Namespace: "ramen-system",
+					RamenControllerType: report.ValidatedString{
+						Validated: report.Validated{
+							State: report.OK,
+						},
+						Value: string(ramenapi.DRHubType),
+					},
 					S3StoreProfiles: report.ValidatedS3StoreProfilesList{
 						Validated: report.Validated{
 							State: report.OK,
@@ -384,6 +411,12 @@ func testClusterStatus() *report.ClustersStatus {
 					ConfigMap: report.ConfigMapSummary{
 						Name:      "ramen-dr-cluster-operator-config",
 						Namespace: "ramen-system",
+						RamenControllerType: report.ValidatedString{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: string(ramenapi.DRClusterType),
+						},
 						S3StoreProfiles: report.ValidatedS3StoreProfilesList{
 							Validated: report.Validated{
 								State: report.OK,
@@ -442,6 +475,12 @@ func testClusterStatus() *report.ClustersStatus {
 					ConfigMap: report.ConfigMapSummary{
 						Name:      "ramen-dr-cluster-operator-config",
 						Namespace: "ramen-system",
+						RamenControllerType: report.ValidatedString{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: string(ramenapi.DRClusterType),
+						},
 						S3StoreProfiles: report.ValidatedS3StoreProfilesList{
 							Validated: report.Validated{
 								State: report.OK,


### PR DESCRIPTION
Include `RamenControllerType` in `ConfigMapSummary` to capture the type of Ramen controller (e.g., dr-hub, dr-cluster). Update equality checks and tests.

```
clusters:
- name: dr1
  ramen:
    configmap:
      name: ramen-dr-cluster-operator-config
      namespace: ramen-system
      ramenControllerType:
        state: ok ✅
        value: dr-cluster
      s3StoreProfiles:
        state: ok ✅
        value:
        - s3ProfileName: s3-profile-dr1
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr1
              namespace: ramen-system
        - s3ProfileName: s3-profile-dr2
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr2
              namespace: ramen-system
- name: dr2
  ramen:
    configmap:
      name: ramen-dr-cluster-operator-config
      namespace: ramen-system
      ramenControllerType:
        state: ok ✅
        value: dr-cluster
      s3StoreProfiles:
        state: ok ✅
        value:
        - s3ProfileName: s3-profile-dr1
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr1
              namespace: ramen-system
        - s3ProfileName: s3-profile-dr2
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr2
              namespace: ramen-system
hub:
  ramen:
    configmap:
      name: ramen-hub-operator-config
      namespace: ramen-system
      ramenControllerType:
        state: ok ✅
        value: dr-hub
      s3StoreProfiles:
        state: ok ✅
        value:
        - s3ProfileName: s3-profile-dr1
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr1
              namespace: ramen-system
        - s3ProfileName: s3-profile-dr2
          s3SecretRef:
            state: ok ✅
            value:
              name: ramen-s3-secret-dr2
              namespace: ramen-system
```

Part-of #170 