### PR TITLE
Validate drpc progression

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -33,7 +33,7 @@ type DRPCSummary struct {
 	DRPolicy    string               `json:"drPolicy"`
 	Action      ValidatedString      `json:"action"`
 	Phase       ValidatedString      `json:"phase"`
-	Progression string               `json:"progression"`
+	Progression ValidatedString      `json:"progression"`
 	Conditions  []ValidatedCondition `json:"conditions,omitempty"`
 }
 

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -79,7 +79,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("hub drpc progression", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.Hub.DRPC.Progression = modified
+		a2.Hub.DRPC.Progression = report.ValidatedString{
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "Waiting for stable progression",
+			},
+			Value: string(ramenapi.ProgressionFailingOverToCluster),
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("hub drpc conditions nil", func(t *testing.T) {
@@ -260,7 +266,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 					},
 					Value: "Deployed",
 				},
-				Progression: "completed",
+				Progression: report.ValidatedString{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: string(ramenapi.ProgressionCompleted),
+				},
 				Conditions: []report.ValidatedCondition{
 					{
 						Validated: report.Validated{


### PR DESCRIPTION
Like phase, we mark only the stable progression as ok, and anything else
as an error. An application should now be in unstable progression for
long time. Possible case may be waiting for user action during failover
or relocate, or application stuck in failover or relocate because some
issue.

Example report:

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - state: ok ✅
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy
      name: appset-deploy-rbd
      namespace: argocd
      phase:
        state: ok ✅
        value: Deployed
      progression:
        state: ok ✅
        value: Completed
```

Part-of #262
