### PR TITLE
Validate vrg state

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -42,7 +42,7 @@ type VRGSummary struct {
 	Name          string                `json:"name"`
 	Namespace     string                `json:"namespace"`
 	Deleted       ValidatedBool         `json:"deleted"`
-	State         string                `json:"state,omitempty"`
+	State         ValidatedString       `json:"state"`
 	Conditions    []ValidatedCondition  `json:"conditions,omitempty"`
 	ProtectedPVCs []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
 }

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -126,7 +126,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("primary cluster vrg state", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.PrimaryCluster.VRG.State = modified
+		a2.PrimaryCluster.VRG.State = report.ValidatedString{
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "Waiting to become \"Primary\"",
+			},
+			Value: string(ramenapi.SecondaryState),
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("primary cluster vrg conditions nil", func(t *testing.T) {
@@ -213,7 +219,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("secondary cluster vrg state", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		a2.SecondaryCluster.VRG.State = modified
+		a2.SecondaryCluster.VRG.State = report.ValidatedString{
+			Validated: report.Validated{
+				State:       report.Error,
+				Description: "Waiting to become \"Secondary\"",
+			},
+			Value: string(ramenapi.PrimaryState),
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("secondary cluster vrg conditions nil", func(t *testing.T) {
@@ -304,7 +316,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						State: report.OK,
 					},
 				},
-				State: "Primary",
+				State: report.ValidatedString{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: string(ramenapi.PrimaryState),
+				},
 				Conditions: []report.ValidatedCondition{
 					{
 						Validated: report.Validated{
@@ -388,7 +405,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						State: report.OK,
 					},
 				},
-				State: "Secondary",
+				State: report.ValidatedString{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: string(ramenapi.SecondaryState),
+				},
 				Conditions: []report.ValidatedCondition{
 					{
 						Validated: report.Validated{


### PR DESCRIPTION
Same as drpc phase and progression, we mark the stable vrg state as ok,
and anything else as an error. The vrg on the primary cluster must have
Primary state, and the vrg on the secondary cluster must be Secondary
state. If an application does not show the right state for long time it
requires investigation.

Example report:

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - state: ok ✅
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy
      name: appset-deploy-rbd
      namespace: argocd
      phase:
        state: ok ✅
        value: Deployed
      progression:
        state: ok ✅
        value: Completed
  primaryCluster:
    name: dr1
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-rbd
      namespace: e2e-appset-deploy-rbd
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: DataReady
        - state: ok ✅
          type: ClusterDataProtected
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: e2e-appset-deploy-rbd
        phase: Bound
        replication: volrep
      state:
        state: ok ✅
        value: Primary
  secondaryCluster:
    name: dr2
    vrg:
      conditions:
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-rbd
      namespace: e2e-appset-deploy-rbd
      state:
        state: ok ✅
        value: Secondary
```

Tested with rbd and cephfs applications.

Part-of #262
