### PR TITLE
report: Unify application status types

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -48,21 +48,21 @@ type VRGSummary struct {
 }
 
 // ApplicationHubStaus is the application status on the hub.
-type HubApplicationStatus struct {
+type ApplicationStatusHub struct {
 	DRPC DRPCSummary `json:"drpc"`
 }
 
 // ApplicationHubStaus is the application status on a managed cluster.
-type ClusterApplicationStatus struct {
+type ApplicationStatusCluster struct {
 	Name string     `json:"name"`
 	VRG  VRGSummary `json:"vrg"`
 }
 
 // ApplicationStatus is protected application status in multi-cluster environment.
 type ApplicationStatus struct {
-	Hub              HubApplicationStatus     `json:"hub"`
-	PrimaryCluster   ClusterApplicationStatus `json:"primaryCluster"`
-	SecondaryCluster ClusterApplicationStatus `json:"secondaryCluster"`
+	Hub              ApplicationStatusHub     `json:"hub"`
+	PrimaryCluster   ApplicationStatusCluster `json:"primaryCluster"`
+	SecondaryCluster ApplicationStatusCluster `json:"secondaryCluster"`
 }
 
 func (a *ApplicationStatus) Equal(o *ApplicationStatus) bool {
@@ -84,7 +84,7 @@ func (a *ApplicationStatus) Equal(o *ApplicationStatus) bool {
 	return true
 }
 
-func (h *HubApplicationStatus) Equal(o *HubApplicationStatus) bool {
+func (h *ApplicationStatusHub) Equal(o *ApplicationStatusHub) bool {
 	if h == o {
 		return true
 	}
@@ -97,7 +97,7 @@ func (h *HubApplicationStatus) Equal(o *HubApplicationStatus) bool {
 	return true
 }
 
-func (c *ClusterApplicationStatus) Equal(o *ClusterApplicationStatus) bool {
+func (c *ApplicationStatusCluster) Equal(o *ApplicationStatusCluster) bool {
 	if c == o {
 		return true
 	}

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -264,7 +264,7 @@ func TestReportApplicationStatusMarshaling(t *testing.T) {
 
 func testApplicationStatus() *report.ApplicationStatus {
 	a := &report.ApplicationStatus{
-		Hub: report.HubApplicationStatus{
+		Hub: report.ApplicationStatusHub{
 			DRPC: report.DRPCSummary{
 				Name:      "drpc-name",
 				Namespace: "drpc-namespace",
@@ -313,7 +313,7 @@ func testApplicationStatus() *report.ApplicationStatus {
 				},
 			},
 		},
-		PrimaryCluster: report.ClusterApplicationStatus{
+		PrimaryCluster: report.ApplicationStatusCluster{
 			Name: "dr1",
 			VRG: report.VRGSummary{
 				Name:      "vrg-name",
@@ -407,7 +407,7 @@ func testApplicationStatus() *report.ApplicationStatus {
 				},
 			},
 		},
-		SecondaryCluster: report.ClusterApplicationStatus{
+		SecondaryCluster: report.ApplicationStatusCluster{
 			Name: "dr2",
 			VRG: report.VRGSummary{
 				Name:      "vrg-name",

--- a/pkg/validate/application.go
+++ b/pkg/validate/application.go
@@ -147,7 +147,7 @@ func (c *Command) validateGatheredApplicationData(drpcName, drpcNamespace string
 }
 
 func (c *Command) validateHub(
-	s *report.HubApplicationStatus,
+	s *report.ApplicationStatusHub,
 	drpcName, drpcNamespace string,
 ) (*ramenapi.DRPlacementControl, error) {
 	log := c.Logger()
@@ -162,7 +162,7 @@ func (c *Command) validateHub(
 }
 
 func (c *Command) validatePrimaryCluster(
-	s *report.ClusterApplicationStatus,
+	s *report.ApplicationStatusCluster,
 	drpc *ramenapi.DRPlacementControl,
 ) error {
 	cluster, err := ramen.PrimaryCluster(c, drpc)
@@ -174,7 +174,7 @@ func (c *Command) validatePrimaryCluster(
 }
 
 func (c *Command) validateSecondaryCluster(
-	s *report.ClusterApplicationStatus,
+	s *report.ApplicationStatusCluster,
 	drpc *ramenapi.DRPlacementControl,
 ) error {
 	cluster, err := ramen.SecondaryCluster(c, drpc)

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -697,7 +697,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 	checkItems(t, validate.report.Steps[1], items)
 
 	expectedStatus := &report.ApplicationStatus{
-		Hub: report.HubApplicationStatus{
+		Hub: report.ApplicationStatusHub{
 			DRPC: report.DRPCSummary{
 				Name:      drpcName,
 				Namespace: drpcNamespace,
@@ -746,7 +746,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 				},
 			},
 		},
-		PrimaryCluster: report.ClusterApplicationStatus{
+		PrimaryCluster: report.ApplicationStatusCluster{
 			Name: "dr1",
 			VRG: report.VRGSummary{
 				Name:      drpcName,
@@ -828,7 +828,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 				},
 			},
 		},
-		SecondaryCluster: report.ClusterApplicationStatus{
+		SecondaryCluster: report.ApplicationStatusCluster{
 			Name: "dr2",
 			VRG: report.VRGSummary{
 				Name:      drpcName,


### PR DESCRIPTION
Use more standard `ApplicationStatusHub` and `ApplicationStatusCluster` to   
match `ClustersStatusHub` and `ClustersStatusClusters`.                         
