### PR TITLE
validate: Skip stale PvsRestored condition

### DIFF
--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -22,6 +22,11 @@ const (
 	// https://github.com/RamenDR/ramen/blob/eebc5c0cb46af2eea145e7d40feef09681f6b110/internal/controller/status.go#L25
 	VRGConditionTypeDataProtected = "DataProtected"
 
+	// VolSync related conditions. These conditions are only applicable
+	// at individual PVCs and not generic VRG conditions.
+	// https://github.com/RamenDR/ramen/blob/eebc5c0cb46af2eea145e7d40feef09681f6b110/internal/controller/status.go#L50
+	VRGConditionTypeVolSyncPVsRestored = "PVsRestored"
+
 	// ConditionUnused is used on the secondary cluster VRG.
 	// https://github.com/RamenDR/ramen/blob/eebc5c0cb46af2eea145e7d40feef09681f6b110/internal/controller/status.go#L55
 	VRGConditionReasonUnused = "Unused"


### PR DESCRIPTION
validate: Skip stale PvsRestored condition

This volsync only condition is always stale after failover or relocate,
but the application is fine. Validating the application fails because
the stale condition.

Example run with this fix:

```console
% ramenctl validate application --name appset-deploy-cephfs --namespace argocd -o out/cephfs/failedover
⭐ Using config "config.yaml"
⭐ Using report "out/cephfs/failedover"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "hub"
   ✅ Application validated

✅ Validation completed (20 ok, 0 stale, 0 errors)
```

Example report:

```yaml
applicationStatus:
  hub:
    drpc:
      action:
        state: ok ✅
        value: Relocate
      conditions:
      - state: ok ✅
        type: Available
      - state: ok ✅
        type: PeerReady
      - state: ok ✅
        type: Protected
      deleted:
        state: ok ✅
      drPolicy: dr-policy
      name: appset-deploy-cephfs
      namespace: argocd
      phase:
        state: ok ✅
        value: Relocated
      progression:
        state: ok ✅
        value: Completed
  primaryCluster:
    name: dr1
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: NoClusterDataConflict
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: KubeObjectsReady
      deleted:
        state: ok ✅
      name: appset-deploy-cephfs
      namespace: e2e-appset-deploy-cephfs
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: ReplicationSourceSetup
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: e2e-appset-deploy-cephfs
        phase:
          state: ok ✅
          value: Bound
        replication: volsync
      state:
        state: ok ✅
        value: Primary
  secondaryCluster:
    name: dr2
    vrg:
      conditions:
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: appset-deploy-cephfs
      namespace: e2e-appset-deploy-cephfs
      state:
        state: ok ✅
        value: Secondary
```

Fixes #291
