### PR TITLE
validate: Improve command description

### DIFF
--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -11,12 +11,12 @@ import (
 
 var ValidateCmd = &cobra.Command{
 	Use:   "validate",
-	Short: "Validate disaster recovery configuration",
+	Short: "Detect disaster recovery problems",
 }
 
 var ValidateClustersCmd = &cobra.Command{
 	Use:   "clusters",
-	Short: "Validate clusters configuration",
+	Short: "Detect problems in disaster recovery clusters",
 	Run: func(c *cobra.Command, args []string) {
 		if err := validate.Clusters(configFile, outputDir); err != nil {
 			console.Fatal(err)
@@ -26,7 +26,7 @@ var ValidateClustersCmd = &cobra.Command{
 
 var ValidateApplicationCmd = &cobra.Command{
 	Use:   "application",
-	Short: "Validate protected application",
+	Short: "Detect problems in disaster recovery protected application",
 	Run: func(c *cobra.Command, args []string) {
 		if err := validate.Application(configFile, outputDir, drpcName, drpcNamespace); err != nil {
 			console.Fatal(err)


### PR DESCRIPTION
The validate command are not only about configuration. They detect disaster recovery problems in configuration or resource status.

Example help:

    % ramenctl validate -h
    Detect disaster recovery problems

    Usage:
      ramenctl validate [command]

    Available Commands:
      application Detect problems in disaster recovery protected application
      clusters    Detect problems in disaster recovery clusters

    Flags:
      -h, --help            help for validate
      -o, --output string   output directory

    Global Flags:
      -c, --config string   configuration file (default "config.yaml")

    Use "ramenctl validate [command] --help" for more information about a command.