### PR TITLE
validate: Hide validate clusters command

### DIFF
--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -22,6 +22,7 @@ var ValidateClustersCmd = &cobra.Command{
 			console.Fatal(err)
 		}
 	},
+	Hidden: true, // Keep hidden until completed.
 }
 
 var ValidateApplicationCmd = &cobra.Command{


### PR DESCRIPTION
The command is not functional yet, so we should not expose it in the release yet.

Example help:

    % ramenctl validate -h
    Detect disaster recovery problems

    Usage:
      ramenctl validate [command]

    Available Commands:
      application Detect problems in disaster recovery protected application

    Flags:
      -h, --help            help for validate
      -o, --output string   output directory

    Global Flags:
      -c, --config string   configuration file (default "config.yaml")

    Use "ramenctl validate [command] --help" for more information about a command.

The command can be used for testing by using the hidden sub command name:

    % ramenctl validate clusters -h
    Detect problems in disaster recovery clusters

    Usage:
      ramenctl validate clusters [flags]

    Flags:
      -h, --help   help for clusters

    Global Flags:
      -c, --config string   configuration file (default "config.yaml")
      -o, --output string   output directory