### PR TITLE
 replace managed clusters with env.ManagedClusters()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.10.1
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
-	github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94
+	github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94 h1:ts1Z8oSS0ozaenQqd2wQ3z6y//w29GYVmaHwXzoBrGo=
-github.com/ramendr/ramen/e2e v0.0.0-20250722150952-d4c9b950df94/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 h1:MVV2VLaG5tToXewTqWkQVNm6/W0Yz91W26PNDbaRxmg=
+github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -230,7 +230,7 @@ func (c *Command) validateClustersClusters(s *[]report.ClustersStatusCluster) er
 	env := c.Env()
 	namespace := c.Config().Namespaces.RamenDRClusterNamespace
 
-	for _, cluster := range []*types.Cluster{env.C1, env.C2} {
+	for _, cluster := range env.ManagedClusters() {
 		cs := report.ClustersStatusCluster{Name: cluster.Name}
 		if err := c.validateRamen(&cs.Ramen, cluster, namespace, ramenapi.DRClusterType); err != nil {
 			return fmt.Errorf("failed to validate ramen: %w", err)

--- a/pkg/validation/ocm.go
+++ b/pkg/validation/ocm.go
@@ -10,8 +10,6 @@ import (
 	ocmv1 "open-cluster-management.io/api/cluster/v1"
 	ocmv1b2 "open-cluster-management.io/api/cluster/v1beta2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/ramendr/ramen/e2e/types"
 )
 
 func validateClusterset(ctx Context) error {
@@ -25,7 +23,7 @@ func validateClusterset(ctx Context) error {
 	if err != nil {
 		return err
 	}
-	clusters := []*types.Cluster{env.C1, env.C2}
+	clusters := env.ManagedClusters()
 	for _, cluster := range clusters {
 		if !slices.Contains(clusterNames, cluster.Name) {
 			return fmt.Errorf(


### PR DESCRIPTION
Update ramen/e2e to consume fix for RamenDR/ramen#2228 to use Env.ManagedCluster() method instead of slices with env.C1 and env.C2.

Fixes #309 