### PR TITLE
test: Use e2e default namespace prefix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.10.1
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
-	github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9
+	github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9 h1:MVV2VLaG5tToXewTqWkQVNm6/W0Yz91W26PNDbaRxmg=
-github.com/ramendr/ramen/e2e v0.0.0-20250828115748-9f9340ba03e9/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969 h1:sfFkhx8jOc3xRdxAkWMB/gehObjLNSbitPw9e1v0X08=
+github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -26,9 +26,6 @@ import (
 	"github.com/ramendr/ramenctl/pkg/time"
 )
 
-// namespacePrefix is used for all namespaces created by tests.
-const namespacePrefix = "test-"
-
 // Command is a ramenctl test command.
 type Command struct {
 	// Command is the generic command used by all ramenctl commands.
@@ -73,9 +70,6 @@ func newCommand(
 	cfg *e2econfig.Config,
 	backend testing.Testing,
 ) *Command {
-	// This is not user configurable. We use the same prefix for all namespaces created by the test.
-	cfg.Channel.Namespace = namespacePrefix + "gitops"
-
 	testCmd := &Command{
 		command:   cmd,
 		config:    cfg,

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -58,7 +58,7 @@ func (c *Context) ManagementNamespace() string {
 }
 
 func (c *Context) AppNamespace() string {
-	return namespacePrefix + c.name
+	return c.Config().NamespacePrefix + c.name
 }
 
 func (c *Context) Logger() *zap.SugaredLogger {


### PR DESCRIPTION
test: Use e2e default namespace prefix                                                                                               
                                                                            
Update ramen/e2e to latest version to consume:                              
https://github.com/RamenDR/ramen/pull/2259                                  
                                                                            
And change test context to use the new config.NamespacePrefix instead of  
a hard coded value.                                                         
                                                                            
Remove the code to set the channel namespace since we use now ramen/e2e  
default channel namespace.                                                  
                                                                            
This avoids the issues when trying to test an application deployed by       
ramen e2e. Since they use the same namespace prefix now, we don't have a 
conflict.                                                                   
                                                                            
ramen/e2e is using now "test-" prefix so this does not change the           
visible behavior.                                                          

Fixes: #302