### PR TITLE
More user friendly error if creating env failed                                                                                      

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.10.1
 	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
-	github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969
+	github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	go.uber.org/zap v1.27.0

--- a/go.sum
+++ b/go.sum
@@ -199,8 +199,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
 github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969 h1:sfFkhx8jOc3xRdxAkWMB/gehObjLNSbitPw9e1v0X08=
-github.com/ramendr/ramen/e2e v0.0.0-20250921165937-3b6482c31969/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1 h1:ltQUo1hPMFUhF/oLJZ/OglRCoJMWZkugYAEzzbg/sU0=
+github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -64,9 +65,8 @@ func New(
 	if err != nil {
 		// Stop the signal handler before we fail.
 		stop()
-		err := fmt.Errorf("failed to create env: %w", err)
-		log.Error(err)
-		return nil, err
+		log.Errorf("Failed to create env: %s", err)
+		return nil, errors.New("failed to create env")
 	}
 
 	return &Command{


### PR DESCRIPTION
We fail with a cleaner error and log the detailed error to the log,                                                                  
similar to other errors.                                                    
                                                                            
Example run with inaccessible cluster:                                      
                                                                            
    % ramenctl validate clusters -o out/env-error
    ⭐ Using config "config.yaml"                                           
    ⭐ Using report "out/env-error"                                         
                                                                            
    ❌ failed to create env                                                 
                                                                            
    % head -1 out/env-error/validate-clusters.log                           
    2025-09-25T23:36:18.271+0300        ERROR   command/command.go:68       
    Failed to create env: failed to create cluster "hub":                   
    failed to build config from kubeconfig (/Users/nir/.config/drenv/rdr/kubeconfigs/hub):
    stat /Users/nir/.config/drenv/rdr/kubeconfigs/hub: no such file or directory
                                                                         
Fixes: #313