### PR TITLE
validate: report and validate peer classes in drpolicy

### DIFF
--- a/pkg/report/clusters.go
+++ b/pkg/report/clusters.go
@@ -16,10 +16,17 @@ type DRClusterSummary struct {
 
 // DRPolicySummary is the summary of a DRPolicy.
 type DRPolicySummary struct {
-	Name               string               `json:"name"`
-	DRClusters         []string             `json:"drClusters"`
-	SchedulingInterval string               `json:"schedulingInterval"`
-	Conditions         []ValidatedCondition `json:"conditions,omitempty"`
+	Name               string                   `json:"name"`
+	DRClusters         []string                 `json:"drClusters"`
+	SchedulingInterval string                   `json:"schedulingInterval"`
+	PeerClasses        ValidatedPeerClassesList `json:"peerClasses"`
+	Conditions         []ValidatedCondition     `json:"conditions,omitempty"`
+}
+
+// PeerClassesSummary is the summary of peerClasses in a DRPolicy.
+type PeerClassesSummary struct {
+	StorageClassName string `json:"storageClassName"`
+	ReplicationID    string `json:"replicationID,omitempty"`
 }
 
 // S3StoreProfilesSummary is the summary of S3 store profiles in the ConfigMap
@@ -163,7 +170,26 @@ func (d *DRPolicySummary) Equal(o *DRPolicySummary) bool {
 	if d.SchedulingInterval != o.SchedulingInterval {
 		return false
 	}
+	if !d.PeerClasses.Equal(&o.PeerClasses) {
+		return false
+	}
 	if !slices.Equal(d.Conditions, o.Conditions) {
+		return false
+	}
+	return true
+}
+
+func (p *PeerClassesSummary) Equal(o *PeerClassesSummary) bool {
+	if p == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if p.StorageClassName != o.StorageClassName {
+		return false
+	}
+	if p.ReplicationID != o.ReplicationID {
 		return false
 	}
 	return true

--- a/pkg/report/clusters_test.go
+++ b/pkg/report/clusters_test.go
@@ -100,6 +100,16 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 		c2.Hub.DRPolicies.Value[0].SchedulingInterval = modified
 		checkClustersNotEqual(t, c1, c2)
 	})
+	t.Run("hub drpolicy peer classes state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.DRPolicies.Value[0].PeerClasses.State = report.Problem
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("hub drpolicy peer classes storage class name", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.DRPolicies.Value[0].PeerClasses.Value[0].StorageClassName = modified
+		checkClustersNotEqual(t, c1, c2)
+	})
 	t.Run("hub drpolicy conditions", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Hub.DRPolicies.Value[0].Conditions[0].State = report.Problem
@@ -382,6 +392,20 @@ func testClusterStatus() *report.ClustersStatus {
 						Name:               "dr-policy-1m",
 						DRClusters:         []string{"dr1", "dr2"},
 						SchedulingInterval: "1m",
+						PeerClasses: report.ValidatedPeerClassesList{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: []report.PeerClassesSummary{
+								{
+									StorageClassName: "rook-ceph-block",
+									ReplicationID:    "rook-ceph-replication-1",
+								},
+								{
+									StorageClassName: "rook-cephfs-fs1",
+								},
+							},
+						},
 						Conditions: []report.ValidatedCondition{
 							{
 								Validated: report.Validated{
@@ -395,6 +419,20 @@ func testClusterStatus() *report.ClustersStatus {
 						Name:               "dr-policy-5m",
 						DRClusters:         []string{"dr1", "dr2"},
 						SchedulingInterval: "5m",
+						PeerClasses: report.ValidatedPeerClassesList{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: []report.PeerClassesSummary{
+								{
+									StorageClassName: "rook-ceph-block",
+									ReplicationID:    "rook-ceph-replication-1",
+								},
+								{
+									StorageClassName: "rook-cephfs-fs1",
+								},
+							},
+						},
 						Conditions: []report.ValidatedCondition{
 							{
 								Validated: report.Validated{

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -81,6 +81,12 @@ type ValidatedDRPoliciesList struct {
 	Value []DRPolicySummary `json:"value,omitempty"`
 }
 
+// ValidatedPeerClassesList is a validated list of peerClasses in a DRPolicy.
+type ValidatedPeerClassesList struct {
+	Validated
+	Value []PeerClassesSummary `json:"value,omitempty"`
+}
+
 func (v *Validated) GetState() ValidationState {
 	return v.State
 }
@@ -127,6 +133,31 @@ func (v *ValidatedDRPoliciesList) Equal(o *ValidatedDRPoliciesList) bool {
 		v.Value,
 		o.Value,
 		func(a DRPolicySummary, b DRPolicySummary) bool {
+			return a.Equal(&b)
+		},
+	) {
+		return false
+	}
+	return true
+}
+
+func (v *ValidatedPeerClassesList) Equal(o *ValidatedPeerClassesList) bool {
+	if v == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if v.State != o.State {
+		return false
+	}
+	if v.Description != o.Description {
+		return false
+	}
+	if !slices.EqualFunc(
+		v.Value,
+		o.Value,
+		func(a PeerClassesSummary, b PeerClassesSummary) bool {
 			return a.Equal(&b)
 		},
 	) {

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -706,6 +706,20 @@ func TestValidateClustersK8s(t *testing.T) {
 						Name:               "dr-policy",
 						DRClusters:         []string{"dr1", "dr2"},
 						SchedulingInterval: "1m",
+						PeerClasses: report.ValidatedPeerClassesList{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: []report.PeerClassesSummary{
+								{
+									StorageClassName: "rook-ceph-block",
+									ReplicationID:    "rook-ceph-replication-1",
+								},
+								{
+									StorageClassName: "rook-cephfs-fs1",
+								},
+							},
+						},
 						Conditions: []report.ValidatedCondition{
 							{
 								Validated: report.Validated{
@@ -719,6 +733,19 @@ func TestValidateClustersK8s(t *testing.T) {
 						Name:               "dr-policy-5m",
 						DRClusters:         []string{"dr1", "dr2"},
 						SchedulingInterval: "5m",
+						PeerClasses: report.ValidatedPeerClassesList{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: []report.PeerClassesSummary{
+								{
+									StorageClassName: "rook-ceph-block",
+								},
+								{
+									StorageClassName: "rook-cephfs-fs1",
+								},
+							},
+						},
 						Conditions: []report.ValidatedCondition{
 							{
 								Validated: report.Validated{
@@ -973,7 +1000,7 @@ func TestValidateClustersK8s(t *testing.T) {
 	}
 	checkClusterStatus(t, validate.report, expected)
 
-	checkSummary(t, validate.report, Summary{OK: 37})
+	checkSummary(t, validate.report, Summary{OK: 39})
 }
 
 func TestValidateClustersOcp(t *testing.T) {
@@ -1067,6 +1094,24 @@ func TestValidateClustersOcp(t *testing.T) {
 						Name:               "odr-policy-5m",
 						DRClusters:         []string{"prsurve-s2-c1", "prsurve-s2-c2"},
 						SchedulingInterval: "5m",
+						PeerClasses: report.ValidatedPeerClassesList{
+							Validated: report.Validated{
+								State: report.OK,
+							},
+							Value: []report.PeerClassesSummary{
+								{
+									StorageClassName: "ocs-storagecluster-ceph-rbd",
+									ReplicationID:    "275fb2e9822a88bfbfb96516fd307ff3",
+								},
+								{
+									StorageClassName: "ocs-storagecluster-ceph-rbd-virtualization",
+									ReplicationID:    "275fb2e9822a88bfbfb96516fd307ff3",
+								},
+								{
+									StorageClassName: "ocs-storagecluster-cephfs",
+								},
+							},
+						},
 						Conditions: []report.ValidatedCondition{
 							{
 								Validated: report.Validated{
@@ -1315,7 +1360,7 @@ func TestValidateClustersOcp(t *testing.T) {
 	}
 	checkClusterStatus(t, validate.report, expected)
 
-	checkSummary(t, validate.report, Summary{OK: 36})
+	checkSummary(t, validate.report, Summary{OK: 37})
 }
 
 func TestValidateClustersValidateFailed(t *testing.T) {


### PR DESCRIPTION
This PR adds support for reporting and validate peer classes if it does not exist in the DRPolicy status. 
Update report and validate clusters unit tests to include peer classes.

Testing:

1. OCP:

```
./ramenctl validate clusters -c out/ocp/ocp.yaml -o out/val_ocp
⭐ Using config "out/ocp/ocp.yaml"
⭐ Using report "out/val_ocp"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "prsurve-s2-c1"
   ✅ Gathered data from cluster "prsurve-s2-c2"
   ✅ Gathered data from cluster "hub"
   ✅ Clusters validated

✅ Validation completed (37 ok, 0 stale, 0 problem)
```

report:
```
  hub:
    ...
    drPolicies:
      state: ok ✅
      value:
      - conditions:
        - state: ok ✅
          type: Validated
        drClusters:
        - prsurve-s2-c1
        - prsurve-s2-c2
        name: odr-policy-5m
        peerClasses:
          state: ok ✅
          value:
          - replicationID: 275fb2e9822a88bfbfb96516fd307ff3
            storageClassName: ocs-storagecluster-ceph-rbd
          - replicationID: 275fb2e9822a88bfbfb96516fd307ff3
            storageClassName: ocs-storagecluster-ceph-rbd-virtualization
          - storageClassName: ocs-storagecluster-cephfs
        schedulingInterval: 5m
```

2. Drenv

```
./ramenctl validate clusters -o out/val_k8s
⭐ Using config "config.yaml"
⭐ Using report "out/val_k8s"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Clusters validated

✅ Validation completed (37 ok, 0 stale, 0 problem)
```

report:

```
  hub:
    ...
    drPolicies:
      state: ok ✅
      value:
      - conditions:
        - state: ok ✅
          type: Validated
        drClusters:
        - dr1
        - dr2
        name: dr-policy
        peerClasses:
          state: ok ✅
          value:
          - replicationID: rook-ceph-replication-1
            storageClassName: rook-ceph-block
          - storageClassName: rook-cephfs-fs1
        schedulingInterval: 1m
```

3. Drenv (deleted SCs rook-ceph-block & rook-cephfs-fs1 on both dr clusters).

DRpolicy has no peer classes in the status:

```
  spec:
    drClusters:
    - dr1
    - dr2
    replicationClassSelector: {}
    schedulingInterval: 1m
    volumeGroupSnapshotClassSelector: {}
    volumeSnapshotClassSelector: {}
  status:
    async: {}
    conditions:
    - lastTransitionTime: "2025-10-06T08:31:28Z"
      message: drpolicy validated
      observedGeneration: 2
      reason: Succeeded
      status: "True"
      type: Validated
```

```
./ramenctl validate clusters -o out/val_k8s_no_sc
⭐ Using config "config.yaml"
⭐ Using report "out/val_k8s_no_sc"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ❌ Issues found during validation

❌ validation failed (36 ok, 0 stale, 1 problem)
```

report:

```
  hub:
    ...
    drPolicies:
      state: ok ✅
      value:
      - conditions:
        - state: ok ✅
          type: Validated
        drClusters:
        - dr1
        - dr2
        name: dr-policy
        peerClasses:
          description: No peer classes found
          state: problem ❌
        schedulingInterval: 1m
```
output dir of all above executions:
[val.tar.gz](https://github.com/user-attachments/files/22719050/val.tar.gz)

Fixes #321 