### PR TITLE
validate: report grouping

### DIFF
--- a/pkg/report/clusters.go
+++ b/pkg/report/clusters.go
@@ -27,6 +27,7 @@ type DRPolicySummary struct {
 type PeerClassesSummary struct {
 	StorageClassName string `json:"storageClassName"`
 	ReplicationID    string `json:"replicationID,omitempty"`
+	Grouping         bool   `json:"grouping,omitempty"`
 }
 
 // S3StoreProfilesSummary is the summary of S3 store profiles in the ConfigMap
@@ -190,6 +191,9 @@ func (p *PeerClassesSummary) Equal(o *PeerClassesSummary) bool {
 		return false
 	}
 	if p.ReplicationID != o.ReplicationID {
+		return false
+	}
+	if p.Grouping != o.Grouping {
 		return false
 	}
 	return true

--- a/pkg/report/clusters_test.go
+++ b/pkg/report/clusters_test.go
@@ -110,6 +110,11 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 		c2.Hub.DRPolicies.Value[0].PeerClasses.Value[0].StorageClassName = modified
 		checkClustersNotEqual(t, c1, c2)
 	})
+	t.Run("hub drpolicy peer classes grouping", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.DRPolicies.Value[0].PeerClasses.Value[0].Grouping = false
+		checkClustersNotEqual(t, c1, c2)
+	})
 	t.Run("hub drpolicy conditions", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Hub.DRPolicies.Value[0].Conditions[0].State = report.Problem
@@ -400,9 +405,11 @@ func testClusterStatus() *report.ClustersStatus {
 								{
 									StorageClassName: "rook-ceph-block",
 									ReplicationID:    "rook-ceph-replication-1",
+									Grouping:         true,
 								},
 								{
 									StorageClassName: "rook-cephfs-fs1",
+									Grouping:         true,
 								},
 							},
 						},
@@ -427,9 +434,11 @@ func testClusterStatus() *report.ClustersStatus {
 								{
 									StorageClassName: "rook-ceph-block",
 									ReplicationID:    "rook-ceph-replication-1",
+									Grouping:         true,
 								},
 								{
 									StorageClassName: "rook-cephfs-fs1",
+									Grouping:         true,
 								},
 							},
 						},

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -174,6 +174,7 @@ func (c *Command) validatedPeerClasses(
 		pcs := report.PeerClassesSummary{
 			StorageClassName: peerClass.StorageClassName,
 			ReplicationID:    peerClass.ReplicationID,
+			Grouping:         peerClass.Grouping,
 		}
 		peerClassesList.Value = append(peerClassesList.Value, pcs)
 	}

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -710,6 +710,7 @@ func TestValidateClustersK8s(t *testing.T) {
 							Validated: report.Validated{
 								State: report.OK,
 							},
+							// TODO: https://github.com/RamenDR/ramenctl/issues/329
 							Value: []report.PeerClassesSummary{
 								{
 									StorageClassName: "rook-ceph-block",
@@ -737,6 +738,7 @@ func TestValidateClustersK8s(t *testing.T) {
 							Validated: report.Validated{
 								State: report.OK,
 							},
+							// TODO: https://github.com/RamenDR/ramenctl/issues/329
 							Value: []report.PeerClassesSummary{
 								{
 									StorageClassName: "rook-ceph-block",
@@ -1103,13 +1105,16 @@ func TestValidateClustersOcp(t *testing.T) {
 								{
 									StorageClassName: "ocs-storagecluster-ceph-rbd",
 									ReplicationID:    "275fb2e9822a88bfbfb96516fd307ff3",
+									Grouping:         true,
 								},
 								{
 									StorageClassName: "ocs-storagecluster-ceph-rbd-virtualization",
 									ReplicationID:    "275fb2e9822a88bfbfb96516fd307ff3",
+									Grouping:         true,
 								},
 								{
 									StorageClassName: "ocs-storagecluster-cephfs",
+									Grouping:         true,
 								},
 							},
 						},


### PR DESCRIPTION
Add support for reporting consistency group capability by including the Grouping field from DR policy peer classes in its summary.

Testing:

OCP:

```
./ramenctl validate clusters -c out/ocp/ocp.yaml -o out/val_ocp_group
⭐ Using config "out/ocp/ocp.yaml"
⭐ Using report "out/val_ocp_group"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "prsurve-s2-c2"
validate: report grouping
   ✅ Gathered data from cluster "prsurve-s2-c1"
   ✅ Clusters validated

✅ Validation completed (37 ok, 0 stale, 0 problem)
```

report:
```
...
    drPolicies:
      state: ok ✅
      value:
      - conditions:
        - state: ok ✅
          type: Validated
        drClusters:
        - prsurve-s2-c1
        - prsurve-s2-c2
        name: odr-policy-5m
        peerClasses:
          state: ok ✅
          value:
          - grouping: true
            replicationID: 275fb2e9822a88bfbfb96516fd307ff3
            storageClassName: ocs-storagecluster-ceph-rbd
          - grouping: true
            replicationID: 275fb2e9822a88bfbfb96516fd307ff3
            storageClassName: ocs-storagecluster-ceph-rbd-virtualization
          - grouping: true
            storageClassName: ocs-storagecluster-cephfs
        schedulingInterval: 5m
...
```

Fixes #318 