### PR TITLE
validate: report pvcgroups in VRG summary

### DIFF
--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -25,6 +25,11 @@ type ProtectedPVCSummary struct {
 	Conditions  []ValidatedCondition `json:"conditions,omitempty"`
 }
 
+// PVCGroupsSummary represents list of CGs that are protected by the VRG.
+type PVCGroupsSummary struct {
+	Grouped []string `json:"grouped,omitempty"`
+}
+
 // DRPCSummary is the summary of a DRPC.
 type DRPCSummary struct {
 	Name        string               `json:"name"`
@@ -45,6 +50,7 @@ type VRGSummary struct {
 	State         ValidatedString       `json:"state"`
 	Conditions    []ValidatedCondition  `json:"conditions,omitempty"`
 	ProtectedPVCs []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
+	PVCGroups     []PVCGroupsSummary    `json:"pvcGroups,omitempty"`
 }
 
 // ApplicationHubStaus is the application status on the hub.
@@ -178,6 +184,15 @@ func (v *VRGSummary) Equal(o *VRGSummary) bool {
 	) {
 		return false
 	}
+	if !slices.EqualFunc(
+		v.PVCGroups,
+		o.PVCGroups,
+		func(a PVCGroupsSummary, b PVCGroupsSummary) bool {
+			return a.Equal(&b)
+		},
+	) {
+		return false
+	}
 	return true
 }
 
@@ -204,6 +219,19 @@ func (p *ProtectedPVCSummary) Equal(o *ProtectedPVCSummary) bool {
 		return false
 	}
 	if !slices.Equal(p.Conditions, o.Conditions) {
+		return false
+	}
+	return true
+}
+
+func (p *PVCGroupsSummary) Equal(o *PVCGroupsSummary) bool {
+	if p == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if !slices.Equal(p.Grouped, o.Grouped) {
 		return false
 	}
 	return true

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -198,6 +198,16 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2.PrimaryCluster.VRG.ProtectedPVCs[0].Conditions[0].State = report.Problem
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("primary cluster vrg pvcgroups nil", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.PVCGroups = nil
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg pvcgroups grouped", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.PVCGroups[0].Grouped = []string{"different-pvc"}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("secondary cluster name", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.SecondaryCluster.Name = modified
@@ -403,6 +413,11 @@ func testApplicationStatus() *report.ApplicationStatus {
 								Type: "DataProtected",
 							},
 						},
+					},
+				},
+				PVCGroups: []report.PVCGroupsSummary{
+					{
+						Grouped: []string{"pvc-name"},
 					},
 				},
 			},

--- a/pkg/validate/application.go
+++ b/pkg/validate/application.go
@@ -232,6 +232,7 @@ func (c *Command) validateApplicationVRG(
 	s.Deleted = c.validatedDeleted(vrg)
 	s.Conditions = c.validatedVRGConditions(vrg)
 	s.ProtectedPVCs = c.validatedProtectedPVCs(cluster, vrg)
+	s.PVCGroups = c.pvcGroups(vrg)
 	s.State = c.validatedVRGState(vrg, stableState)
 
 	return nil
@@ -439,4 +440,18 @@ func (c *Command) validatedProtectedPVCConditions(
 		conditions = append(conditions, validated)
 	}
 	return conditions
+}
+
+func (c *Command) pvcGroups(vrg *ramenapi.VolumeReplicationGroup) []report.PVCGroupsSummary {
+	if len(vrg.Status.PVCGroups) == 0 {
+		return nil
+	}
+
+	groups := make([]report.PVCGroupsSummary, 0, len(vrg.Status.PVCGroups))
+	for _, group := range vrg.Status.PVCGroups {
+		if len(group.Grouped) > 0 {
+			groups = append(groups, report.PVCGroupsSummary{Grouped: group.Grouped})
+		}
+	}
+	return groups
 }

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -1589,6 +1589,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 						},
 					},
 				},
+				// TODO: https://github.com/RamenDR/ramenctl/issues/330
 			},
 		},
 		SecondaryCluster: report.ApplicationStatusCluster{


### PR DESCRIPTION
Add support for reporting consistency group capability in VRG summary through the pvcgroups field in validate application. Update equality checks and tests accordingly.

Testing:

OCP:

```
⭐ Using config "out/ocp/ocp.yaml"
⭐ Using report "out/val_app4"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "prsurve-s2-c1"
   ✅ Gathered data from cluster "prsurve-s2-c2"
   ✅ Application validated

✅ Validation completed (20 ok, 0 stale, 0 problem)
```

report:

```
  primaryCluster:
    name: prsurve-s2-c1
    vrg:
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      name: asn-appset-cephfs-placement-drpc
      namespace: asn-appset-cephfs
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: ReplicationSourceSetup
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: asn-appset-cephfs
        phase:
          state: ok ✅
          value: Bound
        replication: volsync
      pvcGroups:
      - grouped:
        - busybox-pvc
      state:
        state: ok ✅
        value: Primary
```

Fixes #319 