### PR TITLE
build: Remove version from release artifact names

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         goversion: go.mod
+        asset_name: ramenctl-${{ matrix.goos }}-${{ matrix.goarch }}
         md5sum: FALSE
         compress_assets: OFF
         build_command: make ramenctl

--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ and install in the PATH.
 To install the latest release on Linux and macOS, run:
 
 ```console
-tag="$(curl -fsSL https://api.github.com/repos/ramendr/ramenctl/releases/latest | jq -r .tag_name)"
 os="$(uname | tr '[:upper:]' '[:lower:]')"
 machine="$(uname -m)"
 if [ "$machine" = "aarch64" ]; then machine="arm64"; fi
 if [ "$machine" = "x86_64" ]; then machine="amd64"; fi
 curl --location --fail --silent --show-error --output ramenctl \
-    https://github.com/ramendr/ramenctl/releases/download/$tag/ramenctl-$tag-$os-$machine
+    https://github.com/ramendr/ramenctl/releases/latest/download/ramenctl-$os-$machine
 sudo install ramenctl /usr/local/bin/
 rm ramenctl
 ```


### PR DESCRIPTION
Simplifies downloading the latest version. Users no longer need to access the GitHub API to get the tag. The latest version can now be downloaded from:
> https://github.com/ramendr/ramenctl/releases/latest/download/ramenctl-linux-amd64

This makes it easier to install ramenctl and avoids GitHub API failures and rate limiting.

Fixes #237 