### PR TITLE
automatically group imports

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -27,7 +27,7 @@ linters:
 formatters:
   enable:
     - gofmt
-    - goimports
+    - gci
     - golines
   exclusions:
     generated: lax
@@ -38,3 +38,8 @@ formatters:
   settings:
     golines:
       shorten-comments: true
+    gci:
+      sections:
+      - standard
+      - default
+      - localmodule

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ git commit --amend -s
 ## Coding Style
 
 The *ramenctl* project is written in the Go programming language and follows the
-style guidelines of gofmt, goimports, and golines tools.
+style guidelines of gofmt, gci, and golines tools.
 
 If your editor supports the [EditorConfig](https://editorconfig.org/) file it
 will format the code properaly automatically. For some editors you will need to

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -4,9 +4,10 @@
 package commands
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ramendr/ramenctl/pkg/config"
 	"github.com/ramendr/ramenctl/pkg/console"
-	"github.com/spf13/cobra"
 )
 
 var envFile string

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -4,9 +4,10 @@
 package commands
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/test"
-	"github.com/spf13/cobra"
 )
 
 var TestCmd = &cobra.Command{

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -4,9 +4,10 @@
 package commands
 
 import (
+	"github.com/spf13/cobra"
+
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/validate"
-	"github.com/spf13/cobra"
 )
 
 var ValidateCmd = &cobra.Command{

--- a/examples/odf.go
+++ b/examples/odf.go
@@ -7,10 +7,10 @@ package main
 import (
 	"log"
 
+	"github.com/spf13/cobra"
+
 	dr "github.com/ramendr/ramenctl/cmd/commands"
 	drbuild "github.com/ramendr/ramenctl/pkg/build"
-
-	"github.com/spf13/cobra"
 )
 
 var rootCmd = &cobra.Command{

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -11,12 +11,11 @@ import (
 	"os/signal"
 	"path/filepath"
 
-	"go.uber.org/zap"
-	"sigs.k8s.io/yaml"
-
 	e2econfig "github.com/ramendr/ramen/e2e/config"
 	e2eenv "github.com/ramendr/ramen/e2e/env"
 	"github.com/ramendr/ramen/e2e/types"
+	"go.uber.org/zap"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramenctl/pkg/console"
 )

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -9,9 +9,9 @@ import (
 	"maps"
 	"os"
 
+	"github.com/ramendr/ramen/e2e/config"
 	"github.com/spf13/viper"
 
-	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramenctl/pkg/console"
 )
 

--- a/pkg/config/envfile.go
+++ b/pkg/config/envfile.go
@@ -6,7 +6,6 @@ package config
 import (
 	"fmt"
 	"os"
-
 	"path/filepath"
 
 	"sigs.k8s.io/yaml"

--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -11,9 +11,10 @@ import (
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	e2etypes "github.com/ramendr/ramen/e2e/types"
-	"github.com/ramendr/ramenctl/pkg/gathering"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/yaml"
+
+	"github.com/ramendr/ramenctl/pkg/gathering"
 )
 
 const (

--- a/pkg/test/config.go
+++ b/pkg/test/config.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/deployers"
 	"github.com/ramendr/ramen/e2e/workloads"
+
 	"github.com/ramendr/ramenctl/pkg/console"
 )
 

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -8,10 +8,9 @@ import (
 	"fmt"
 	stdtime "time"
 
-	"go.uber.org/zap"
-
 	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
+	"go.uber.org/zap"
 )
 
 // Context implements types.TestContext interface.

--- a/pkg/test/report_test.go
+++ b/pkg/test/report_test.go
@@ -6,9 +6,8 @@ package test
 import (
 	"testing"
 
-	"sigs.k8s.io/yaml"
-
 	e2econfig "github.com/ramendr/ramen/e2e/config"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramenctl/pkg/report"
 	"github.com/ramendr/ramenctl/pkg/time"

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -9,12 +9,12 @@ import (
 	"os"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
+	"github.com/ramendr/ramen/e2e/types"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/ramendr/ramen/e2e/types"
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/ramen"

--- a/pkg/validation/backend.go
+++ b/pkg/validation/backend.go
@@ -5,6 +5,7 @@ package validation
 
 import (
 	"github.com/ramendr/ramen/e2e/types"
+
 	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/ramen"
 )

--- a/pkg/validation/distro.go
+++ b/pkg/validation/distro.go
@@ -6,12 +6,11 @@ package validation
 import (
 	"fmt"
 
+	e2econfig "github.com/ramendr/ramen/e2e/config"
+	"github.com/ramendr/ramen/e2e/types"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	e2econfig "github.com/ramendr/ramen/e2e/config"
-	"github.com/ramendr/ramen/e2e/types"
 )
 
 // detectDistro detects the cluster distribution. If distro is set in config, it uses the user

--- a/pkg/validation/mock.go
+++ b/pkg/validation/mock.go
@@ -5,6 +5,7 @@ package validation
 
 import (
 	"github.com/ramendr/ramen/e2e/types"
+
 	"github.com/ramendr/ramenctl/pkg/gathering"
 )
 


### PR DESCRIPTION
Switch from goimports to gci formatter to enforce import grouping across the codebase to organize imports into three sections: standard library, external dependencies (default), and local module imports.
Affected Go files have been reformatted.

Fixes #190 