### PR TITLE
refactor: Move k8s resource readers from validate package

### DIFF
--- a/pkg/core/core.go
+++ b/pkg/core/core.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package validate
+package core
 
 import (
 	v1 "k8s.io/api/core/v1"
@@ -16,7 +16,7 @@ const (
 	secretPlural    = "secrets"
 )
 
-func readPVC(
+func ReadPVC(
 	reader gathering.OutputReader,
 	name, namespace string,
 ) (*v1.PersistentVolumeClaim, error) {
@@ -31,7 +31,7 @@ func readPVC(
 	return pvc, nil
 }
 
-func readConfigMap(
+func ReadConfigMap(
 	reader gathering.OutputReader,
 	name, namespace string,
 ) (*v1.ConfigMap, error) {
@@ -46,7 +46,7 @@ func readConfigMap(
 	return configMap, nil
 }
 
-func readSecret(
+func ReadSecret(
 	reader gathering.OutputReader,
 	name, namespace string,
 ) (*v1.Secret, error) {

--- a/pkg/validate/application.go
+++ b/pkg/validate/application.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/core"
 	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/ramen"
 	"github.com/ramendr/ramenctl/pkg/report"
@@ -359,7 +360,7 @@ func (c *Command) validatedProtectedPVCs(
 			Conditions:  c.validatedProtectedPVCConditions(vrg, ppvc),
 		}
 
-		if pvc, err := readPVC(reader, ppvc.Name, ppvc.Namespace); err != nil {
+		if pvc, err := core.ReadPVC(reader, ppvc.Name, ppvc.Namespace); err != nil {
 			log.Warnf("failed to read pvc \"%s/%s\" from cluster %q: %s",
 				ppvc.Namespace, ppvc.Name, cluster.Name, err)
 			ps.Deleted = c.validatedDeleted(nil)

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -16,6 +16,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramenctl/pkg/console"
+	"github.com/ramendr/ramenctl/pkg/core"
 	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/ramen"
 	"github.com/ramendr/ramenctl/pkg/report"
@@ -319,7 +320,7 @@ func (c *Command) validateRamenConfigMap(
 	s.Name = name
 	s.Namespace = namespace
 
-	configMap, err := readConfigMap(reader, name, namespace)
+	configMap, err := core.ReadConfigMap(reader, name, namespace)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to read configmap \"%s/%s\" from cluster %q: %w",
@@ -417,7 +418,7 @@ func (c *Command) validatedSecretRef(
 		namespace = configNamespace
 	}
 
-	_, err := readSecret(reader, secretRef.Name, namespace)
+	_, err := core.ReadSecret(reader, secretRef.Name, namespace)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			err := fmt.Errorf("failed to read secret \"%s/%s\" from cluster %q: %w",


### PR DESCRIPTION
Move the resource reader helpers from `pkg/validate/core.go` to new `pkg/core` package and export them. These functions are generic utilities for reading Kubernetes resources and are not specific to the validate package.