### PR TITLE
ramen: add helpers for deployment and configmap names

### DIFF
--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -81,6 +81,18 @@ type Context interface {
 	Context() context.Context
 }
 
+// OperatorDeploymentName returns the deployment name for the given controller type.
+func OperatorDeploymentName(controllerType ramenapi.ControllerType) string {
+	switch controllerType {
+	case ramenapi.DRHubType:
+		return HubOperatorName
+	case ramenapi.DRClusterType:
+		return DRClusterOperatorName
+	default:
+		panic(fmt.Sprintf("Invalid controller type %q", controllerType))
+	}
+}
+
 // OperatorConfigMapName returns the ramen configmap name for the given controller type.
 func OperatorConfigMapName(controllerType ramenapi.ControllerType) string {
 	switch controllerType {

--- a/pkg/report/clusters_test.go
+++ b/pkg/report/clusters_test.go
@@ -500,7 +500,7 @@ func testClusterStatus() *report.ClustersStatus {
 					},
 				},
 				Deployment: report.DeploymentSummary{
-					Name:      "ramen-hub-operator",
+					Name:      ramen.HubOperatorName,
 					Namespace: "ramen-system",
 					Deleted: report.ValidatedBool{
 						Validated: report.Validated{
@@ -581,7 +581,7 @@ func testClusterStatus() *report.ClustersStatus {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: "ramen-system",
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{
@@ -661,7 +661,7 @@ func testClusterStatus() *report.ClustersStatus {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: "ramen-system",
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -274,17 +274,7 @@ func (c *Command) validateRamen(
 	namespace string,
 	controllerType ramenapi.ControllerType,
 ) error {
-	var deploymentName string
-
-	switch controllerType {
-	case ramenapi.DRHubType:
-		deploymentName = ramen.HubOperatorName
-	case ramenapi.DRClusterType:
-		deploymentName = ramen.DRClusterOperatorName
-	default:
-		panic(fmt.Sprintf("Invalid controller type %q", controllerType))
-	}
-
+	deploymentName := ramen.OperatorDeploymentName(controllerType)
 	configMapName := ramen.OperatorConfigMapName(controllerType)
 
 	if err := c.validateDeployment(

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -809,7 +809,7 @@ func TestValidateClustersK8s(t *testing.T) {
 					},
 				},
 				Deployment: report.DeploymentSummary{
-					Name:      "ramen-hub-operator",
+					Name:      ramen.HubOperatorName,
 					Namespace: testK8s.config.Namespaces.RamenHubNamespace,
 					Deleted: report.ValidatedBool{
 						Validated: report.Validated{
@@ -890,7 +890,7 @@ func TestValidateClustersK8s(t *testing.T) {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: testK8s.config.Namespaces.RamenDRClusterNamespace,
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{
@@ -970,7 +970,7 @@ func TestValidateClustersK8s(t *testing.T) {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: testK8s.config.Namespaces.RamenDRClusterNamespace,
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{
@@ -1176,7 +1176,7 @@ func TestValidateClustersOcp(t *testing.T) {
 					},
 				},
 				Deployment: report.DeploymentSummary{
-					Name:      "ramen-hub-operator",
+					Name:      ramen.HubOperatorName,
 					Namespace: testOcp.config.Namespaces.RamenHubNamespace,
 					Deleted: report.ValidatedBool{
 						Validated: report.Validated{
@@ -1255,7 +1255,7 @@ func TestValidateClustersOcp(t *testing.T) {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: testOcp.config.Namespaces.RamenDRClusterNamespace,
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{
@@ -1333,7 +1333,7 @@ func TestValidateClustersOcp(t *testing.T) {
 						},
 					},
 					Deployment: report.DeploymentSummary{
-						Name:      "ramen-dr-cluster-operator",
+						Name:      ramen.DRClusterOperatorName,
 						Namespace: testOcp.config.Namespaces.RamenDRClusterNamespace,
 						Deleted: report.ValidatedBool{
 							Validated: report.Validated{


### PR DESCRIPTION
This PR unifies operator and configmap naming across ramen, validate, and report packages:

- Add OperatorConfigMapName() and ConfigMap name constants.
- Add OperatorDeploymentName() for consistent deployment name lookup.
- Update report and validate tests to use shared constants.

validate cluster test to check any regression:

```
./ramenctl validate clusters -o out/val_k8s
⭐ Using config "config.yaml"
⭐ Using report "out/val_k8s"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Clusters validated

✅ Validation completed (39 ok, 0 stale, 0 problem)


report:
build:
  commit: b87e1d85ccdb5b699ffd35fa61b710eea0e3921e
  version: v0.12.0-18-gb87e1d8
clustersStatus:
  clusters:
  - name: dr1
    ramen:
      configmap:
        deleted:
          state: ok ✅
        name: ramen-dr-cluster-operator-config
        namespace: ramen-system
        ramenControllerType:
          state: ok ✅
          value: dr-cluster
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
      deployment:
        conditions:
        - state: ok ✅
          type: Available
        - state: ok ✅
          type: Progressing
        deleted:
          state: ok ✅
        name: ramen-dr-cluster-operator
        namespace: ramen-system
        replicas:
          state: ok ✅
          value: 1
  - name: dr2
    ramen:
      configmap:
        deleted:
          state: ok ✅
        name: ramen-dr-cluster-operator-config
        namespace: ramen-system
        ramenControllerType:
          state: ok ✅
          value: dr-cluster
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
      deployment:
        conditions:
        - state: ok ✅
          type: Available
        - state: ok ✅
          type: Progressing
        deleted:
          state: ok ✅
        name: ramen-dr-cluster-operator
        namespace: ramen-system
        replicas:
          state: ok ✅
          value: 1
  hub:
    drClusters:
    ...
    drPolicies:
    ...
    ramen:
      configmap:
        deleted:
          state: ok ✅
        name: ramen-hub-operator-config
        namespace: ramen-system
        ramenControllerType:
          state: ok ✅
          value: dr-hub
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
      deployment:
        conditions:
        - state: ok ✅
          type: Available
        - state: ok ✅
          type: Progressing
        deleted:
          state: ok ✅
        name: ramen-hub-operator
        namespace: ramen-system
        replicas:
          state: ok ✅
          value: 1
```