### PR TITLE
validate: gather ramen namespaces for application validation

### DIFF
--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -94,6 +94,8 @@ var (
 	})
 
 	validateApplicationNamespaces = sets.Sorted([]string{
+		testK8s.config.Namespaces.RamenHubNamespace,
+		testK8s.config.Namespaces.RamenDRClusterNamespace,
 		drpcNamespace,
 		applicationNamespace,
 	})


### PR DESCRIPTION
Add namespacesToGather to include ramen hub and managed cluster namespaces when gathering data for application validation. This allows accessing the ramen configmap and secrets needed for S3 validation.

Testing:

```
$ ./ramenctl validate application --namespace argocd --name appset-deploy-rbd --output out/v_appset_3
⭐ Using config "config.yaml"
⭐ Using report "out/v_appset_3"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Application validated

✅ Validation completed (21 ok, 0 stale, 0 problem)


$ tree -L3 validate-application.data
validate-application.data
├── dr1
│   ├── cluster
│   │   ├── namespaces
│   │   ├── persistentvolumes
│   │   └── storage.k8s.io
│   └── namespaces
│       ├── ramen-system
│       └── test-appset-deploy-rbd
├── dr2
│   ├── cluster
│   │   └── namespaces
│   └── namespaces
│       ├── ramen-system
│       └── test-appset-deploy-rbd
└── hub
    ├── cluster
    │   └── namespaces
    └── namespaces
        ├── argocd
        └── ramen-system

21 directories, 0 files
```