### PR TITLE
ci: update x86 macOS runner from macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,7 +82,7 @@ jobs:
           - ubuntu-24.04 # x86_64
           - ubuntu-24.04-arm # arm64
           - windows-latest # x86_64
-          - macos-13 # x86_64
+          - macos-15-intel # x86_64
           - macos-15 # arm64
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
The macos-13 runner is being deprecated. Use macos-15-intel to maintain x86_64 testing on macOS.

See: https://github.com/actions/runner-images/issues/13046