### PR TITLE
lint: format long lines for golines linter

### DIFF
--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -16,7 +16,11 @@ var InitCmd = &cobra.Command{
 	Use:   "init",
 	Short: "Create configuration file for your clusters",
 	Run: func(c *cobra.Command, args []string) {
-		if err := config.CreateSampleConfig(configFile, RootCmd.DisplayName(), envFile); err != nil {
+		if err := config.CreateSampleConfig(
+			configFile,
+			RootCmd.DisplayName(),
+			envFile,
+		); err != nil {
 			console.Fatal(err)
 		}
 		console.Completed("Created config file %q - please modify for your clusters", configFile)

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -304,7 +304,12 @@ func (c *Command) validateClustersClusters(s *[]report.ClustersStatusCluster) er
 
 	for _, cluster := range env.ManagedClusters() {
 		cs := report.ClustersStatusCluster{Name: cluster.Name}
-		if err := c.validateRamen(&cs.Ramen, cluster, namespace, ramenapi.DRClusterType); err != nil {
+		if err := c.validateRamen(
+			&cs.Ramen,
+			cluster,
+			namespace,
+			ramenapi.DRClusterType,
+		); err != nil {
 			return fmt.Errorf("failed to validate ramen: %w", err)
 		}
 		*s = append(*s, cs)

--- a/pkg/validation/distro.go
+++ b/pkg/validation/distro.go
@@ -40,8 +40,12 @@ func detectDistro(ctx Context) error {
 		if detectedDistro == "" {
 			detectedDistro = distro
 		} else if detectedDistro != distro {
-			return fmt.Errorf("clusters have inconsistent distributions, cluster %q has distro %q, expected %q",
-				cluster.Name, distro, detectedDistro)
+			return fmt.Errorf(
+				"clusters have inconsistent distributions, cluster %q has distro %q, expected %q",
+				cluster.Name,
+				distro,
+				detectedDistro,
+			)
 		}
 	}
 


### PR DESCRIPTION
Format long lines to comply with the updated golangci-lint from 2.7.2 to v2.8.0 golines rules.

CI:

- v2.7.2 (Jan 7): [[link]](https://github.com/RamenDR/ramenctl/actions/runs/20787906396/job/59702442026)
- v2.8.0 (Jan 9): [[link]](https://github.com/RamenDR/ramenctl/actions/runs/20853059731/job/59912536274)