### PR TITLE
validate: Add s3 bucket, endpoint and region fields validation

### DIFF
--- a/pkg/report/clusters.go
+++ b/pkg/report/clusters.go
@@ -32,9 +32,11 @@ type PeerClassesSummary struct {
 
 // S3StoreProfilesSummary is the summary of S3 store profiles in the ConfigMap
 type S3StoreProfilesSummary struct {
-	S3ProfileName string               `json:"profileName"`
-	S3Bucket      ValidatedString      `json:"bucket"`
-	S3SecretRef   ValidatedS3SecretRef `json:"secret"`
+	S3ProfileName        string               `json:"profileName"`
+	S3Bucket             ValidatedString      `json:"bucket"`
+	S3CompatibleEndpoint ValidatedString      `json:"endpoint"`
+	S3Region             ValidatedString      `json:"region"`
+	S3SecretRef          ValidatedS3SecretRef `json:"secret"`
 }
 
 // ConfigMapSummary is the summary of a Ramen ConfigMap.
@@ -267,6 +269,12 @@ func (s *S3StoreProfilesSummary) Equal(o *S3StoreProfilesSummary) bool {
 		return false
 	}
 	if s.S3Bucket != o.S3Bucket {
+		return false
+	}
+	if s.S3CompatibleEndpoint != o.S3CompatibleEndpoint {
+		return false
+	}
+	if s.S3Region != o.S3Region {
 		return false
 	}
 	if s.S3SecretRef != o.S3SecretRef {

--- a/pkg/report/clusters_test.go
+++ b/pkg/report/clusters_test.go
@@ -180,6 +180,26 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Bucket.Value = helpers.Modified
 		checkClustersNotEqual(t, c1, c2)
 	})
+	t.Run("hub ramen configmap s3storeprofiles s3CompatibleEndpoint state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3CompatibleEndpoint.State = report.Problem
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("hub ramen configmap s3storeprofiles s3CompatibleEndpoint value", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3CompatibleEndpoint.Value = helpers.Modified
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("hub ramen configmap s3storeprofiles s3Region state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Region.State = report.Problem
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("hub ramen configmap s3storeprofiles s3Region value", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Region.Value = helpers.Modified
+		checkClustersNotEqual(t, c1, c2)
+	})
 	t.Run("hub ramen configmap s3storeprofiles secretref state", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Hub.Ramen.ConfigMap.S3StoreProfiles.Value[0].S3SecretRef.State = report.Problem
@@ -296,6 +316,26 @@ func TestReportClusterStatusNotEqual(t *testing.T) {
 	t.Run("cluster ramen configmap s3storeprofiles s3bucket value", func(t *testing.T) {
 		c2 := testClusterStatus()
 		c2.Clusters[0].Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Bucket.Value = helpers.Modified
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap s3storeprofiles s3CompatibleEndpoint state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.S3StoreProfiles.Value[0].S3CompatibleEndpoint.State = report.Problem
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap s3storeprofiles s3CompatibleEndpoint value", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.S3StoreProfiles.Value[0].S3CompatibleEndpoint.Value = helpers.Modified
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap s3storeprofiles s3Region state", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Region.State = report.Problem
+		checkClustersNotEqual(t, c1, c2)
+	})
+	t.Run("cluster ramen configmap s3storeprofiles s3Region value", func(t *testing.T) {
+		c2 := testClusterStatus()
+		c2.Clusters[0].Ramen.ConfigMap.S3StoreProfiles.Value[0].S3Region.Value = helpers.Modified
 		checkClustersNotEqual(t, c1, c2)
 	})
 	t.Run("cluster ramen configmap s3storeprofiles secretref state", func(t *testing.T) {
@@ -536,6 +576,14 @@ func testClusterStatus() *report.ClustersStatus {
 									Validated: report.Validated{State: report.OK},
 									Value:     "bucket",
 								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "http://example-cluster:30000",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "us-west-1",
+								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
 										State: report.OK,
@@ -551,6 +599,14 @@ func testClusterStatus() *report.ClustersStatus {
 								S3Bucket: report.ValidatedString{
 									Validated: report.Validated{State: report.OK},
 									Value:     "bucket",
+								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "http://example-cluster:30000",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "us-east-1",
 								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
@@ -625,6 +681,14 @@ func testClusterStatus() *report.ClustersStatus {
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-west-1",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -640,6 +704,14 @@ func testClusterStatus() *report.ClustersStatus {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-east-1",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
@@ -713,6 +785,14 @@ func testClusterStatus() *report.ClustersStatus {
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-west-1",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -728,6 +808,14 @@ func testClusterStatus() *report.ClustersStatus {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-east-1",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{

--- a/pkg/validate/clusters.go
+++ b/pkg/validate/clusters.go
@@ -446,9 +446,11 @@ func (c *Command) validatedHubS3Profiles(
 		}
 
 		ps := report.S3StoreProfilesSummary{
-			S3ProfileName: profile.S3ProfileName,
-			S3Bucket:      c.validatedRequiredString(profile.S3Bucket),
-			S3SecretRef:   validatedSecret,
+			S3ProfileName:        profile.S3ProfileName,
+			S3Bucket:             c.validatedRequiredString(profile.S3Bucket),
+			S3CompatibleEndpoint: c.validatedRequiredString(profile.S3CompatibleEndpoint),
+			S3Region:             c.validatedRequiredString(profile.S3Region),
+			S3SecretRef:          validatedSecret,
 		}
 		s.Value = append(s.Value, ps)
 	}
@@ -488,6 +490,16 @@ func (c *Command) validatedManagedClusterS3Profiles(
 			S3Bucket: c.validatedManagedClusterRequiredString(
 				profile.S3Bucket,
 				hubS3Profile.S3Bucket,
+				found,
+			),
+			S3CompatibleEndpoint: c.validatedManagedClusterRequiredString(
+				profile.S3CompatibleEndpoint,
+				hubS3Profile.S3CompatibleEndpoint,
+				found,
+			),
+			S3Region: c.validatedManagedClusterRequiredString(
+				profile.S3Region,
+				hubS3Profile.S3Region,
 				found,
 			),
 			S3SecretRef: validatedSecret,

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -856,6 +856,14 @@ func TestValidateClustersK8s(t *testing.T) {
 									Validated: report.Validated{State: report.OK},
 									Value:     "bucket",
 								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "http://example-cluster:30000",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "us-west-1",
+								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
 										State: report.OK,
@@ -871,6 +879,14 @@ func TestValidateClustersK8s(t *testing.T) {
 								S3Bucket: report.ValidatedString{
 									Validated: report.Validated{State: report.OK},
 									Value:     "bucket",
+								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "http://example-cluster:30000",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "us-east-1",
 								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
@@ -945,6 +961,14 @@ func TestValidateClustersK8s(t *testing.T) {
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-west-1",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -960,6 +984,14 @@ func TestValidateClustersK8s(t *testing.T) {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-east-1",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
@@ -1033,6 +1065,14 @@ func TestValidateClustersK8s(t *testing.T) {
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-west-1",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -1048,6 +1088,14 @@ func TestValidateClustersK8s(t *testing.T) {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "bucket",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "http://example-cluster:30000",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "us-east-1",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
@@ -1124,7 +1172,7 @@ func TestValidateClustersK8s(t *testing.T) {
 	}
 	checkClusterStatus(t, validate.report, expected)
 
-	checkSummary(t, validate.report, report.Summary{OK: 48})
+	checkSummary(t, validate.report, report.Summary{OK: 60})
 }
 
 func TestValidateClustersOcp(t *testing.T) {
@@ -1285,6 +1333,14 @@ func TestValidateClustersOcp(t *testing.T) {
 									Validated: report.Validated{State: report.OK},
 									Value:     "odrbucket-244c8f95bf0d",
 								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "https://s3-openshift-storage.apps.c1.example.com",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "noobaa",
+								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
 										State: report.OK,
@@ -1299,6 +1355,14 @@ func TestValidateClustersOcp(t *testing.T) {
 								S3Bucket: report.ValidatedString{
 									Validated: report.Validated{State: report.OK},
 									Value:     "odrbucket-244c8f95bf0d",
+								},
+								S3CompatibleEndpoint: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "https://s3-openshift-storage.apps.c2.example.com",
+								},
+								S3Region: report.ValidatedString{
+									Validated: report.Validated{State: report.OK},
+									Value:     "noobaa",
 								},
 								S3SecretRef: report.ValidatedS3SecretRef{
 									Validated: report.Validated{
@@ -1372,6 +1436,14 @@ func TestValidateClustersOcp(t *testing.T) {
 										Validated: report.Validated{State: report.OK},
 										Value:     "odrbucket-244c8f95bf0d",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "https://s3-openshift-storage.apps.c1.example.com",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "noobaa",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -1386,6 +1458,14 @@ func TestValidateClustersOcp(t *testing.T) {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "odrbucket-244c8f95bf0d",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "https://s3-openshift-storage.apps.c2.example.com",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "noobaa",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
@@ -1458,6 +1538,14 @@ func TestValidateClustersOcp(t *testing.T) {
 										Validated: report.Validated{State: report.OK},
 										Value:     "odrbucket-244c8f95bf0d",
 									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "https://s3-openshift-storage.apps.c1.example.com",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "noobaa",
+									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
 											State: report.OK,
@@ -1472,6 +1560,14 @@ func TestValidateClustersOcp(t *testing.T) {
 									S3Bucket: report.ValidatedString{
 										Validated: report.Validated{State: report.OK},
 										Value:     "odrbucket-244c8f95bf0d",
+									},
+									S3CompatibleEndpoint: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "https://s3-openshift-storage.apps.c2.example.com",
+									},
+									S3Region: report.ValidatedString{
+										Validated: report.Validated{State: report.OK},
+										Value:     "noobaa",
 									},
 									S3SecretRef: report.ValidatedS3SecretRef{
 										Validated: report.Validated{
@@ -1547,7 +1643,7 @@ func TestValidateClustersOcp(t *testing.T) {
 	}
 	checkClusterStatus(t, validate.report, expected)
 
-	checkSummary(t, validate.report, report.Summary{OK: 46})
+	checkSummary(t, validate.report, report.Summary{OK: 58})
 }
 
 func TestValidateClustersValidateFailed(t *testing.T) {
@@ -1678,7 +1774,7 @@ func TestValidateClustersCheckS3Failed(t *testing.T) {
 	checkSummary(
 		t,
 		validate.report,
-		report.Summary{OK: 47, Problem: 1},
+		report.Summary{OK: 59, Problem: 1},
 	)
 }
 


### PR DESCRIPTION
Add S3 store profile bucket, endpoint and region validation in the validate clusters command to ensure fields are not empty and are same between hub and managed clusters.

Testing(done for s3 bucket and validation is similar for endpoint and region fields):

Pass scenario:
```
./ramenctl validate clusters --output out/v_clu_1
⭐ Using config "config.yaml"
⭐ Using report "out/v_clu_1"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr2"
   ✅ Checked S3 profile "minio-on-dr1"
   ✅ Clusters validated

✅ Validation completed (48 ok, 0 stale, 0 problem)

clusters:
  - name: dr1
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  - name: dr2
    ramen:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  hub:
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
 ```

Fail scenario: edited to provide incorrect bucket name `wrong-bucket` in dr2 configmap:

```               
./ramenctl validate clusters --output out/v_clu_2
⭐ Using config "config.yaml"
⭐ Using report "out/v_clu_2"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr1"
   ✅ Checked S3 profile "minio-on-dr2"
   ❌ Issues found during validation

❌ validation failed (47 ok, 0 stale, 1 problem)

clustersStatus:
  clusters:
  - name: dr1
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  - name: dr2
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              description: '"wrong-bucket" does not match hub "bucket"'
              state: problem ❌
              value: wrong-bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  hub:
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
```
 
Fail scenario: edited hub configmap to remove one of the profiles bucket name(`empty value`), which was propgated to dr clusters. Other validation problems seen in check s3 and drcluster which are expected:

```
./ramenctl validate clusters --output out/v_clu_3
⭐ Using config "config.yaml"
⭐ Using report "out/v_clu_3"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr2"
   ❌ Failed to check S3 profile "minio-on-dr1"
   ❌ Issues found during validation

❌ validation failed (43 ok, 0 stale, 5 problem)


clustersStatus:
  clusters:
  - name: dr1
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              description: value is empty
              state: problem ❌
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  - name: dr2
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              description: value is empty
              state: problem ❌
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  hub:
    drClusters:
      state: ok ✅
      value:
      - conditions:
        - state: ok ✅
          type: Fenced
        - state: ok ✅
          type: Clean
        - description: 'minio-on-dr1: failed to get profile minio-on-dr1 for caller
            drpolicy validation, s3 bucket has not been configured in s3 profile minio-on-dr1'
          state: problem ❌
          type: Validated
        name: dr1
        phase: Available
      - conditions:
        - state: ok ✅
          type: Fenced
        - state: ok ✅
          type: Clean
        - state: ok ✅
          type: Validated
        name: dr2
        phase: Available
    ramen:
      configmap:
        s3StoreProfiles:
          state: ok ✅
          value:
          - s3Bucket:
              description: value is empty
              state: problem ❌
            s3ProfileName: minio-on-dr1
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr1
                namespace: ramen-system
          - s3Bucket:
              state: ok ✅
              value: bucket
            s3ProfileName: minio-on-dr2
            s3SecretRef:
              state: ok ✅
              value:
                name: ramen-s3-secret-dr2
                namespace: ramen-system
  s3:
    profiles:
      state: ok ✅
      value:
      - accessible:
          state: ok ✅
          value: true
        name: minio-on-dr2
      - accessible:
          description: 'failed to access bucket "" for profile "minio-on-dr1": operation
            error S3: HeadBucket, https response error StatusCode: 400, RequestID:
            , HostID: , api error BadRequest: Bad Request'
          state: problem ❌
        name: minio-on-dr1
```

Fixes part-of: https://github.com/RamenDR/ramenctl/issues/358