### PR TITLE
e2e: Support tests with recipes and hooks

### DIFF
--- a/docs/init.md
+++ b/docs/init.md
@@ -137,6 +137,26 @@ deployers:
 - name: disapp
   type: disapp
   description: Discovered Application deployer for discovered applications
+- name: disapp-recipe
+  type: disapp
+  recipe:
+    type: generate
+- name: disapp-recipe-check
+  type: disapp
+  recipe:
+    type: generate
+    checkHook: true
+- name: disapp-recipe-exec
+  type: disapp
+  recipe:
+    type: generate
+    execHook: true
+- name: disapp-recipe-check-exec
+  type: disapp
+  recipe:
+    type: generate
+    checkHook: true
+    execHook: true
 
 ## Tests cases for test command.
 # - Modify the test for your preferred workload or deployment type.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,7 +126,15 @@ The available options are:
 - deployers
   - `appset`: OCM managed application deployed using *ApplicationSet*.
   - `subscr`: OCM managed application deployed using *Subscription*.
-  - `disapp`: OCM discovered application deployed by the test command.`
+  - `disapp`: OCM discovered application deployed by the test command.
+  - `disapp-recipe`: OCM discovered application deployed using recipe without
+   any hooks by the test command.
+  - `disapp-recipe-check`: OCM discovered application deployed using recipe
+   with check hooks by the test command.
+  - `disapp-recipe-exec`: OCM discovered application deployed using recipe
+   with exec hooks by the test command.
+  - `disapp-recipe-check-exec`: OCM discovered application deployed using
+   recipe with check and exec hooks by the test command.
 - pvcSpecs:
   - `rbd`: *Ceph* *RBD* storage
   - `cephfs`: *CephFS* storage

--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/aymanbagabas/go-udiff v0.3.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.10.1
-	github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5
-	github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1
+	github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30
+	github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.19.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4

--- a/go.sum
+++ b/go.sum
@@ -235,10 +235,10 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5 h1:2hL/5Ofwx/7O2NRA7q3WdL4rHe1yl8k3sHy7GNkCp+A=
-github.com/ramendr/ramen/api v0.0.0-20250710152106-9a4f493138c5/go.mod h1:vtuEN3pI8SD0WEp5jAPf2Bqi/3CeiuQZkNz6F52NIqo=
-github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1 h1:ltQUo1hPMFUhF/oLJZ/OglRCoJMWZkugYAEzzbg/sU0=
-github.com/ramendr/ramen/e2e v0.0.0-20250925105626-1e3bf8dbc4d1/go.mod h1:7/WO8c/srYUJ+S/gmV7qwJABxQX9ymWcaqWjUFewRRc=
+github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf5Kg+u05Q/0klUEDTVT27kKc2/9LeLI=
+github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
+github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780 h1:6TJ2D6N8sfFYWXXTyzkLQg7nBFu0yNYZdGmnRkhcOOU=
+github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780/go.mod h1:BhAPwG+WRu/nJ3Qr9BM+pEMNu6N4QYGftCczD8QWsHk=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/config/sample.yaml
+++ b/pkg/config/sample.yaml
@@ -56,6 +56,26 @@ deployers:
 - name: disapp
   type: disapp
   description: Discovered Application deployer for discovered applications
+- name: disapp-recipe
+  type: disapp
+  recipe:
+    type: generate
+- name: disapp-recipe-check
+  type: disapp
+  recipe:
+    type: generate
+    checkHook: true
+- name: disapp-recipe-exec
+  type: disapp
+  recipe:
+    type: generate
+    execHook: true
+- name: disapp-recipe-check-exec
+  type: disapp
+  recipe:
+    type: generate
+    checkHook: true
+    execHook: true
 
 ## Tests cases for test command.
 # - Modify the test for your preferred workload or deployment type.

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	e2econfig "github.com/ramendr/ramen/e2e/config"
@@ -34,6 +35,22 @@ var (
 			{Name: "appset", Type: "appset"},
 			{Name: "subscr", Type: "subscr"},
 			{Name: "disapp", Type: "disapp"},
+			{Name: "disapp-recipe", Type: "disapp", Recipe: &e2econfig.Recipe{Type: "generate"}},
+			{
+				Name:   "disapp-recipe-check",
+				Type:   "disapp",
+				Recipe: &e2econfig.Recipe{Type: "generate", CheckHook: true},
+			},
+			{
+				Name:   "disapp-recipe-exec",
+				Type:   "disapp",
+				Recipe: &e2econfig.Recipe{Type: "generate", ExecHook: true},
+			},
+			{
+				Name:   "disapp-recipe-check-exec",
+				Type:   "disapp",
+				Recipe: &e2econfig.Recipe{Type: "generate", CheckHook: true, ExecHook: true},
+			},
 		},
 		Tests: []e2econfig.Test{
 			{Workload: "deploy", Deployer: "appset", PVCSpec: "rbd"},
@@ -42,6 +59,14 @@ var (
 			{Workload: "deploy", Deployer: "subscr", PVCSpec: "cephfs"},
 			{Workload: "deploy", Deployer: "disapp", PVCSpec: "rbd"},
 			{Workload: "deploy", Deployer: "disapp", PVCSpec: "cephfs"},
+			{Workload: "deploy", Deployer: "disapp-recipe", PVCSpec: "rbd"},
+			{Workload: "deploy", Deployer: "disapp-recipe", PVCSpec: "cephfs"},
+			{Workload: "deploy", Deployer: "disapp-recipe-check", PVCSpec: "rbd"},
+			{Workload: "deploy", Deployer: "disapp-recipe-check", PVCSpec: "cephfs"},
+			{Workload: "deploy", Deployer: "disapp-recipe-exec", PVCSpec: "rbd"},
+			{Workload: "deploy", Deployer: "disapp-recipe-exec", PVCSpec: "cephfs"},
+			{Workload: "deploy", Deployer: "disapp-recipe-check-exec", PVCSpec: "rbd"},
+			{Workload: "deploy", Deployer: "disapp-recipe-check-exec", PVCSpec: "cephfs"},
 		},
 	}
 
@@ -254,7 +279,7 @@ func TestRunDisappFailed(t *testing.T) {
 		t,
 		test.report,
 		report.Failed,
-		report.Summary{Passed: 4, Failed: 2},
+		report.Summary{Passed: 4, Failed: 10},
 	)
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
@@ -267,7 +292,7 @@ func TestRunDisappFailed(t *testing.T) {
 	checkStep(t, tests, TestsStep, report.Failed)
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
-		if tc.Deployer == "disapp" {
+		if strings.HasPrefix(tc.Deployer, "disapp") {
 			checkTest(t, result, tc, report.Failed, "deploy", "protect", "failover")
 		} else {
 			checkTest(t, result, tc, report.Passed, runFlow...)
@@ -310,7 +335,7 @@ func TestCleanPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	checkReport(t, test.report, report.Passed, report.Summary{Passed: 6})
+	checkReport(t, test.report, report.Passed, report.Summary{Passed: 14})
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}


### PR DESCRIPTION
This PR:
1. updates go mod to get the latest dependency from ramen/e2e using `go get github.com/ramendr/ramen/e2e@latest`
2. update sample.yaml with deployers having recipe and disapp config.

Fixes #385 and consumes https://github.com/RamenDR/ramen/pull/2405 