### PR TITLE
golangci: Disable gosec rules that don't apply to CLI tools

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,8 +19,20 @@ linters:
       - third_party$
       - builtin$
       - examples$
+    rules:
+      # G705 (XSS) not relevant for CLI tools writing to stderr.
+      - path: tools/
+        text: "G705"
   settings:
     gosec:
+      excludes:
+        # G602 (slice bounds) has high false positive rate and Go has runtime
+        # bounds checking, so out of bounds access causes a panic instead of
+        # silent memory corruption.
+        - G602
+        # G703 (path traversal) not relevant for CLI tools. The user can
+        # specify any path, including paths with "..".
+        - G703
       config:
         # Maximum allowed permissions mode for os.WriteFile (default 0600)
         G306: "0640"


### PR DESCRIPTION
After upgrading golangci-lint, gosec reports new errors that are false positives for this project:

G602 (slice bounds out of range):
Flagged in fingerprint.go where we iterate over a sha256 sum and index into a slice created with the same length. Gosec cannot prove the lengths match through static analysis. Since Go has runtime bounds checking, out of bounds access causes a panic with a clear stack trace rather than silent memory corruption. With good test coverage, this check adds noise without value.

G703 (path traversal via taint analysis):
Flagged in htmlfmt when reading/writing files from command line args. This rule is designed for web services where user input could escape a sandboxed directory. For CLI tools, the user can specify any path - this is the intended behavior, not a vulnerability.

G705 (XSS via taint analysis):
Flagged in htmlfmt when printing to stderr. This rule is designed for web services outputting HTML. Stderr is plain text, not rendered as HTML, so XSS is not possible. Disabled only for tools/ directory to keep XSS checks active for HTML report generation in pkg/.