### PR TITLE
golangci: Disable gosec G118 (context cancellation)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -33,6 +33,10 @@ linters:
         # G703 (path traversal) not relevant for CLI tools. The user can
         # specify any path, including paths with "..".
         - G703
+        # G118 (context cancellation) flags functions that return cancel to the
+        # caller instead of calling it directly. This is a valid pattern for
+        # helper functions like withTimeout().
+        - G118
       config:
         # Maximum allowed permissions mode for os.WriteFile (default 0600)
         G306: "0640"


### PR DESCRIPTION
G118 flags context.WithTimeout calls where the cancel function is returned to the caller instead of being called in the same function. This is a false positive for our withTimeout() helpers that return cancel for the caller to defer.

Assisted-by: Cursor/Claude Opus 4.6