### PR TITLE
templates: Extract validated sub-template for reuse

### DIFF
--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -14,7 +14,7 @@ func TestTemplate(t *testing.T) {
 	}
 
 	// Check that shared templates are defined
-	for _, name := range []string{"report.tmpl", "style"} {
+	for _, name := range []string{"report.tmpl", "style", "validated"} {
 		if tmpl.Lookup(name) == nil {
 			t.Errorf("template %q not defined", name)
 		}

--- a/pkg/report/templates/validated.tmpl
+++ b/pkg/report/templates/validated.tmpl
@@ -1,0 +1,9 @@
+{{/* SPDX-FileCopyrightText: The RamenDR authors */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{define "validated" -}}
+<span class="value">{{.Value}}</span>
+<span class="state">{{icon .State}}</span>
+{{- if .Description}}
+<p class="description">{{.Description}}</p>
+{{- end}}
+{{- end}}

--- a/pkg/validate/application/html_test.go
+++ b/pkg/validate/application/html_test.go
@@ -19,7 +19,7 @@ func TestTemplate(t *testing.T) {
 	}
 
 	// Check that shared templates and command templates are defined
-	for _, name := range []string{"report.tmpl", "style", "content"} {
+	for _, name := range []string{"report.tmpl", "style", "validated", "content"} {
 		if tmpl.Lookup(name) == nil {
 			t.Errorf("template %q not defined", name)
 		}

--- a/pkg/validate/application/templates/content.tmpl
+++ b/pkg/validate/application/templates/content.tmpl
@@ -18,38 +18,14 @@
         </dl>
         <dl class="validation">
             <dt>Action</dt>
-            <dd>
-                <span class="value">{{.Action.Value}}</span>
-                <span class="state">{{icon .Action.State}}</span>
-                {{- if .Action.Description}}
-                    <p class="description">{{.Action.Description}}</p>
-                {{- end}}
-            </dd>
+            <dd>{{template "validated" .Action}}</dd>
             <dt>Phase</dt>
-            <dd>
-                <span class="value">{{.Phase.Value}}</span>
-                <span class="state">{{icon .Phase.State}}</span>
-                {{- if .Phase.Description}}
-                    <p class="description">{{.Phase.Description}}</p>
-                {{- end}}
-            </dd>
+            <dd>{{template "validated" .Phase}}</dd>
             <dt>Progression</dt>
-            <dd>
-                <span class="value">{{.Progression.Value}}</span>
-                <span class="state">{{icon .Progression.State}}</span>
-                {{- if .Progression.Description}}
-                    <p class="description">{{.Progression.Description}}</p>
-                {{- end}}
-            </dd>
+            <dd>{{template "validated" .Progression}}</dd>
             {{- if isProblem .Deleted.State}}
                 <dt>Deleted</dt>
-                <dd>
-                    <span class="value">{{.Deleted.Value}}</span>
-                    <span class="state">{{icon .Deleted.State}}</span>
-                    {{- if .Deleted.Description}}
-                        <p class="description">{{.Deleted.Description}}</p>
-                    {{- end}}
-                </dd>
+                <dd>{{template "validated" .Deleted}}</dd>
             {{- end}}
         </dl>
         <section>
@@ -98,13 +74,7 @@
             <h4>{{.Name}}</h4>
             <dl class="validation">
                 <dt>Gathered</dt>
-                <dd>
-                    <span class="value">{{.Gathered.Value}}</span>
-                    <span class="state">{{icon .Gathered.State}}</span>
-                    {{- if .Gathered.Description}}
-                        <p class="description">{{.Gathered.Description}}</p>
-                    {{- end}}
-                </dd>
+                <dd>{{template "validated" .Gathered}}</dd>
             </dl>
         </section>
     {{- end}}


### PR DESCRIPTION
The value/state/description pattern for validated fields was repeated 6 times in content.tmpl and would multiply as VRG and PVC sections are added.

Extract a shared "validated" template in pkg/report/templates/ so it can be reused by both the application and clusters reports. Usage in content.tmpl:

    <dd>{{template "validated" .Action}}</dd>

Instead of:

    <dd>
        <span class="value">{{.Action.Value}}</span>
        <span class="state">{{icon .Action.State}}</span>
        {{- if .Action.Description}}
            <p class="description">{{.Action.Description}}</p>
        {{- end}}
    </dd>

The template works with any report.Validated* type that has Value, State, and Description fields (ValidatedString, ValidatedBool, etc.).

The S3 Profiles count (uses {{len .Value}}) and conditions (no Value field) cannot use this template and remain unchanged.

Assisted-by: Cursor/Claude Opus 4.6