### PR TITLE
command: Open HTML report in default browser

### DIFF
--- a/cmd/commands/gather.go
+++ b/cmd/commands/gather.go
@@ -4,10 +4,11 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/gather"
 )
 
@@ -28,7 +29,7 @@ var GatherApplicationCmd = &cobra.Command{
 			DRPCName:      drpcName,
 			DRPCNamespace: drpcNamespace,
 		}); err != nil {
-			console.Fatal(err)
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/commands/init.go
+++ b/cmd/commands/init.go
@@ -4,6 +4,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/config"
@@ -21,7 +23,8 @@ var InitCmd = &cobra.Command{
 			RootCmd.DisplayName(),
 			envFile,
 		); err != nil {
-			console.Fatal(err)
+			_ = console.Failed(err)
+			os.Exit(1)
 		}
 		console.Completed("Created config file %q - please modify for your clusters", configFile)
 	},

--- a/cmd/commands/root.go
+++ b/cmd/commands/root.go
@@ -4,7 +4,10 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 
 	"github.com/ramendr/ramenctl/pkg/build"
 )
@@ -22,6 +25,10 @@ var (
 	// drpcNamespace is the DRPC resource namespace on the hub. Used by commands handlign protected
 	// applications.
 	drpcNamespace string
+
+	// interactive controls interactive features like opening a browser. When not set by the user,
+	// defaults to true if stdout is a terminal.
+	interactive bool
 )
 
 var RootCmd = &cobra.Command{
@@ -30,7 +37,11 @@ var RootCmd = &cobra.Command{
 	Version: build.Version,
 
 	// When used as a subcommand in another tool, don't inherit persistent pre run commands.
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {},
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if !cmd.Flags().Changed("interactive") {
+			interactive = term.IsTerminal(int(os.Stdout.Fd()))
+		}
+	},
 }
 
 func init() {
@@ -40,6 +51,9 @@ func init() {
 	// These flags are used by all sub commands.
 	RootCmd.PersistentFlags().
 		StringVarP(&configFile, "config", "c", "config.yaml", "configuration file")
+	RootCmd.PersistentFlags().
+		BoolVar(&interactive, "interactive", false, "enable interactive features")
+	RootCmd.PersistentFlags().Lookup("interactive").DefValue = "auto"
 }
 
 func addOutputFlags(c *cobra.Command) {

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -4,10 +4,11 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/test"
 )
 
@@ -24,7 +25,7 @@ var TestRunCmd = &cobra.Command{
 			ConfigFile: configFile,
 			OutputDir:  outputDir,
 		}); err != nil {
-			console.Fatal(err)
+			os.Exit(1)
 		}
 	},
 }
@@ -37,7 +38,7 @@ var TestCleanCmd = &cobra.Command{
 			ConfigFile: configFile,
 			OutputDir:  outputDir,
 		}); err != nil {
-			console.Fatal(err)
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -4,10 +4,11 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/ramendr/ramenctl/pkg/command"
-	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/validate"
 )
 
@@ -24,7 +25,7 @@ var ValidateClustersCmd = &cobra.Command{
 			ConfigFile: configFile,
 			OutputDir:  outputDir,
 		}); err != nil {
-			console.Fatal(err)
+			os.Exit(1)
 		}
 	},
 }
@@ -41,7 +42,7 @@ var ValidateApplicationCmd = &cobra.Command{
 			DRPCName:      drpcName,
 			DRPCNamespace: drpcNamespace,
 		}); err != nil {
-			console.Fatal(err)
+			os.Exit(1)
 		}
 	},
 }

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -22,8 +22,9 @@ var ValidateClustersCmd = &cobra.Command{
 	Short: "Detect problems in disaster recovery clusters",
 	Run: func(c *cobra.Command, args []string) {
 		if err := validate.Clusters(command.Options{
-			ConfigFile: configFile,
-			OutputDir:  outputDir,
+			ConfigFile:  configFile,
+			OutputDir:   outputDir,
+			Interactive: interactive,
 		}); err != nil {
 			os.Exit(1)
 		}
@@ -36,8 +37,9 @@ var ValidateApplicationCmd = &cobra.Command{
 	Run: func(c *cobra.Command, args []string) {
 		if err := validate.Application(command.ApplicationOptions{
 			Options: command.Options{
-				ConfigFile: configFile,
-				OutputDir:  outputDir,
+				ConfigFile:  configFile,
+				OutputDir:   outputDir,
+				Interactive: interactive,
 			},
 			DRPCName:      drpcName,
 			DRPCNamespace: drpcNamespace,

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4
 	go.uber.org/zap v1.27.1
+	golang.org/x/term v0.41.0
 	k8s.io/api v0.33.10
 	k8s.io/apimachinery v0.33.10
 	k8s.io/client-go v0.33.10
@@ -89,7 +90,6 @@ require (
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	golang.org/x/term v0.41.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	golang.org/x/time v0.9.0 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect

--- a/pkg/command/browser.go
+++ b/pkg/command/browser.go
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ramendr/ramenctl/pkg/console"
+)
+
+// BrowseReport opens the HTML report in the default browser. If the report cannot be opened, it
+// logs a notice suggesting to open the file manually to view the report.
+func (c *Command) BrowseReport() {
+	path := filepath.Join(c.outputDir, c.name+".html")
+
+	if _, err := os.Stat(path); err != nil {
+		c.log.Warnf("Skipping browse %q: %s", path, err)
+		return
+	}
+
+	var err error
+	var hint string
+
+	switch runtime.GOOS {
+	case "darwin":
+		// https://keith.github.io/xcode-man-pages/open.1.html
+		err = run("open", path)
+	case "windows":
+		// https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/start
+		err = run("cmd", "/c", "start", "", path)
+	default:
+		// Other platforms (linux, *bsd, etc.) - may not have xdg-open, but contributors
+		// can add special cases above for their platform.
+		// https://portland.freedesktop.org/doc/xdg-open.html
+		if _, e := exec.LookPath("xdg-open"); e != nil {
+			err = e
+			hint = "Install xdg-open to open the report automatically"
+		} else {
+			err = run("xdg-open", path)
+		}
+	}
+
+	if err != nil {
+		c.log.Warnf("Cannot open %q in browser: %s", path, err)
+		console.Info("Cannot open %q, please open it in a browser to view the report", path)
+		if hint != "" {
+			console.Hint(hint)
+		}
+	}
+}
+
+func run(command string, args ...string) error {
+	cmd := exec.Command(command, args...)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("%w: %s", err, stderr.String())
+	}
+	return nil
+}

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -5,8 +5,9 @@ package command
 
 // Options shared by all commands except init.
 type Options struct {
-	ConfigFile string
-	OutputDir  string
+	ConfigFile  string
+	OutputDir   string
+	Interactive bool
 }
 
 // ApplicationOptions shared by commands operating on a protected application.

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -4,9 +4,13 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 	"os"
 )
+
+// errReported is returned by Failed to signal that the error was already reported to the user.
+var errReported = errors.New("command failed")
 
 func Info(format string, args ...any) {
 	fmt.Printf("⭐ "+format+"\n", args...)
@@ -37,8 +41,9 @@ func Hint(format string, args ...any) {
 	fmt.Printf("   "+format+"\n", args...)
 }
 
-// Fatal logs command failure and exit.
-func Fatal(err error) {
+// Failed logs command failure and returns a generic error to signal failure without duplicating
+// the error message.
+func Failed(err error) error {
 	fmt.Fprintf(os.Stderr, "\n❌ %s\n", err)
-	os.Exit(1)
+	return errReported
 }

--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -32,6 +32,11 @@ func Completed(format string, args ...any) {
 	fmt.Printf("\n✅ "+format+"\n", args...)
 }
 
+// Hint logs a suggestion to the user, indented under the previous message.
+func Hint(format string, args ...any) {
+	fmt.Printf("   "+format+"\n", args...)
+}
+
 // Fatal logs command failure and exit.
 func Fatal(err error) {
 	fmt.Fprintf(os.Stderr, "\n❌ %s\n", err)

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -8,21 +8,26 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/validation"
 )
 
 func Gather(opts command.ApplicationOptions) error {
 	config, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
-		return fmt.Errorf("unable to read config: %w", err)
+		return console.Failed(fmt.Errorf("unable to read config: %w", err))
 	}
 
 	cmd, err := command.New("gather-application", config.Clusters, opts.Options)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 	defer cmd.Close()
 
 	gather := newCommand(cmd, config, validation.Backend{}, opts)
-	return gather.Run()
+	if err := gather.Run(); err != nil {
+		return console.Failed(err)
+	}
+
+	return nil
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -5,21 +5,26 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
 func Clean(opts command.Options) error {
 	cfg, err := readConfig(opts.ConfigFile)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 
 	cmd, err := command.New("test-clean", cfg.Clusters, opts)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 	defer cmd.Close()
 
 	test := newCommand(cmd, cfg, testing.Backend{})
-	return test.Clean()
+	if err := test.Clean(); err != nil {
+		return console.Failed(err)
+	}
+
+	return nil
 }

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -5,21 +5,26 @@ package test
 
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
 func Run(opts command.Options) error {
 	cfg, err := readConfig(opts.ConfigFile)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 
 	cmd, err := command.New("test-run", cfg.Clusters, opts)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 	defer cmd.Close()
 
 	test := newCommand(cmd, cfg, testing.Backend{})
-	return test.Run()
+	if err := test.Run(); err != nil {
+		return console.Failed(err)
+	}
+
+	return nil
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -25,11 +25,17 @@ func Clusters(opts command.Options) error {
 	defer cmd.Close()
 
 	validate := clusters.NewCommand(cmd, cfg, validation.Backend{})
+
+	var failed error
 	if err := validate.Run(); err != nil {
-		return console.Failed(err)
+		failed = console.Failed(err)
 	}
 
-	return nil
+	if opts.Interactive {
+		cmd.BrowseReport()
+	}
+
+	return failed
 }
 
 func Application(opts command.ApplicationOptions) error {
@@ -45,9 +51,15 @@ func Application(opts command.ApplicationOptions) error {
 	defer cmd.Close()
 
 	validate := application.NewCommand(cmd, cfg, validation.Backend{}, opts)
+
+	var failed error
 	if err := validate.Run(); err != nil {
-		return console.Failed(err)
+		failed = console.Failed(err)
 	}
 
-	return nil
+	if opts.Interactive {
+		cmd.BrowseReport()
+	}
+
+	return failed
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -6,6 +6,7 @@ package validate
 import (
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
+	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/validate/application"
 	"github.com/ramendr/ramenctl/pkg/validate/clusters"
 	"github.com/ramendr/ramenctl/pkg/validation"
@@ -14,31 +15,39 @@ import (
 func Clusters(opts command.Options) error {
 	cfg, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 
 	cmd, err := command.New(clusters.CommandName, cfg.Clusters, opts)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 	defer cmd.Close()
 
 	validate := clusters.NewCommand(cmd, cfg, validation.Backend{})
-	return validate.Run()
+	if err := validate.Run(); err != nil {
+		return console.Failed(err)
+	}
+
+	return nil
 }
 
 func Application(opts command.ApplicationOptions) error {
 	cfg, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 
 	cmd, err := command.New(application.CommandName, cfg.Clusters, opts.Options)
 	if err != nil {
-		return err
+		return console.Failed(err)
 	}
 	defer cmd.Close()
 
 	validate := application.NewCommand(cmd, cfg, validation.Backend{}, opts)
-	return validate.Run()
+	if err := validate.Run(); err != nil {
+		return console.Failed(err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
After validation completes, the HTML report is automatically opened in
the default browser, whether the validation passed or failed. When
ramenctl is used in scripts or automation (stdout piped), the browser is
not opened. Users can override the auto-detection with
`--interactive=true` or `--interactive=false`.

Changes:

- Add `BrowseReport()` function to open the HTML report in the default
  browser after a command completes.
- Move error output from cobra handlers into the command functions so
  commands have full control over the output flow. This is needed to
  open the browser after the last error message.
- Wire up `BrowseReport()` in the validate commands to open the report
  when done.
- Add `--interactive` flag (default auto) to skip browser opening when
  running non-interactively. When not set explicitly, defaults to true
  if stdout is a terminal.

Example usage:

```console
# opens browser (tty)
$ ramenctl validate clusters -o out

# no browser (pipe)
$ ramenctl validate clusters -o out | cat

# opens browser (explicit)
$ ramenctl validate clusters -o out --interactive=true | tee out.log
```
---
Based on #424 for testing.