### PR TITLE
HTML report stylesheet

### DIFF
--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -7,6 +7,8 @@ import (
 	"embed"
 	"fmt"
 	"html/template"
+	"os"
+	"path/filepath"
 
 	"github.com/yosssi/gohtml"
 	"sigs.k8s.io/yaml"
@@ -16,6 +18,15 @@ import (
 
 //go:embed templates/*.tmpl
 var templates embed.FS
+
+//go:embed style.css
+var styleCSS []byte
+
+// WriteCSS writes the shared stylesheet to the output directory.
+func WriteCSS(dir string) error {
+	path := filepath.Join(dir, "style.css")
+	return os.WriteFile(path, styleCSS, 0o640)
+}
 
 // Template returns a new template set with shared definitions.
 func Template() (*template.Template, error) {

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -36,6 +36,8 @@ func Template() (*template.Template, error) {
 		"formatYAML":     formatYAML,
 		"icon":           icon,
 		"isProblem":      isProblem,
+		"truncate":       truncate,
+		"isTruncated":    isTruncated,
 	}
 	return template.New("").Funcs(funcs).ParseFS(templates, "templates/*.tmpl")
 }
@@ -57,6 +59,20 @@ func icon(s ValidationState) string {
 	default:
 		return ""
 	}
+}
+
+// truncate shortens a value to n characters, appending ".." if truncated.
+func truncate(v any, n int) string {
+	s := fmt.Sprint(v)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
+// isTruncated returns true if the value would be truncated by truncate().
+func isTruncated(v any, n int) bool {
+	return len(fmt.Sprint(v)) > n
 }
 
 // formatTime formats a time value for display in reports.

--- a/pkg/report/html_test.go
+++ b/pkg/report/html_test.go
@@ -14,7 +14,7 @@ func TestTemplate(t *testing.T) {
 	}
 
 	// Check that shared templates are defined
-	for _, name := range []string{"report.tmpl", "style", "validated"} {
+	for _, name := range []string{"report.tmpl", "validated"} {
 		if tmpl.Lookup(name) == nil {
 			t.Errorf("template %q not defined", name)
 		}

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -1,0 +1,6 @@
+/* SPDX-FileCopyrightText: The RamenDR authors */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+body {
+    font-family: system-ui, sans-serif;
+}

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -58,6 +58,88 @@ section section {
     padding-left: 12px;
 }
 
+.details-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
+    gap: 12px;
+    background: #e8e8e8;
+    padding: 12px;
+}
+
+.details-grid > h2 {
+    grid-column: 1 / -1;
+    margin: 0;
+}
+
+.details-grid > section {
+    margin-top: 0;
+    background: white;
+    border: 1px solid darkgray;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.details-grid > section > h3 {
+    margin: 0;
+}
+
+.details-grid > section > dl + h3 {
+    margin-top: 12px;
+}
+
+.namespaces {
+    list-style: none;
+    padding: 0;
+    margin: 8px 0 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.namespaces > li {
+    background: #f0f0f0;
+    padding: 2px 10px;
+    border-radius: 12px;
+    font-size: 0.9em;
+}
+
+.steps {
+    list-style: none;
+    padding: 0;
+    margin: 4px 0 0 0;
+}
+
+.steps ul {
+    list-style: none;
+    padding: 0;
+    padding-left: 32px;
+    margin-right: -8px;
+    flex-basis: 100%;
+}
+
+.step {
+    padding: 4px 8px;
+    margin: 4px 0;
+    border-left: 3px solid darkgray;
+    border-radius: 4px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+}
+
+.step-duration {
+    margin-left: auto;
+    color: gray;
+}
+
+.step.passed {
+    border-left-color: green;
+}
+
+.step.failed {
+    border-left-color: red;
+}
+
 /*
  * Header grid layout:
  *

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -16,3 +16,76 @@ h5,
 h6 {
     font-size: 1.1em;
 }
+
+section {
+    max-width: 40em;
+}
+
+/*
+ * dl.metadata - key/value pairs:
+ *
+ *   key ... value
+ *   key ... value
+ *
+ * dl.validation - key/value pairs with state icon,
+ * optional description, and optional nested dl:
+ *
+ *   key ... value text .............................. icon
+ *           optional description
+ *
+ *   key ... nested key ... value .................... icon
+ *
+ *       ... nested key ... value .................... icon
+ *                          optional description
+ */
+
+dl.metadata,
+dl.validation {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 12px;
+    align-items: baseline;
+    margin: 0;
+    width: 100%;
+}
+
+dl.metadata+dl.validation,
+dl.validation+dl.metadata {
+    margin-top: 4px;
+}
+
+dl.metadata dt,
+dl.validation dt {
+    color: gray;
+}
+
+dl.metadata dd,
+dl.validation dd {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+    margin: 0;
+    min-width: 0;
+}
+
+.value {
+    flex: 1;
+}
+
+.state {
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+.description {
+    flex-basis: 100%;
+    font-size: 0.85em;
+    margin: 0;
+}
+
+dd>ul {
+    flex-basis: 100%;
+    list-style: none;
+    padding: 0;
+}

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -271,6 +271,13 @@ dl.validation dd {
     font-size: 0.85em;
 }
 
+.pvc {
+    background: #f9fafb;
+    border-left: 3px solid #d1d5db;
+    border-radius: 4px;
+    margin: 8px 0;
+}
+
 .description {
     flex-basis: 100%;
     font-size: 0.85em;

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -3,6 +3,7 @@
 
 body {
     font-family: system-ui, sans-serif;
+    margin: 0;
 }
 
 h1 {
@@ -10,15 +11,51 @@ h1 {
 }
 
 h2,
-h3,
+h3 {
+    font-size: 1.1em;
+    margin: 4px 0;
+}
+
 h4,
 h5,
 h6 {
-    font-size: 1.1em;
+    font-size: 1em;
+    margin: 4px 0;
 }
 
-section {
-    max-width: 40em;
+
+.main-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
+    gap: 12px;
+    background: #e8e8e8;
+    padding: 12px;
+}
+
+.main-grid > h2 {
+    grid-column: 1 / -1;
+    margin: 0;
+}
+
+.main-grid > section {
+    margin-top: 0;
+    background: white;
+    border: 1px solid darkgray;
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.main-grid > section > h3 {
+    margin: 0;
+}
+
+dl + section,
+section section + section {
+    margin-top: 8px;
+}
+
+section section {
+    padding-left: 12px;
 }
 
 /*
@@ -148,6 +185,7 @@ dl.validation dd {
 .state {
     flex-shrink: 0;
     margin-left: auto;
+    font-size: 0.85em;
 }
 
 .description {

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -22,6 +22,78 @@ section {
 }
 
 /*
+ * Header grid layout:
+ *
+ *   Title ... subtitle           ┌────────────────────────┐
+ *                                │        passed          │
+ *   Created ...  Duration ...    └────────────────────────┘
+ *                                24 ok, 0 stale, 0 problem
+ */
+
+header {
+    background: #4a4a4a;
+    color: white;
+    padding: 20px 24px 12px 24px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 4px 12px;
+}
+
+header h1 {
+    grid-column: 1;
+    font-size: 1.1em;
+    margin: 0;
+}
+
+.subtitle {
+    margin-left: 12px;
+}
+
+.result {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    justify-content: center;
+    gap: 4px;
+}
+
+.status {
+    padding: 8px 16px;
+    border-radius: 20px;
+    font-weight: 600;
+    font-size: 16px;
+    text-align: center;
+}
+
+.status.passed {
+    background: green;
+}
+
+.status.failed {
+    background: red;
+}
+
+.status.canceled {
+    background: gray;
+}
+
+header footer {
+    grid-column: 1;
+    display: flex;
+    gap: 20px;
+    font-size: 0.85em;
+    opacity: 0.9;
+}
+
+.summary {
+    font-size: 0.85em;
+    opacity: 0.9;
+    text-align: center;
+}
+
+/*
  * dl.metadata - key/value pairs:
  *
  *   key ... value

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -3,6 +3,7 @@
 
 body {
     font-family: system-ui, sans-serif;
+    font-size: 0.9em;
     margin: 0;
 }
 
@@ -26,7 +27,7 @@ h6 {
 
 .main-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(540px, 1fr));
     gap: 12px;
     background: #e8e8e8;
     padding: 12px;
@@ -60,7 +61,7 @@ section section {
 
 .details-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(600px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(540px, 1fr));
     gap: 12px;
     background: #e8e8e8;
     padding: 12px;

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -20,8 +20,12 @@ h3 {
 h4,
 h5,
 h6 {
-    font-size: 1em;
-    margin: 4px 0;
+    font-size: 0.9em;
+    font-weight: bold;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    color: #666;
+    margin: 12px 0 4px 0;
 }
 
 
@@ -57,6 +61,12 @@ section section + section {
 
 section section {
     padding-left: 12px;
+}
+
+section section > h4,
+section section > h5,
+section section > h6 {
+    margin-left: -12px;
 }
 
 .details-grid {
@@ -130,7 +140,7 @@ section section {
 
 .step-duration {
     margin-left: auto;
-    color: gray;
+    color: #666;
 }
 
 .step.passed {
@@ -248,7 +258,9 @@ dl.validation+dl.metadata {
 
 dl.metadata dt,
 dl.validation dt {
-    color: gray;
+    color: #666;
+    font-weight: normal;
+    min-width: 8em;
 }
 
 dl.metadata dd,
@@ -259,6 +271,7 @@ dl.validation dd {
     gap: 8px;
     margin: 0;
     min-width: 0;
+    font-weight: 600;
 }
 
 .value {

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -4,3 +4,15 @@
 body {
     font-family: system-ui, sans-serif;
 }
+
+h1 {
+    font-size: 1.4em;
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-size: 1.1em;
+}

--- a/pkg/report/templates/report.tmpl
+++ b/pkg/report/templates/report.tmpl
@@ -9,22 +9,17 @@
 </head>
 <body>
 <header>
-    <h1>{{.HeaderData.Title}}</h1>
-{{- if .HeaderData.Subtitle}}
-    <p class="subtitle">{{.HeaderData.Subtitle}}</p>
-{{- end}}
-    <p class="result">
+    <h1>{{.HeaderData.Title}}{{- if .HeaderData.Subtitle}} <span class="subtitle">{{.HeaderData.Subtitle}}</span>{{- end}}</h1>
+    <div class="result">
         <span class="status {{.Status}}">{{.Status}}</span>
         {{- if .Summary}}
-            <span class="summary">{{.SummaryString}}</span>
+        <span class="summary">{{.SummaryString}}</span>
         {{- end}}
-    </p>
-    <dl class="timing">
-        <dt>Created</dt>
-        <dd>{{formatTime .Created}}</dd>
-        <dt>Duration</dt>
-        <dd>{{formatDuration .Duration}}</dd>
-    </dl>
+    </div>
+    <footer>
+        <span>Created {{formatTime .Created}}</span>
+        <span>Duration {{formatDuration .Duration}}</span>
+    </footer>
 </header>
 <main>
     <section>

--- a/pkg/report/templates/report.tmpl
+++ b/pkg/report/templates/report.tmpl
@@ -5,9 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <title>{{.HeaderData.Title}}</title>
-    <style>
-        {{template "style" .}}
-    </style>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <header>

--- a/pkg/report/templates/report.tmpl
+++ b/pkg/report/templates/report.tmpl
@@ -26,10 +26,10 @@
         {{template "content" .}}
     </section>
 
-    <section>
+    <div class="details-grid">
         <h2>Report Details</h2>
-        {{- with .Build}}
         <section>
+            {{- with .Build}}
             <h3>Build</h3>
             <dl class="metadata">
                 <dt>Version</dt>
@@ -37,9 +37,7 @@
                 <dt>Commit</dt>
                 <dd title="{{.Commit}}">{{truncate .Commit 10}}</dd>
             </dl>
-        </section>
-        {{- end}}
-        <section>
+            {{- end}}
             <h3>Host</h3>
             <dl class="metadata">
                 <dt>OS</dt>
@@ -49,17 +47,15 @@
                 <dt>CPUs</dt>
                 <dd>{{.Host.Cpus}}</dd>
             </dl>
-        </section>
-        {{- with .Namespaces}}
-        <section>
+            {{- with .Namespaces}}
             <h3>Namespaces</h3>
-            <ul>
+            <ul class="namespaces">
                 {{- range .}}
                 <li>{{.}}</li>
                 {{- end}}
             </ul>
+            {{- end}}
         </section>
-        {{- end}}
         <section>
             <h3>Config</h3>
             <pre>{{formatYAML .Config}}</pre>
@@ -70,7 +66,7 @@
                 {{- template "steps" .Steps}}
             </ul>
         </section>
-    </section>
+    </div>
 </main>
 </body>
 </html>

--- a/pkg/report/templates/report.tmpl
+++ b/pkg/report/templates/report.tmpl
@@ -40,7 +40,7 @@
                 <dt>Version</dt>
                 <dd>{{.Version}}</dd>
                 <dt>Commit</dt>
-                <dd>{{.Commit}}</dd>
+                <dd title="{{.Commit}}">{{truncate .Commit 10}}</dd>
             </dl>
         </section>
         {{- end}}

--- a/pkg/report/templates/steps.tmpl
+++ b/pkg/report/templates/steps.tmpl
@@ -3,8 +3,8 @@
 {{define "steps" -}}
 {{- range .}}
 <li class="step {{.Status}}">
-    <span>{{.Name}}</span>
-    <span>{{formatDuration .Duration}}</span>
+    <span class="step-name">{{.Name}}</span>
+    <span class="step-duration">{{formatDuration .Duration}}</span>
     {{- with .Items}}
     <ul>
         {{- template "steps" .}}

--- a/pkg/report/templates/style.tmpl
+++ b/pkg/report/templates/style.tmpl
@@ -1,5 +1,0 @@
-{{/* SPDX-FileCopyrightText: The RamenDR authors */}}
-{{/* SPDX-License-Identifier: Apache-2.0 */}}
-{{define "style" -}}
-body { font-family: system-ui, sans-serif; }
-{{- end}}

--- a/pkg/report/templates/validated.tmpl
+++ b/pkg/report/templates/validated.tmpl
@@ -1,7 +1,11 @@
 {{/* SPDX-FileCopyrightText: The RamenDR authors */}}
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{define "validated" -}}
+{{- if isTruncated .Value .MaxLen -}}
+<span class="value" title="{{.Value}}">{{truncate .Value .MaxLen}}</span>
+{{- else -}}
 <span class="value">{{.Value}}</span>
+{{- end}}
 <span class="state">{{icon .State}}</span>
 {{- if .Description}}
 <p class="description">{{.Description}}</p>

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -101,6 +101,16 @@ func (v *Validated) GetState() ValidationState {
 	return v.State
 }
 
+// MaxLen returns the maximum display length for truncation.
+func (v *Validated) MaxLen() int {
+	return 32
+}
+
+// MaxLen returns the maximum display length for fingerprint truncation.
+func (v *ValidatedFingerprint) MaxLen() int {
+	return 16
+}
+
 func (v *ValidatedDRClustersList) Equal(o *ValidatedDRClustersList) bool {
 	if v == o {
 		return true

--- a/pkg/validate/application/html.go
+++ b/pkg/validate/application/html.go
@@ -23,7 +23,7 @@ type templateData struct {
 // HeaderData returns data for the report template.
 func (d *templateData) HeaderData() report.HeaderData {
 	return report.HeaderData{
-		Title:    "Application Validation Report",
+		Title:    "Validate Application",
 		Subtitle: d.Application.Namespace + " / " + d.Application.Name,
 	}
 }

--- a/pkg/validate/application/html_test.go
+++ b/pkg/validate/application/html_test.go
@@ -24,7 +24,6 @@ func TestTemplate(t *testing.T) {
 		// Shared templates from pkg/report.
 		"conditions",
 		"report.tmpl",
-		"style",
 		"validated",
 		// Command templates.
 		"content",

--- a/pkg/validate/application/html_test.go
+++ b/pkg/validate/application/html_test.go
@@ -89,7 +89,7 @@ func TestHeaderData(t *testing.T) {
 	actual := d.HeaderData()
 
 	expected := report.HeaderData{
-		Title:    "Application Validation Report",
+		Title:    "Validate Application",
 		Subtitle: "argocd / appset-deploy-rbd",
 	}
 

--- a/pkg/validate/application/templates/content.tmpl
+++ b/pkg/validate/application/templates/content.tmpl
@@ -2,8 +2,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{define "content" -}}
 {{- with .ApplicationStatus}}
+<div class="main-grid">
 <h2>Application Status</h2>
-
 {{- with .Hub}}
 <section>
     <h3>Hub</h3>
@@ -40,5 +40,6 @@
     {{template "s3" .Profiles}}
 </section>
 {{- end}}
+</div>
 {{- end}}
 {{- end}}

--- a/pkg/validate/application/templates/vrg.tmpl
+++ b/pkg/validate/application/templates/vrg.tmpl
@@ -19,10 +19,14 @@
     <h5>Conditions</h5>
     {{template "conditions" .Conditions}}
 </section>
-{{- range .ProtectedPVCs}}
+{{- with .ProtectedPVCs}}
 <section>
-    <h5>PVC: {{.Name}}</h5>
-    {{template "pvc" .}}
+    <h5>Protected PVCs</h5>
+    {{- range .}}
+    <section class="pvc">
+        {{template "pvc" .}}
+    </section>
+    {{- end}}
 </section>
 {{- end}}
 {{- end}}

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -78,27 +78,29 @@
                 </dl>
               </section>
               <section>
-                <h5>PVC: busybox-pvc</h5>
-                <dl class="metadata">
-                  <dt>Name</dt>
-                  <dd>busybox-pvc</dd>
-                  <dt>Namespace</dt>
-                  <dd>test-appset-deploy-rbd</dd>
-                  <dt>Replication</dt>
-                  <dd>volrep</dd>
-                </dl>
-                <dl class="validation">
-                  <dt>Phase</dt>
-                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                </dl>
-                <section>
-                  <h6>Conditions</h6>
-                  <dl class="validation">
-                    <dt>DataReady</dt>
-                    <dd><span class="state">✅</span></dd>
-                    <dt>ClusterDataProtected</dt>
-                    <dd><span class="state">✅</span></dd>
+                <h5>Protected PVCs</h5>
+                <section class="pvc">
+                  <dl class="metadata">
+                    <dt>Name</dt>
+                    <dd>busybox-pvc</dd>
+                    <dt>Namespace</dt>
+                    <dd>test-appset-deploy-rbd</dd>
+                    <dt>Replication</dt>
+                    <dd>volrep</dd>
                   </dl>
+                  <dl class="validation">
+                    <dt>Phase</dt>
+                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                  </dl>
+                  <section>
+                    <h6>Conditions</h6>
+                    <dl class="validation">
+                      <dt>DataReady</dt>
+                      <dd><span class="state">✅</span></dd>
+                      <dt>ClusterDataProtected</dt>
+                      <dd><span class="state">✅</span></dd>
+                    </dl>
+                  </section>
                 </section>
               </section>
             </section>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -149,7 +149,7 @@
           </section>
         </div>
       </section>
-      <section>
+      <div class="details-grid">
         <h2>Report Details</h2>
         <section>
           <h3>Build</h3>
@@ -159,8 +159,6 @@
             <dt>Commit</dt>
             <dd title="c5cc831b601f99c3a83a297da6840c3f21376b39">c5cc831b60...</dd>
           </dl>
-        </section>
-        <section>
           <h3>Host</h3>
           <dl class="metadata">
             <dt>OS</dt>
@@ -170,10 +168,8 @@
             <dt>CPUs</dt>
             <dd>12</dd>
           </dl>
-        </section>
-        <section>
           <h3>Namespaces</h3>
-          <ul>
+          <ul class="namespaces">
             <li>argocd</li>
             <li>ramen-system</li>
             <li>test-appset-deploy-rbd</li>
@@ -202,23 +198,23 @@ namespaces:
         <section>
           <h3>Steps</h3>
           <ul class="steps">
-            <li class="step passed"><span>validate config</span><span>0.01s</span></li>
+            <li class="step passed"><span class="step-name">validate config</span><span class="step-duration">0.01s</span></li>
             <li class="step passed">
-              <span>validate application</span><span>2.20s</span>
+              <span class="step-name">validate application</span><span class="step-duration">2.20s</span>
               <ul>
-                <li class="step passed"><span>inspect application</span><span>0.00s</span></li>
-                <li class="step passed"><span>gather &#34;hub&#34;</span><span>1.22s</span></li>
-                <li class="step passed"><span>gather &#34;dr2&#34;</span><span>2.14s</span></li>
-                <li class="step passed"><span>gather &#34;dr1&#34;</span><span>2.18s</span></li>
-                <li class="step passed"><span>inspect S3 profiles</span><span>0.00s</span></li>
-                <li class="step passed"><span>gather S3 profile &#34;minio-on-dr2&#34;</span><span>0.01s</span></li>
-                <li class="step passed"><span>gather S3 profile &#34;minio-on-dr1&#34;</span><span>0.01s</span></li>
-                <li class="step passed"><span>validate data</span><span>0.00s</span></li>
+                <li class="step passed"><span class="step-name">inspect application</span><span class="step-duration">0.00s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;hub&#34;</span><span class="step-duration">1.22s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr2&#34;</span><span class="step-duration">2.14s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr1&#34;</span><span class="step-duration">2.18s</span></li>
+                <li class="step passed"><span class="step-name">inspect S3 profiles</span><span class="step-duration">0.00s</span></li>
+                <li class="step passed"><span class="step-name">gather S3 profile &#34;minio-on-dr2&#34;</span><span class="step-duration">0.01s</span></li>
+                <li class="step passed"><span class="step-name">gather S3 profile &#34;minio-on-dr1&#34;</span><span class="step-duration">0.01s</span></li>
+                <li class="step passed"><span class="step-name">validate data</span><span class="step-duration">0.00s</span></li>
               </ul>
             </li>
           </ul>
         </section>
-      </section>
+      </div>
     </main>
   </body>
 </html>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -13,139 +13,141 @@
     </header>
     <main>
       <section>
-        <h2>Application Status</h2>
-        <section>
-          <h3>Hub</h3>
+        <div class="main-grid">
+          <h2>Application Status</h2>
           <section>
-            <h4>DRPC</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>argocd</dd>
-              <dt>DRPolicy</dt>
-              <dd>dr-policy-1m</dd>
-            </dl>
-            <dl class="validation">
-              <dt>Action</dt>
-              <dd><span class="value"></span><span class="state">✅</span></dd>
-              <dt>Phase</dt>
-              <dd><span class="value">Deployed</span><span class="state">✅</span></dd>
-              <dt>Progression</dt>
-              <dd><span class="value">Completed</span><span class="state">✅</span></dd>
-            </dl>
+            <h3>Hub</h3>
             <section>
-              <h5>Conditions</h5>
-              <dl class="validation">
-                <dt>Available</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>PeerReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>Protected</dt>
-                <dd><span class="state">✅</span></dd>
-              </dl>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>Primary Cluster: dr1</h3>
-          <section>
-            <h4>VRG</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>test-appset-deploy-rbd</dd>
-            </dl>
-            <dl class="validation">
-              <dt>State</dt>
-              <dd><span class="value">Primary</span><span class="state">✅</span></dd>
-            </dl>
-            <section>
-              <h5>Conditions</h5>
-              <dl class="validation">
-                <dt>DataReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>ClusterDataReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>ClusterDataProtected</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>KubeObjectsReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>NoClusterDataConflict</dt>
-                <dd><span class="state">✅</span></dd>
-              </dl>
-            </section>
-            <section>
-              <h5>PVC: busybox-pvc</h5>
+              <h4>DRPC</h4>
               <dl class="metadata">
                 <dt>Name</dt>
-                <dd>busybox-pvc</dd>
+                <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
-                <dd>test-appset-deploy-rbd</dd>
-                <dt>Replication</dt>
-                <dd>volrep</dd>
+                <dd>argocd</dd>
+                <dt>DRPolicy</dt>
+                <dd>dr-policy-1m</dd>
               </dl>
               <dl class="validation">
+                <dt>Action</dt>
+                <dd><span class="value"></span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
-                <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                <dd><span class="value">Deployed</span><span class="state">✅</span></dd>
+                <dt>Progression</dt>
+                <dd><span class="value">Completed</span><span class="state">✅</span></dd>
               </dl>
               <section>
-                <h6>Conditions</h6>
+                <h5>Conditions</h5>
                 <dl class="validation">
-                  <dt>DataReady</dt>
+                  <dt>Available</dt>
                   <dd><span class="state">✅</span></dd>
-                  <dt>ClusterDataProtected</dt>
+                  <dt>PeerReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>Protected</dt>
                   <dd><span class="state">✅</span></dd>
                 </dl>
               </section>
             </section>
           </section>
-        </section>
-        <section>
-          <h3>Secondary Cluster: dr2</h3>
           <section>
-            <h4>VRG</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>test-appset-deploy-rbd</dd>
-            </dl>
+            <h3>Primary Cluster: dr1</h3>
+            <section>
+              <h4>VRG</h4>
+              <dl class="metadata">
+                <dt>Name</dt>
+                <dd>appset-deploy-rbd</dd>
+                <dt>Namespace</dt>
+                <dd>test-appset-deploy-rbd</dd>
+              </dl>
+              <dl class="validation">
+                <dt>State</dt>
+                <dd><span class="value">Primary</span><span class="state">✅</span></dd>
+              </dl>
+              <section>
+                <h5>Conditions</h5>
+                <dl class="validation">
+                  <dt>DataReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>ClusterDataReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>ClusterDataProtected</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>KubeObjectsReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>NoClusterDataConflict</dt>
+                  <dd><span class="state">✅</span></dd>
+                </dl>
+              </section>
+              <section>
+                <h5>PVC: busybox-pvc</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>busybox-pvc</dd>
+                  <dt>Namespace</dt>
+                  <dd>test-appset-deploy-rbd</dd>
+                  <dt>Replication</dt>
+                  <dd>volrep</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Phase</dt>
+                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>DataReady</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>ClusterDataProtected</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>Secondary Cluster: dr2</h3>
+            <section>
+              <h4>VRG</h4>
+              <dl class="metadata">
+                <dt>Name</dt>
+                <dd>appset-deploy-rbd</dd>
+                <dt>Namespace</dt>
+                <dd>test-appset-deploy-rbd</dd>
+              </dl>
+              <dl class="validation">
+                <dt>State</dt>
+                <dd><span class="value">Secondary</span><span class="state">✅</span></dd>
+              </dl>
+              <section>
+                <h5>Conditions</h5>
+                <dl class="validation">
+                  <dt>NoClusterDataConflict</dt>
+                  <dd><span class="state">✅</span></dd>
+                </dl>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>S3 Stores</h3>
             <dl class="validation">
-              <dt>State</dt>
-              <dd><span class="value">Secondary</span><span class="state">✅</span></dd>
+              <dt>Profiles</dt>
+              <dd><span class="value">2</span><span class="state">✅</span></dd>
             </dl>
             <section>
-              <h5>Conditions</h5>
+              <h4>minio-on-dr2</h4>
               <dl class="validation">
-                <dt>NoClusterDataConflict</dt>
-                <dd><span class="state">✅</span></dd>
+                <dt>Gathered</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
+              </dl>
+            </section>
+            <section>
+              <h4>minio-on-dr1</h4>
+              <dl class="validation">
+                <dt>Gathered</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
               </dl>
             </section>
           </section>
-        </section>
-        <section>
-          <h3>S3 Stores</h3>
-          <dl class="validation">
-            <dt>Profiles</dt>
-            <dd><span class="value">2</span><span class="state">✅</span></dd>
-          </dl>
-          <section>
-            <h4>minio-on-dr2</h4>
-            <dl class="validation">
-              <dt>Gathered</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
-            </dl>
-          </section>
-          <section>
-            <h4>minio-on-dr1</h4>
-            <dl class="validation">
-              <dt>Gathered</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
-            </dl>
-          </section>
-        </section>
+        </div>
       </section>
       <section>
         <h2>Report Details</h2>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -2,20 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Application Validation Report</title>
+    <title>Validate Application</title>
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>
-      <h1>Application Validation Report</h1>
-      <p class="subtitle">argocd / appset-deploy-rbd</p>
-      <p class="result"><span class="status passed">passed</span><span class="summary">24 ok, 0 stale, 0 problem</span></p>
-      <dl class="timing">
-        <dt>Created</dt>
-        <dd>2026-03-16 20:16:31 &#43;0200</dd>
-        <dt>Duration</dt>
-        <dd>2.21s</dd>
-      </dl>
+      <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
+      <div class="result"><span class="status passed">passed</span><span class="summary">24 ok, 0 stale, 0 problem</span></div>
+      <footer><span>Created 2026-03-16 20:16:31 &#43;0200</span><span>Duration 2.21s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Application Validation Report</title>
-    <style> body { font-family: system-ui, sans-serif; } </style>
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -161,7 +161,7 @@
             <dt>Version</dt>
             <dd>v0.17.0-2-gc5cc831</dd>
             <dt>Commit</dt>
-            <dd>c5cc831b601f99c3a83a297da6840c3f21376b39</dd>
+            <dd title="c5cc831b601f99c3a83a297da6840c3f21376b39">c5cc831b60...</dd>
           </dl>
         </section>
         <section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -87,27 +87,29 @@
                 </dl>
               </section>
               <section>
-                <h5>PVC: busybox-pvc</h5>
-                <dl class="metadata">
-                  <dt>Name</dt>
-                  <dd>busybox-pvc</dd>
-                  <dt>Namespace</dt>
-                  <dd>test-appset-deploy-rbd</dd>
-                  <dt>Replication</dt>
-                  <dd>volrep</dd>
-                </dl>
-                <dl class="validation">
-                  <dt>Phase</dt>
-                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                </dl>
-                <section>
-                  <h6>Conditions</h6>
-                  <dl class="validation">
-                    <dt>DataReady</dt>
-                    <dd><span class="state">✅</span></dd>
-                    <dt>ClusterDataProtected</dt>
-                    <dd><span class="state">✅</span></dd>
+                <h5>Protected PVCs</h5>
+                <section class="pvc">
+                  <dl class="metadata">
+                    <dt>Name</dt>
+                    <dd>busybox-pvc</dd>
+                    <dt>Namespace</dt>
+                    <dd>test-appset-deploy-rbd</dd>
+                    <dt>Replication</dt>
+                    <dd>volrep</dd>
                   </dl>
+                  <dl class="validation">
+                    <dt>Phase</dt>
+                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                  </dl>
+                  <section>
+                    <h6>Conditions</h6>
+                    <dl class="validation">
+                      <dt>DataReady</dt>
+                      <dd><span class="state">✅</span></dd>
+                      <dt>ClusterDataProtected</dt>
+                      <dd><span class="state">✅</span></dd>
+                    </dl>
+                  </section>
                 </section>
               </section>
             </section>
@@ -142,38 +144,40 @@
                 </dl>
               </section>
               <section>
-                <h5>PVC: busybox-pvc</h5>
-                <dl class="metadata">
-                  <dt>Name</dt>
-                  <dd>busybox-pvc</dd>
-                  <dt>Namespace</dt>
-                  <dd>test-appset-deploy-rbd</dd>
-                  <dt>Replication</dt>
-                  <dd>volrep</dd>
-                </dl>
-                <dl class="validation">
-                  <dt>Phase</dt>
-                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                  <dt>Deleted</dt>
-                  <dd>
-                    <span class="value">true</span><span class="state">❌</span>
-                    <p class="description">Resource was deleted</p>
-                  </dd>
-                </dl>
-                <section>
-                  <h6>Conditions</h6>
+                <h5>Protected PVCs</h5>
+                <section class="pvc">
+                  <dl class="metadata">
+                    <dt>Name</dt>
+                    <dd>busybox-pvc</dd>
+                    <dt>Namespace</dt>
+                    <dd>test-appset-deploy-rbd</dd>
+                    <dt>Replication</dt>
+                    <dd>volrep</dd>
+                  </dl>
                   <dl class="validation">
-                    <dt>DataReady</dt>
+                    <dt>Phase</dt>
+                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                    <dt>Deleted</dt>
                     <dd>
-                      <span class="state">❌</span>
-                      <p class="description">failed to demote volume</p>
-                    </dd>
-                    <dt>ClusterDataProtected</dt>
-                    <dd>
-                      <span class="state">⭕</span>
-                      <p class="description">Observed generation 1 does not match object generation 2</p>
+                      <span class="value">true</span><span class="state">❌</span>
+                      <p class="description">Resource was deleted</p>
                     </dd>
                   </dl>
+                  <section>
+                    <h6>Conditions</h6>
+                    <dl class="validation">
+                      <dt>DataReady</dt>
+                      <dd>
+                        <span class="state">❌</span>
+                        <p class="description">failed to demote volume</p>
+                      </dd>
+                      <dt>ClusterDataProtected</dt>
+                      <dd>
+                        <span class="state">⭕</span>
+                        <p class="description">Observed generation 1 does not match object generation 2</p>
+                      </dd>
+                    </dl>
+                  </section>
                 </section>
               </section>
             </section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -2,20 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Application Validation Report</title>
+    <title>Validate Application</title>
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>
-      <h1>Application Validation Report</h1>
-      <p class="subtitle">argocd / appset-deploy-rbd</p>
-      <p class="result"><span class="status failed">failed</span><span class="summary">21 ok, 1 stale, 7 problem</span></p>
-      <dl class="timing">
-        <dt>Created</dt>
-        <dd>2026-03-16 20:19:49 &#43;0200</dd>
-        <dt>Duration</dt>
-        <dd>2.30s</dd>
-      </dl>
+      <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
+      <div class="result"><span class="status failed">failed</span><span class="summary">21 ok, 1 stale, 7 problem</span></div>
+      <footer><span>Created 2026-03-16 20:19:49 &#43;0200</span><span>Duration 2.30s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -201,7 +201,7 @@
           </section>
         </div>
       </section>
-      <section>
+      <div class="details-grid">
         <h2>Report Details</h2>
         <section>
           <h3>Build</h3>
@@ -211,8 +211,6 @@
             <dt>Commit</dt>
             <dd title="c5cc831b601f99c3a83a297da6840c3f21376b39">c5cc831b60...</dd>
           </dl>
-        </section>
-        <section>
           <h3>Host</h3>
           <dl class="metadata">
             <dt>OS</dt>
@@ -222,10 +220,8 @@
             <dt>CPUs</dt>
             <dd>12</dd>
           </dl>
-        </section>
-        <section>
           <h3>Namespaces</h3>
-          <ul>
+          <ul class="namespaces">
             <li>argocd</li>
             <li>ramen-system</li>
             <li>test-appset-deploy-rbd</li>
@@ -254,23 +250,23 @@ namespaces:
         <section>
           <h3>Steps</h3>
           <ul class="steps">
-            <li class="step passed"><span>validate config</span><span>0.01s</span></li>
+            <li class="step passed"><span class="step-name">validate config</span><span class="step-duration">0.01s</span></li>
             <li class="step failed">
-              <span>validate application</span><span>2.29s</span>
+              <span class="step-name">validate application</span><span class="step-duration">2.29s</span>
               <ul>
-                <li class="step passed"><span>inspect application</span><span>0.00s</span></li>
-                <li class="step passed"><span>gather &#34;hub&#34;</span><span>1.25s</span></li>
-                <li class="step passed"><span>gather &#34;dr1&#34;</span><span>2.19s</span></li>
-                <li class="step passed"><span>gather &#34;dr2&#34;</span><span>2.27s</span></li>
-                <li class="step passed"><span>inspect S3 profiles</span><span>0.01s</span></li>
-                <li class="step passed"><span>gather S3 profile &#34;minio-on-dr2&#34;</span><span>0.01s</span></li>
-                <li class="step passed"><span>gather S3 profile &#34;minio-on-dr1&#34;</span><span>0.01s</span></li>
-                <li class="step failed"><span>validate data</span><span>0.00s</span></li>
+                <li class="step passed"><span class="step-name">inspect application</span><span class="step-duration">0.00s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;hub&#34;</span><span class="step-duration">1.25s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr1&#34;</span><span class="step-duration">2.19s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr2&#34;</span><span class="step-duration">2.27s</span></li>
+                <li class="step passed"><span class="step-name">inspect S3 profiles</span><span class="step-duration">0.01s</span></li>
+                <li class="step passed"><span class="step-name">gather S3 profile &#34;minio-on-dr2&#34;</span><span class="step-duration">0.01s</span></li>
+                <li class="step passed"><span class="step-name">gather S3 profile &#34;minio-on-dr1&#34;</span><span class="step-duration">0.01s</span></li>
+                <li class="step failed"><span class="step-name">validate data</span><span class="step-duration">0.00s</span></li>
               </ul>
             </li>
           </ul>
         </section>
-      </section>
+      </div>
     </main>
   </body>
 </html>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Application Validation Report</title>
-    <style> body { font-family: system-ui, sans-serif; } </style>
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -213,7 +213,7 @@
             <dt>Version</dt>
             <dd>v0.17.0-2-gc5cc831</dd>
             <dt>Commit</dt>
-            <dd>c5cc831b601f99c3a83a297da6840c3f21376b39</dd>
+            <dd title="c5cc831b601f99c3a83a297da6840c3f21376b39">c5cc831b60...</dd>
           </dl>
         </section>
         <section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -13,191 +13,193 @@
     </header>
     <main>
       <section>
-        <h2>Application Status</h2>
-        <section>
-          <h3>Hub</h3>
+        <div class="main-grid">
+          <h2>Application Status</h2>
           <section>
-            <h4>DRPC</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>argocd</dd>
-              <dt>DRPolicy</dt>
-              <dd>dr-policy-1m</dd>
-            </dl>
-            <dl class="validation">
-              <dt>Action</dt>
-              <dd><span class="value">Failover</span><span class="state">✅</span></dd>
-              <dt>Phase</dt>
-              <dd><span class="value">FailedOver</span><span class="state">✅</span></dd>
-              <dt>Progression</dt>
-              <dd>
-                <span class="value">Cleaning Up</span><span class="state">❌</span>
-                <p class="description">Waiting for progression &#34;Completed&#34;</p>
-              </dd>
-            </dl>
+            <h3>Hub</h3>
             <section>
-              <h5>Conditions</h5>
-              <dl class="validation">
-                <dt>Available</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>PeerReady</dt>
-                <dd>
-                  <span class="state">❌</span>
-                  <p class="description">Started failover to cluster &#34;dr2&#34;</p>
-                </dd>
-                <dt>Protected</dt>
-                <dd>
-                  <span class="state">❌</span>
-                  <p class="description">VolumeReplicationGroup (test-appset-deploy-rbd/appset-deploy-rbd) on cluster dr2 is not reporting any lastGroupSyncTime as primary, retrying till status is met</p>
-                </dd>
-              </dl>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>Primary Cluster: dr2</h3>
-          <section>
-            <h4>VRG</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>test-appset-deploy-rbd</dd>
-            </dl>
-            <dl class="validation">
-              <dt>State</dt>
-              <dd><span class="value">Primary</span><span class="state">✅</span></dd>
-            </dl>
-            <section>
-              <h5>Conditions</h5>
-              <dl class="validation">
-                <dt>DataReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>ClusterDataReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>ClusterDataProtected</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>KubeObjectsReady</dt>
-                <dd><span class="state">✅</span></dd>
-                <dt>NoClusterDataConflict</dt>
-                <dd><span class="state">✅</span></dd>
-              </dl>
-            </section>
-            <section>
-              <h5>PVC: busybox-pvc</h5>
+              <h4>DRPC</h4>
               <dl class="metadata">
                 <dt>Name</dt>
-                <dd>busybox-pvc</dd>
+                <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
-                <dd>test-appset-deploy-rbd</dd>
-                <dt>Replication</dt>
-                <dd>volrep</dd>
+                <dd>argocd</dd>
+                <dt>DRPolicy</dt>
+                <dd>dr-policy-1m</dd>
               </dl>
               <dl class="validation">
+                <dt>Action</dt>
+                <dd><span class="value">Failover</span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
-                <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                <dd><span class="value">FailedOver</span><span class="state">✅</span></dd>
+                <dt>Progression</dt>
+                <dd>
+                  <span class="value">Cleaning Up</span><span class="state">❌</span>
+                  <p class="description">Waiting for progression &#34;Completed&#34;</p>
+                </dd>
               </dl>
               <section>
-                <h6>Conditions</h6>
+                <h5>Conditions</h5>
                 <dl class="validation">
-                  <dt>DataReady</dt>
+                  <dt>Available</dt>
                   <dd><span class="state">✅</span></dd>
-                  <dt>ClusterDataProtected</dt>
-                  <dd><span class="state">✅</span></dd>
+                  <dt>PeerReady</dt>
+                  <dd>
+                    <span class="state">❌</span>
+                    <p class="description">Started failover to cluster &#34;dr2&#34;</p>
+                  </dd>
+                  <dt>Protected</dt>
+                  <dd>
+                    <span class="state">❌</span>
+                    <p class="description">VolumeReplicationGroup (test-appset-deploy-rbd/appset-deploy-rbd) on cluster dr2 is not reporting any lastGroupSyncTime as primary, retrying till status is met</p>
+                  </dd>
                 </dl>
               </section>
             </section>
           </section>
-        </section>
-        <section>
-          <h3>Secondary Cluster: dr1</h3>
           <section>
-            <h4>VRG</h4>
-            <dl class="metadata">
-              <dt>Name</dt>
-              <dd>appset-deploy-rbd</dd>
-              <dt>Namespace</dt>
-              <dd>test-appset-deploy-rbd</dd>
-            </dl>
-            <dl class="validation">
-              <dt>State</dt>
-              <dd>
-                <span class="value">Unknown</span><span class="state">❌</span>
-                <p class="description">Waiting to become &#34;Secondary&#34;</p>
-              </dd>
-            </dl>
+            <h3>Primary Cluster: dr2</h3>
             <section>
-              <h5>Conditions</h5>
-              <dl class="validation">
-                <dt>DataReady</dt>
-                <dd>
-                  <span class="state">❌</span>
-                  <p class="description">All PVCs of the VolumeReplicationGroup are not ready</p>
-                </dd>
-                <dt>NoClusterDataConflict</dt>
-                <dd><span class="state">✅</span></dd>
-              </dl>
-            </section>
-            <section>
-              <h5>PVC: busybox-pvc</h5>
+              <h4>VRG</h4>
               <dl class="metadata">
                 <dt>Name</dt>
-                <dd>busybox-pvc</dd>
+                <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
                 <dd>test-appset-deploy-rbd</dd>
-                <dt>Replication</dt>
-                <dd>volrep</dd>
               </dl>
               <dl class="validation">
-                <dt>Phase</dt>
-                <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                <dt>Deleted</dt>
+                <dt>State</dt>
+                <dd><span class="value">Primary</span><span class="state">✅</span></dd>
+              </dl>
+              <section>
+                <h5>Conditions</h5>
+                <dl class="validation">
+                  <dt>DataReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>ClusterDataReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>ClusterDataProtected</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>KubeObjectsReady</dt>
+                  <dd><span class="state">✅</span></dd>
+                  <dt>NoClusterDataConflict</dt>
+                  <dd><span class="state">✅</span></dd>
+                </dl>
+              </section>
+              <section>
+                <h5>PVC: busybox-pvc</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>busybox-pvc</dd>
+                  <dt>Namespace</dt>
+                  <dd>test-appset-deploy-rbd</dd>
+                  <dt>Replication</dt>
+                  <dd>volrep</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Phase</dt>
+                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>DataReady</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>ClusterDataProtected</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>Secondary Cluster: dr1</h3>
+            <section>
+              <h4>VRG</h4>
+              <dl class="metadata">
+                <dt>Name</dt>
+                <dd>appset-deploy-rbd</dd>
+                <dt>Namespace</dt>
+                <dd>test-appset-deploy-rbd</dd>
+              </dl>
+              <dl class="validation">
+                <dt>State</dt>
                 <dd>
-                  <span class="value">true</span><span class="state">❌</span>
-                  <p class="description">Resource was deleted</p>
+                  <span class="value">Unknown</span><span class="state">❌</span>
+                  <p class="description">Waiting to become &#34;Secondary&#34;</p>
                 </dd>
               </dl>
               <section>
-                <h6>Conditions</h6>
+                <h5>Conditions</h5>
                 <dl class="validation">
                   <dt>DataReady</dt>
                   <dd>
                     <span class="state">❌</span>
-                    <p class="description">failed to demote volume</p>
+                    <p class="description">All PVCs of the VolumeReplicationGroup are not ready</p>
                   </dd>
-                  <dt>ClusterDataProtected</dt>
+                  <dt>NoClusterDataConflict</dt>
+                  <dd><span class="state">✅</span></dd>
+                </dl>
+              </section>
+              <section>
+                <h5>PVC: busybox-pvc</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>busybox-pvc</dd>
+                  <dt>Namespace</dt>
+                  <dd>test-appset-deploy-rbd</dd>
+                  <dt>Replication</dt>
+                  <dd>volrep</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Phase</dt>
+                  <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                  <dt>Deleted</dt>
                   <dd>
-                    <span class="state">⭕</span>
-                    <p class="description">Observed generation 1 does not match object generation 2</p>
+                    <span class="value">true</span><span class="state">❌</span>
+                    <p class="description">Resource was deleted</p>
                   </dd>
                 </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>DataReady</dt>
+                    <dd>
+                      <span class="state">❌</span>
+                      <p class="description">failed to demote volume</p>
+                    </dd>
+                    <dt>ClusterDataProtected</dt>
+                    <dd>
+                      <span class="state">⭕</span>
+                      <p class="description">Observed generation 1 does not match object generation 2</p>
+                    </dd>
+                  </dl>
+                </section>
               </section>
             </section>
           </section>
-        </section>
-        <section>
-          <h3>S3 Stores</h3>
-          <dl class="validation">
-            <dt>Profiles</dt>
-            <dd><span class="value">2</span><span class="state">✅</span></dd>
-          </dl>
           <section>
-            <h4>minio-on-dr2</h4>
+            <h3>S3 Stores</h3>
             <dl class="validation">
-              <dt>Gathered</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
+              <dt>Profiles</dt>
+              <dd><span class="value">2</span><span class="state">✅</span></dd>
             </dl>
+            <section>
+              <h4>minio-on-dr2</h4>
+              <dl class="validation">
+                <dt>Gathered</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
+              </dl>
+            </section>
+            <section>
+              <h4>minio-on-dr1</h4>
+              <dl class="validation">
+                <dt>Gathered</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
+              </dl>
+            </section>
           </section>
-          <section>
-            <h4>minio-on-dr1</h4>
-            <dl class="validation">
-              <dt>Gathered</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
-            </dl>
-          </section>
-        </section>
+        </div>
       </section>
       <section>
         <h2>Report Details</h2>

--- a/pkg/validate/application/testdata/style.css
+++ b/pkg/validate/application/testdata/style.css
@@ -1,0 +1,1 @@
+../../../report/style.css

--- a/pkg/validate/clusters/html.go
+++ b/pkg/validate/clusters/html.go
@@ -23,7 +23,7 @@ type templateData struct {
 // HeaderData returns data for the report template.
 func (d *templateData) HeaderData() report.HeaderData {
 	return report.HeaderData{
-		Title: "Clusters Validation Report",
+		Title: "Validate Clusters",
 	}
 }
 

--- a/pkg/validate/clusters/html_test.go
+++ b/pkg/validate/clusters/html_test.go
@@ -24,7 +24,6 @@ func TestTemplate(t *testing.T) {
 		// Shared templates from pkg/report.
 		"conditions",
 		"report.tmpl",
-		"style",
 		"validated",
 		// Command templates.
 		"content",

--- a/pkg/validate/clusters/html_test.go
+++ b/pkg/validate/clusters/html_test.go
@@ -86,7 +86,7 @@ func TestHeaderData(t *testing.T) {
 	actual := d.HeaderData()
 
 	expected := report.HeaderData{
-		Title: "Clusters Validation Report",
+		Title: "Validate Clusters",
 	}
 
 	if actual != expected {

--- a/pkg/validate/clusters/templates/content.tmpl
+++ b/pkg/validate/clusters/templates/content.tmpl
@@ -2,8 +2,8 @@
 {{/* SPDX-License-Identifier: Apache-2.0 */}}
 {{define "content" -}}
 {{- with .ClustersStatus}}
+<div class="main-grid">
 <h2>Clusters Status</h2>
-
 {{- with .Hub}}
 <section>
     <h3>Hub</h3>
@@ -38,5 +38,6 @@
     {{template "s3" .Profiles}}
 </section>
 {{- end}}
+</div>
 {{- end}}
 {{- end}}

--- a/pkg/validate/clusters/templates/s3profile.tmpl
+++ b/pkg/validate/clusters/templates/s3profile.tmpl
@@ -23,9 +23,9 @@
                     <dt>Deleted</dt>
                     <dd>{{template "validated" .S3SecretRef.Deleted}}</dd>
                 {{- end}}
-                <dt>AWS Access Key ID</dt>
+                <dt>Key ID</dt>
                 <dd>{{template "validated" .S3SecretRef.AWSAccessKeyID}}</dd>
-                <dt>AWS Secret Access Key</dt>
+                <dt>Access Key</dt>
                 <dd>{{template "validated" .S3SecretRef.AWSSecretAccessKey}}</dd>
             </dl>
         </dd>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Clusters Validation Report</title>
-    <style> body { font-family: system-ui, sans-serif; } </style>
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -500,7 +500,7 @@
           </section>
         </div>
       </section>
-      <section>
+      <div class="details-grid">
         <h2>Report Details</h2>
         <section>
           <h3>Build</h3>
@@ -510,8 +510,6 @@
             <dt>Commit</dt>
             <dd title="c306e20340a666f0124ad7e1c50cf0cd0531b094">c306e20340...</dd>
           </dl>
-        </section>
-        <section>
           <h3>Host</h3>
           <dl class="metadata">
             <dt>OS</dt>
@@ -521,10 +519,8 @@
             <dt>CPUs</dt>
             <dd>12</dd>
           </dl>
-        </section>
-        <section>
           <h3>Namespaces</h3>
-          <ul>
+          <ul class="namespaces">
             <li>ramen-system</li>
           </ul>
         </section>
@@ -551,22 +547,22 @@ namespaces:
         <section>
           <h3>Steps</h3>
           <ul class="steps">
-            <li class="step passed"><span>validate config</span><span>0.01s</span></li>
+            <li class="step passed"><span class="step-name">validate config</span><span class="step-duration">0.01s</span></li>
             <li class="step passed">
-              <span>validate clusters</span><span>1.12s</span>
+              <span class="step-name">validate clusters</span><span class="step-duration">1.12s</span>
               <ul>
-                <li class="step passed"><span>gather &#34;hub&#34;</span><span>0.59s</span></li>
-                <li class="step passed"><span>gather &#34;dr1&#34;</span><span>1.06s</span></li>
-                <li class="step passed"><span>gather &#34;dr2&#34;</span><span>1.06s</span></li>
-                <li class="step passed"><span>inspect S3 profiles</span><span>0.02s</span></li>
-                <li class="step passed"><span>check S3 profile &#34;minio-on-dr2&#34;</span><span>0.02s</span></li>
-                <li class="step passed"><span>check S3 profile &#34;minio-on-dr1&#34;</span><span>0.02s</span></li>
-                <li class="step passed"><span>validate clusters data</span><span>0.01s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;hub&#34;</span><span class="step-duration">0.59s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr1&#34;</span><span class="step-duration">1.06s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr2&#34;</span><span class="step-duration">1.06s</span></li>
+                <li class="step passed"><span class="step-name">inspect S3 profiles</span><span class="step-duration">0.02s</span></li>
+                <li class="step passed"><span class="step-name">check S3 profile &#34;minio-on-dr2&#34;</span><span class="step-duration">0.02s</span></li>
+                <li class="step passed"><span class="step-name">check S3 profile &#34;minio-on-dr1&#34;</span><span class="step-duration">0.02s</span></li>
+                <li class="step passed"><span class="step-name">validate clusters data</span><span class="step-duration">0.01s</span></li>
               </ul>
             </li>
           </ul>
         </section>
-      </section>
+      </div>
     </main>
   </body>
 </html>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -2,19 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Clusters Validation Report</title>
+    <title>Validate Clusters</title>
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>
-      <h1>Clusters Validation Report</h1>
-      <p class="result"><span class="status passed">passed</span><span class="summary">90 ok, 0 stale, 0 problem</span></p>
-      <dl class="timing">
-        <dt>Created</dt>
-        <dd>2026-03-23 18:18:13 &#43;0200</dd>
-        <dt>Duration</dt>
-        <dd>1.13s</dd>
-      </dl>
+      <h1>Validate Clusters</h1>
+      <div class="result"><span class="status passed">passed</span><span class="summary">90 ok, 0 stale, 0 problem</span></div>
+      <footer><span>Created 2026-03-23 18:18:13 &#43;0200</span><span>Duration 1.13s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -13,490 +13,492 @@
     </header>
     <main>
       <section>
-        <h2>Clusters Status</h2>
-        <section>
-          <h3>Hub</h3>
+        <div class="main-grid">
+          <h2>Clusters Status</h2>
           <section>
-            <h4>Ramen</h4>
+            <h3>Hub</h3>
             <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-hub-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
+              <h4>Ramen</h4>
               <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-hub-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
                 </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-hub-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-hub</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  </dl>
+                  <section>
+                    <h6>minio-on-dr1</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                  <section>
+                    <h6>minio-on-dr2</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                </section>
               </section>
             </section>
             <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-hub-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
+              <h4>DRPolicies</h4>
               <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-hub</span><span class="state">✅</span></dd>
+                <dt>Policies</dt>
+                <dd><span class="value">2</span><span class="state">✅</span></dd>
               </dl>
               <section>
-                <h6>S3 Store Profiles</h6>
+                <h5>dr-policy-1m</h5>
+                <dl class="metadata">
+                  <dt>Scheduling Interval</dt>
+                  <dd>1m</dd>
+                  <dt>DRClusters</dt>
+                  <dd>dr1, dr2</dd>
+                </dl>
                 <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  <dt>Peer Classes</dt>
+                  <dd>
+                    <span class="value">2</span><span class="state">✅</span>
+                    <ul>
+                      <li>
+                        <dl class="metadata">
+                          <dt>Storage Class</dt>
+                          <dd>rook-ceph-block</dd>
+                          <dt>Replication ID</dt>
+                          <dd>rook-ceph-replication-1</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="metadata">
+                          <dt>Storage Class</dt>
+                          <dd>rook-cephfs-fs1</dd>
+                        </dl>
+                      </li>
+                    </ul>
+                  </dd>
                 </dl>
                 <section>
-                  <h6>minio-on-dr1</h6>
+                  <h6>Conditions</h6>
                   <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
+                    <dt>Validated</dt>
+                    <dd><span class="state">✅</span></dd>
                   </dl>
                 </section>
+              </section>
+              <section>
+                <h5>dr-policy-5m</h5>
+                <dl class="metadata">
+                  <dt>Scheduling Interval</dt>
+                  <dd>5m</dd>
+                  <dt>DRClusters</dt>
+                  <dd>dr1, dr2</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Peer Classes</dt>
+                  <dd>
+                    <span class="value">2</span><span class="state">✅</span>
+                    <ul>
+                      <li>
+                        <dl class="metadata">
+                          <dt>Storage Class</dt>
+                          <dd>rook-ceph-block</dd>
+                          <dt>Replication ID</dt>
+                          <dd>rook-ceph-replication-1</dd>
+                        </dl>
+                      </li>
+                      <li>
+                        <dl class="metadata">
+                          <dt>Storage Class</dt>
+                          <dd>rook-cephfs-fs1</dd>
+                        </dl>
+                      </li>
+                    </ul>
+                  </dd>
+                </dl>
                 <section>
-                  <h6>minio-on-dr2</h6>
+                  <h6>Conditions</h6>
                   <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
+                    <dt>Validated</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+            </section>
+            <section>
+              <h4>DRClusters</h4>
+              <dl class="validation">
+                <dt>Clusters</dt>
+                <dd><span class="value">2</span><span class="state">✅</span></dd>
+              </dl>
+              <section>
+                <h5>dr1</h5>
+                <dl class="metadata">
+                  <dt>Phase</dt>
+                  <dd>Available</dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Validated</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Fenced</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Clean</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>dr2</h5>
+                <dl class="metadata">
+                  <dt>Phase</dt>
+                  <dd>Available</dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Validated</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Fenced</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Clean</dt>
+                    <dd><span class="state">✅</span></dd>
                   </dl>
                 </section>
               </section>
             </section>
           </section>
           <section>
-            <h4>DRPolicies</h4>
+            <h3>Managed Cluster: dr1</h3>
+            <section>
+              <h4>Ramen</h4>
+              <section>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  </dl>
+                  <section>
+                    <h6>minio-on-dr1</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                  <section>
+                    <h6>minio-on-dr2</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                </section>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>Managed Cluster: dr2</h3>
+            <section>
+              <h4>Ramen</h4>
+              <section>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  </dl>
+                  <section>
+                    <h6>minio-on-dr1</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                  <section>
+                    <h6>minio-on-dr2</h6>
+                    <dl class="validation">
+                      <dt>Bucket</dt>
+                      <dd><span class="value">bucket</span><span class="state">✅</span></dd>
+                      <dt>Endpoint</dt>
+                      <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
+                      <dt>Region</dt>
+                      <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
+                      <dt>CA Certificate</dt>
+                      <dd><span class="value"></span><span class="state">✅</span></dd>
+                      <dt>Secret</dt>
+                      <dd>
+                        <dl class="validation">
+                          <dt>Name</dt>
+                          <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
+                          <dt>Namespace</dt>
+                          <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
+                          <dt>AWS Access Key ID</dt>
+                          <dd>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                          <dt>AWS Secret Access Key</dt>
+                          <dd>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="state">✅</span>
+                          </dd>
+                        </dl>
+                      </dd>
+                    </dl>
+                  </section>
+                </section>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>S3 Stores</h3>
             <dl class="validation">
-              <dt>Policies</dt>
+              <dt>Profiles</dt>
               <dd><span class="value">2</span><span class="state">✅</span></dd>
             </dl>
             <section>
-              <h5>dr-policy-1m</h5>
-              <dl class="metadata">
-                <dt>Scheduling Interval</dt>
-                <dd>1m</dd>
-                <dt>DRClusters</dt>
-                <dd>dr1, dr2</dd>
-              </dl>
+              <h4>minio-on-dr2</h4>
               <dl class="validation">
-                <dt>Peer Classes</dt>
-                <dd>
-                  <span class="value">2</span><span class="state">✅</span>
-                  <ul>
-                    <li>
-                      <dl class="metadata">
-                        <dt>Storage Class</dt>
-                        <dd>rook-ceph-block</dd>
-                        <dt>Replication ID</dt>
-                        <dd>rook-ceph-replication-1</dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <dl class="metadata">
-                        <dt>Storage Class</dt>
-                        <dd>rook-cephfs-fs1</dd>
-                      </dl>
-                    </li>
-                  </ul>
-                </dd>
+                <dt>Accessible</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
               </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Validated</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
             </section>
             <section>
-              <h5>dr-policy-5m</h5>
-              <dl class="metadata">
-                <dt>Scheduling Interval</dt>
-                <dd>5m</dd>
-                <dt>DRClusters</dt>
-                <dd>dr1, dr2</dd>
-              </dl>
+              <h4>minio-on-dr1</h4>
               <dl class="validation">
-                <dt>Peer Classes</dt>
-                <dd>
-                  <span class="value">2</span><span class="state">✅</span>
-                  <ul>
-                    <li>
-                      <dl class="metadata">
-                        <dt>Storage Class</dt>
-                        <dd>rook-ceph-block</dd>
-                        <dt>Replication ID</dt>
-                        <dd>rook-ceph-replication-1</dd>
-                      </dl>
-                    </li>
-                    <li>
-                      <dl class="metadata">
-                        <dt>Storage Class</dt>
-                        <dd>rook-cephfs-fs1</dd>
-                      </dl>
-                    </li>
-                  </ul>
-                </dd>
+                <dt>Accessible</dt>
+                <dd><span class="value">true</span><span class="state">✅</span></dd>
               </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Validated</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
             </section>
           </section>
-          <section>
-            <h4>DRClusters</h4>
-            <dl class="validation">
-              <dt>Clusters</dt>
-              <dd><span class="value">2</span><span class="state">✅</span></dd>
-            </dl>
-            <section>
-              <h5>dr1</h5>
-              <dl class="metadata">
-                <dt>Phase</dt>
-                <dd>Available</dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Validated</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Fenced</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Clean</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-            <section>
-              <h5>dr2</h5>
-              <dl class="metadata">
-                <dt>Phase</dt>
-                <dd>Available</dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Validated</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Fenced</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Clean</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>Managed Cluster: dr1</h3>
-          <section>
-            <h4>Ramen</h4>
-            <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-            <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>S3 Store Profiles</h6>
-                <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd><span class="value">2</span><span class="state">✅</span></dd>
-                </dl>
-                <section>
-                  <h6>minio-on-dr1</h6>
-                  <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </section>
-                <section>
-                  <h6>minio-on-dr2</h6>
-                  <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </section>
-              </section>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>Managed Cluster: dr2</h3>
-          <section>
-            <h4>Ramen</h4>
-            <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-            <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>S3 Store Profiles</h6>
-                <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd><span class="value">2</span><span class="state">✅</span></dd>
-                </dl>
-                <section>
-                  <h6>minio-on-dr1</h6>
-                  <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.6:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-west-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </section>
-                <section>
-                  <h6>minio-on-dr2</h6>
-                  <dl class="validation">
-                    <dt>Bucket</dt>
-                    <dd><span class="value">bucket</span><span class="state">✅</span></dd>
-                    <dt>Endpoint</dt>
-                    <dd><span class="value">http://192.168.105.5:30000</span><span class="state">✅</span></dd>
-                    <dt>Region</dt>
-                    <dd><span class="value">us-east-1</span><span class="state">✅</span></dd>
-                    <dt>CA Certificate</dt>
-                    <dd><span class="value"></span><span class="state">✅</span></dd>
-                    <dt>Secret</dt>
-                    <dd>
-                      <dl class="validation">
-                        <dt>Name</dt>
-                        <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
-                        <dt>Namespace</dt>
-                        <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                        <dt>AWS Access Key ID</dt>
-                        <dd>
-                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                        <dt>AWS Secret Access Key</dt>
-                        <dd>
-                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
-                          <span class="state">✅</span>
-                        </dd>
-                      </dl>
-                    </dd>
-                  </dl>
-                </section>
-              </section>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>S3 Stores</h3>
-          <dl class="validation">
-            <dt>Profiles</dt>
-            <dd><span class="value">2</span><span class="state">✅</span></dd>
-          </dl>
-          <section>
-            <h4>minio-on-dr2</h4>
-            <dl class="validation">
-              <dt>Accessible</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
-            </dl>
-          </section>
-          <section>
-            <h4>minio-on-dr1</h4>
-            <dl class="validation">
-              <dt>Accessible</dt>
-              <dd><span class="value">true</span><span class="state">✅</span></dd>
-            </dl>
-          </section>
-        </section>
+        </div>
       </section>
       <section>
         <h2>Report Details</h2>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -77,12 +77,12 @@
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>
@@ -109,12 +109,12 @@
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>
@@ -315,12 +315,12 @@
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>
@@ -347,12 +347,12 @@
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>
@@ -427,12 +427,12 @@
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>
@@ -459,12 +459,12 @@
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
                           <dt>Namespace</dt>
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
-                          <dt>AWS Access Key ID</dt>
+                          <dt>Key ID</dt>
                           <dd>
                             <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
                             <span class="state">✅</span>
                           </dd>
-                          <dt>AWS Secret Access Key</dt>
+                          <dt>Access Key</dt>
                           <dd>
                             <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
                             <span class="state">✅</span>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -82,9 +82,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -108,9 +114,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -308,9 +320,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -334,9 +352,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -408,9 +432,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -434,9 +464,15 @@
                         <dt>Namespace</dt>
                         <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                         <dt>AWS Access Key ID</dt>
-                        <dd><span class="value">57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                          <span class="state">✅</span>
+                        </dd>
                         <dt>AWS Secret Access Key</dt>
-                        <dd><span class="value">17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1</span><span class="state">✅</span></dd>
+                        <dd>
+                          <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                          <span class="state">✅</span>
+                        </dd>
                       </dl>
                     </dd>
                   </dl>
@@ -475,7 +511,7 @@
             <dt>Version</dt>
             <dd>v0.17.0-15-gc306e20</dd>
             <dt>Commit</dt>
-            <dd>c306e20340a666f0124ad7e1c50cf0cd0531b094</dd>
+            <dd title="c306e20340a666f0124ad7e1c50cf0cd0531b094">c306e20340...</dd>
           </dl>
         </section>
         <section>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -2,19 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8">
-    <title>Clusters Validation Report</title>
+    <title>Validate Clusters</title>
     <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>
-      <h1>Clusters Validation Report</h1>
-      <p class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 6 problem</span></p>
-      <dl class="timing">
-        <dt>Created</dt>
-        <dd>2026-03-23 18:20:41 &#43;0200</dd>
-        <dt>Duration</dt>
-        <dd>1.05s</dd>
-      </dl>
+      <h1>Validate Clusters</h1>
+      <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 6 problem</span></div>
+      <footer><span>Created 2026-03-23 18:20:41 &#43;0200</span><span>Duration 1.05s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -13,190 +13,192 @@
     </header>
     <main>
       <section>
-        <h2>Clusters Status</h2>
-        <section>
-          <h3>Hub</h3>
+        <div class="main-grid">
+          <h2>Clusters Status</h2>
           <section>
-            <h4>Ramen</h4>
+            <h3>Hub</h3>
             <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-hub-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
+              <h4>Ramen</h4>
               <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-hub-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
                 </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-hub-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-hub</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd>
+                      <span class="value">0</span><span class="state">❌</span>
+                      <p class="description">Found 0 S3 profile(s), expected at least 2</p>
+                    </dd>
+                  </dl>
+                </section>
               </section>
             </section>
             <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-hub-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
+              <h4>DRPolicies</h4>
               <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-hub</span><span class="state">✅</span></dd>
+                <dt>Policies</dt>
+                <dd>
+                  <span class="value">0</span><span class="state">❌</span>
+                  <p class="description">No DRPolicies found</p>
+                </dd>
               </dl>
+            </section>
+            <section>
+              <h4>DRClusters</h4>
+              <dl class="validation">
+                <dt>Clusters</dt>
+                <dd>
+                  <span class="value">0</span><span class="state">❌</span>
+                  <p class="description">2 DRClusters required, 0 found</p>
+                </dd>
+              </dl>
+            </section>
+          </section>
+          <section>
+            <h3>Managed Cluster: dr1</h3>
+            <section>
+              <h4>Ramen</h4>
               <section>
-                <h6>S3 Store Profiles</h6>
-                <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd>
-                    <span class="value">0</span><span class="state">❌</span>
-                    <p class="description">Found 0 S3 profile(s), expected at least 2</p>
-                  </dd>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
                 </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd>
+                      <span class="value">0</span><span class="state">❌</span>
+                      <p class="description">Found 0 S3 profile(s), expected at least 2</p>
+                    </dd>
+                  </dl>
+                </section>
               </section>
             </section>
           </section>
           <section>
-            <h4>DRPolicies</h4>
+            <h3>Managed Cluster: dr2</h3>
+            <section>
+              <h4>Ramen</h4>
+              <section>
+                <h5>Deployment</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Replicas</dt>
+                  <dd><span class="value">1</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>Conditions</h6>
+                  <dl class="validation">
+                    <dt>Available</dt>
+                    <dd><span class="state">✅</span></dd>
+                    <dt>Progressing</dt>
+                    <dd><span class="state">✅</span></dd>
+                  </dl>
+                </section>
+              </section>
+              <section>
+                <h5>ConfigMap</h5>
+                <dl class="metadata">
+                  <dt>Name</dt>
+                  <dd>ramen-dr-cluster-operator-config</dd>
+                  <dt>Namespace</dt>
+                  <dd>ramen-system</dd>
+                </dl>
+                <dl class="validation">
+                  <dt>Controller Type</dt>
+                  <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
+                </dl>
+                <section>
+                  <h6>S3 Store Profiles</h6>
+                  <dl class="validation">
+                    <dt>Profiles</dt>
+                    <dd>
+                      <span class="value">0</span><span class="state">❌</span>
+                      <p class="description">Found 0 S3 profile(s), expected at least 2</p>
+                    </dd>
+                  </dl>
+                </section>
+              </section>
+            </section>
+          </section>
+          <section>
+            <h3>S3 Stores</h3>
             <dl class="validation">
-              <dt>Policies</dt>
+              <dt>Profiles</dt>
               <dd>
                 <span class="value">0</span><span class="state">❌</span>
-                <p class="description">No DRPolicies found</p>
+                <p class="description">No s3 profiles found</p>
               </dd>
             </dl>
           </section>
-          <section>
-            <h4>DRClusters</h4>
-            <dl class="validation">
-              <dt>Clusters</dt>
-              <dd>
-                <span class="value">0</span><span class="state">❌</span>
-                <p class="description">2 DRClusters required, 0 found</p>
-              </dd>
-            </dl>
-          </section>
-        </section>
-        <section>
-          <h3>Managed Cluster: dr1</h3>
-          <section>
-            <h4>Ramen</h4>
-            <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-            <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>S3 Store Profiles</h6>
-                <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd>
-                    <span class="value">0</span><span class="state">❌</span>
-                    <p class="description">Found 0 S3 profile(s), expected at least 2</p>
-                  </dd>
-                </dl>
-              </section>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>Managed Cluster: dr2</h3>
-          <section>
-            <h4>Ramen</h4>
-            <section>
-              <h5>Deployment</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Replicas</dt>
-                <dd><span class="value">1</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>Conditions</h6>
-                <dl class="validation">
-                  <dt>Available</dt>
-                  <dd><span class="state">✅</span></dd>
-                  <dt>Progressing</dt>
-                  <dd><span class="state">✅</span></dd>
-                </dl>
-              </section>
-            </section>
-            <section>
-              <h5>ConfigMap</h5>
-              <dl class="metadata">
-                <dt>Name</dt>
-                <dd>ramen-dr-cluster-operator-config</dd>
-                <dt>Namespace</dt>
-                <dd>ramen-system</dd>
-              </dl>
-              <dl class="validation">
-                <dt>Controller Type</dt>
-                <dd><span class="value">dr-cluster</span><span class="state">✅</span></dd>
-              </dl>
-              <section>
-                <h6>S3 Store Profiles</h6>
-                <dl class="validation">
-                  <dt>Profiles</dt>
-                  <dd>
-                    <span class="value">0</span><span class="state">❌</span>
-                    <p class="description">Found 0 S3 profile(s), expected at least 2</p>
-                  </dd>
-                </dl>
-              </section>
-            </section>
-          </section>
-        </section>
-        <section>
-          <h3>S3 Stores</h3>
-          <dl class="validation">
-            <dt>Profiles</dt>
-            <dd>
-              <span class="value">0</span><span class="state">❌</span>
-              <p class="description">No s3 profiles found</p>
-            </dd>
-          </dl>
-        </section>
+        </div>
       </section>
       <section>
         <h2>Report Details</h2>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Clusters Validation Report</title>
-    <style> body { font-family: system-ui, sans-serif; } </style>
+    <link rel="stylesheet" href="style.css">
   </head>
   <body>
     <header>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -211,7 +211,7 @@
             <dt>Version</dt>
             <dd>v0.17.0-15-gc306e20</dd>
             <dt>Commit</dt>
-            <dd>c306e20340a666f0124ad7e1c50cf0cd0531b094</dd>
+            <dd title="c306e20340a666f0124ad7e1c50cf0cd0531b094">c306e20340...</dd>
           </dl>
         </section>
         <section>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -200,7 +200,7 @@
           </section>
         </div>
       </section>
-      <section>
+      <div class="details-grid">
         <h2>Report Details</h2>
         <section>
           <h3>Build</h3>
@@ -210,8 +210,6 @@
             <dt>Commit</dt>
             <dd title="c306e20340a666f0124ad7e1c50cf0cd0531b094">c306e20340...</dd>
           </dl>
-        </section>
-        <section>
           <h3>Host</h3>
           <dl class="metadata">
             <dt>OS</dt>
@@ -221,10 +219,8 @@
             <dt>CPUs</dt>
             <dd>12</dd>
           </dl>
-        </section>
-        <section>
           <h3>Namespaces</h3>
-          <ul>
+          <ul class="namespaces">
             <li>ramen-system</li>
           </ul>
         </section>
@@ -251,20 +247,20 @@ namespaces:
         <section>
           <h3>Steps</h3>
           <ul class="steps">
-            <li class="step passed"><span>validate config</span><span>0.01s</span></li>
+            <li class="step passed"><span class="step-name">validate config</span><span class="step-duration">0.01s</span></li>
             <li class="step failed">
-              <span>validate clusters</span><span>1.04s</span>
+              <span class="step-name">validate clusters</span><span class="step-duration">1.04s</span>
               <ul>
-                <li class="step passed"><span>gather &#34;hub&#34;</span><span>0.40s</span></li>
-                <li class="step passed"><span>gather &#34;dr1&#34;</span><span>1.03s</span></li>
-                <li class="step passed"><span>gather &#34;dr2&#34;</span><span>1.03s</span></li>
-                <li class="step failed"><span>inspect S3 profiles</span><span>0.00s</span></li>
-                <li class="step failed"><span>validate clusters data</span><span>0.00s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;hub&#34;</span><span class="step-duration">0.40s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr1&#34;</span><span class="step-duration">1.03s</span></li>
+                <li class="step passed"><span class="step-name">gather &#34;dr2&#34;</span><span class="step-duration">1.03s</span></li>
+                <li class="step failed"><span class="step-name">inspect S3 profiles</span><span class="step-duration">0.00s</span></li>
+                <li class="step failed"><span class="step-name">validate clusters data</span><span class="step-duration">0.00s</span></li>
               </ul>
             </li>
           </ul>
         </section>
-      </section>
+      </div>
     </main>
   </body>
 </html>

--- a/pkg/validate/clusters/testdata/style.css
+++ b/pkg/validate/clusters/testdata/style.css
@@ -1,0 +1,1 @@
+../../../report/style.css


### PR DESCRIPTION
## Summary

Redesign the HTML report styling for readability and at-a-glance comparison
of clusters. Move CSS to an external stylesheet, truncate long values,
and use responsive CSS grids to lay out content.

### Changes

- **External stylesheet**: Move inline CSS to `style.css` so CSS changes don't
  require updating golden test files, and editors provide proper syntax highlighting.
- **Truncate long values**: Fingerprints (16 chars), commit hashes (10 chars), and
  other validated values (32 chars) are truncated with `...` suffix. Full value shown
  as tooltip on hover.
- **Header redesign**: Dark header with title, optional subtitle, colored status badge
  (passed/failed) on the right, and timing/summary info below.
- **Cluster grid**: Responsive 3x1 grid (adapts to 2x2 or 1x1) with white cards on
  light gray background for side-by-side cluster comparison.
- **Details grid**: Build/Host/Namespaces combined in one card, Config and Steps in
  separate cards. Namespaces shown as rounded tags. Steps use colored left borders
  with indented nesting and right-aligned gray durations.

## Validate Application: passed
<img width="1791" height="1338" alt="validate-application-ok" src="https://github.com/user-attachments/assets/4a6314bd-9095-498b-86a9-f9934a8f80c1" />

## Validate Application: failed
<img width="1791" height="1338" alt="validate-application-problem" src="https://github.com/user-attachments/assets/752e5d15-3286-4693-b815-1cb562c08ce1" />

## Validate Clusters: passed
<img width="1791" height="1338" alt="validate-clusters-ok" src="https://github.com/user-attachments/assets/f168b595-ec06-4972-a118-f6cb5c8532c7" />

## Validate Clusters: failed
<img width="1791" height="1338" alt="validate-clusters-problem" src="https://github.com/user-attachments/assets/40c49ebf-cea8-4d85-b0fa-2c491ada7601" />
