### PR TITLE
helpers: Consolidate test mock infrastructure

### DIFF
--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -57,25 +57,25 @@ var (
 		applicationNamespace,
 	})
 
-	validateConfigFailed = &validation.Mock{
+	validateConfigFailed = &helpers.ValidationMock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return errors.New("No validate for you!")
 		},
 	}
 
-	validateConfigCanceled = &validation.Mock{
+	validateConfigCanceled = &helpers.ValidationMock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return context.Canceled
 		},
 	}
 
-	inspectApplicationFailed = &validation.Mock{
+	inspectApplicationFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return nil, errors.New("No namespaces for you!")
 		},
 	}
 
-	gatherClusterFailed = &validation.Mock{
+	gatherClusterFailed = &helpers.ValidationMock{
 		GatherFunc: func(
 			ctx validation.Context,
 			clusters []*types.Cluster,
@@ -94,19 +94,19 @@ var (
 		},
 	}
 
-	inspectS3ProfilesCanceled = &validation.Mock{
+	inspectS3ProfilesCanceled = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return nil, context.Canceled
 		},
 	}
 
-	getSecretFailed = &validation.Mock{
+	getSecretFailed = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return nil, errors.New("secret not found")
 		},
 	}
 
-	getSecretInvalid = &validation.Mock{
+	getSecretInvalid = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return &corev1.Secret{
 				Data: map[string][]byte{
@@ -117,7 +117,7 @@ var (
 		},
 	}
 
-	gatherS3Failed = &validation.Mock{
+	gatherS3Failed = &helpers.ValidationMock{
 		GatherS3Func: func(
 			ctx validation.Context,
 			profiles []*s3.Profile,
@@ -137,7 +137,7 @@ var (
 		},
 	}
 
-	gatherS3Canceled = &validation.Mock{
+	gatherS3Canceled = &helpers.ValidationMock{
 		GatherS3Func: func(
 			ctx validation.Context,
 			profiles []*s3.Profile,
@@ -159,7 +159,7 @@ var (
 )
 
 func TestGatherApplicationPassed(t *testing.T) {
-	cmd := testCommand(t, &validation.Mock{})
+	cmd := testCommand(t, &helpers.ValidationMock{})
 	helpers.AddGatheredData(t, cmd.dataDir(), "appset-deploy-rbd", "validate-application")
 	if err := cmd.Application(drpcName, drpcNamespace); err != nil {
 		t.Fatal(err)
@@ -257,7 +257,7 @@ func TestGatherApplicationGatherClusterFailed(t *testing.T) {
 }
 
 func TestGatherApplicationNamespaces(t *testing.T) {
-	mockBackend := &validation.Mock{
+	mockBackend := &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(ctx validation.Context, name, namespace string) ([]string, error) {
 			if name != drpcName || namespace != drpcNamespace {
 				t.Fatalf("unexpected args: name=%s, namespace=%s", drpcName, drpcNamespace)
@@ -280,7 +280,7 @@ func TestGatherApplicationNamespaces(t *testing.T) {
 }
 
 func TestGatherApplicationInspectS3ProfilesFailed(t *testing.T) {
-	cmd := testCommand(t, &validation.Mock{})
+	cmd := testCommand(t, &helpers.ValidationMock{})
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
 	}

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -56,63 +56,73 @@ var (
 		applicationNamespace,
 	})
 
-	gatherClusterFailed = &helpers.ValidationMock{
-		GatherFunc: func(
-			ctx validation.Context,
-			clusters []*types.Cluster,
-			options gathering.Options,
-		) <-chan gathering.Result {
-			results := make(chan gathering.Result, 3)
-			for _, cluster := range clusters {
-				if cluster.Name == "hub" {
-					results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
-				} else {
-					results <- gathering.Result{Name: cluster.Name}
-				}
+	// Mock functions used by mock instances below.
+
+	gatherDataFailed = func(
+		ctx validation.Context,
+		clusters []*types.Cluster,
+		options gathering.Options,
+	) <-chan gathering.Result {
+		results := make(chan gathering.Result, 3)
+		for _, cluster := range clusters {
+			if cluster.Name == "hub" {
+				results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
+			} else {
+				results <- gathering.Result{Name: cluster.Name}
 			}
-			close(results)
-			return results
-		},
+		}
+		close(results)
+		return results
+	}
+
+	gatherS3DataFailed = func(
+		ctx validation.Context,
+		profiles []*s3.Profile,
+		prefixes []string,
+		outputDir string,
+	) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for i, profile := range profiles {
+			if i == 0 {
+				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
+			} else {
+				results <- s3.Result{ProfileName: profile.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	gatherS3DataCanceled = func(
+		ctx validation.Context,
+		profiles []*s3.Profile,
+		prefixes []string,
+		outputDir string,
+	) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for i, profile := range profiles {
+			if i == 0 {
+				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+			} else {
+				results <- s3.Result{ProfileName: profile.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	// Mock instances composing shared mock functions and helpers.
+
+	gatherClusterFailed = &helpers.ValidationMock{
+		GatherFunc: gatherDataFailed,
 	}
 
 	gatherS3Failed = &helpers.ValidationMock{
-		GatherS3Func: func(
-			ctx validation.Context,
-			profiles []*s3.Profile,
-			prefixes []string,
-			outputDir string,
-		) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for i, profile := range profiles {
-				if i == 0 {
-					results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
-				} else {
-					results <- s3.Result{ProfileName: profile.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		GatherS3Func: gatherS3DataFailed,
 	}
 
 	gatherS3Canceled = &helpers.ValidationMock{
-		GatherS3Func: func(
-			ctx validation.Context,
-			profiles []*s3.Profile,
-			prefixes []string,
-			outputDir string,
-		) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for i, profile := range profiles {
-				if i == 0 {
-					results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-				} else {
-					results <- s3.Result{ProfileName: profile.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		GatherS3Func: gatherS3DataCanceled,
 	}
 )
 

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -3,8 +3,6 @@
 package gather
 
 import (
-	"context"
-	"errors"
 	"reflect"
 	"slices"
 	"testing"
@@ -14,10 +12,8 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
-	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/report"
-	"github.com/ramendr/ramenctl/pkg/s3"
 	"github.com/ramendr/ramenctl/pkg/sets"
 	"github.com/ramendr/ramenctl/pkg/validation"
 )
@@ -56,73 +52,18 @@ var (
 		applicationNamespace,
 	})
 
-	// Mock functions used by mock instances below.
-
-	gatherDataFailed = func(
-		ctx validation.Context,
-		clusters []*types.Cluster,
-		options gathering.Options,
-	) <-chan gathering.Result {
-		results := make(chan gathering.Result, 3)
-		for _, cluster := range clusters {
-			if cluster.Name == "hub" {
-				results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
-			} else {
-				results <- gathering.Result{Name: cluster.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	gatherS3DataFailed = func(
-		ctx validation.Context,
-		profiles []*s3.Profile,
-		prefixes []string,
-		outputDir string,
-	) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for i, profile := range profiles {
-			if i == 0 {
-				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
-			} else {
-				results <- s3.Result{ProfileName: profile.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	gatherS3DataCanceled = func(
-		ctx validation.Context,
-		profiles []*s3.Profile,
-		prefixes []string,
-		outputDir string,
-	) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for i, profile := range profiles {
-			if i == 0 {
-				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-			} else {
-				results <- s3.Result{ProfileName: profile.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
 	// Mock instances composing shared mock functions and helpers.
 
 	gatherClusterFailed = &helpers.ValidationMock{
-		GatherFunc: gatherDataFailed,
+		GatherFunc: helpers.GatherDataFailed,
 	}
 
 	gatherS3Failed = &helpers.ValidationMock{
-		GatherS3Func: gatherS3DataFailed,
+		GatherS3Func: helpers.GatherS3DataFailed,
 	}
 
 	gatherS3Canceled = &helpers.ValidationMock{
-		GatherS3Func: gatherS3DataCanceled,
+		GatherS3Func: helpers.GatherS3DataCanceled,
 	}
 )
 

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -11,7 +11,6 @@ import (
 
 	e2econfig "github.com/ramendr/ramen/e2e/config"
 	"github.com/ramendr/ramen/e2e/types"
-	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
@@ -57,24 +56,6 @@ var (
 		applicationNamespace,
 	})
 
-	validateConfigFailed = &helpers.ValidationMock{
-		ValidateFunc: func(ctx validation.Context) error {
-			return errors.New("No validate for you!")
-		},
-	}
-
-	validateConfigCanceled = &helpers.ValidationMock{
-		ValidateFunc: func(ctx validation.Context) error {
-			return context.Canceled
-		},
-	}
-
-	inspectApplicationFailed = &helpers.ValidationMock{
-		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
-			return nil, errors.New("No namespaces for you!")
-		},
-	}
-
 	gatherClusterFailed = &helpers.ValidationMock{
 		GatherFunc: func(
 			ctx validation.Context,
@@ -91,29 +72,6 @@ var (
 			}
 			close(results)
 			return results
-		},
-	}
-
-	inspectS3ProfilesCanceled = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return nil, context.Canceled
-		},
-	}
-
-	getSecretFailed = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return nil, errors.New("secret not found")
-		},
-	}
-
-	getSecretInvalid = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return &corev1.Secret{
-				Data: map[string][]byte{
-					"AWS_ACCESS_KEY_ID":     []byte("invalid id"),
-					"AWS_SECRET_ACCESS_KEY": []byte("invalid key"),
-				},
-			}, nil
 		},
 	}
 
@@ -186,7 +144,7 @@ func TestGatherApplicationPassed(t *testing.T) {
 }
 
 func TestGatherApplicationValidateFailed(t *testing.T) {
-	cmd := testCommand(t, validateConfigFailed)
+	cmd := testCommand(t, helpers.ValidateConfigFailed)
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
 	}
@@ -200,7 +158,7 @@ func TestGatherApplicationValidateFailed(t *testing.T) {
 }
 
 func TestGatherApplicationValidateCanceled(t *testing.T) {
-	cmd := testCommand(t, validateConfigCanceled)
+	cmd := testCommand(t, helpers.ValidateConfigCanceled)
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
 	}
@@ -214,7 +172,7 @@ func TestGatherApplicationValidateCanceled(t *testing.T) {
 }
 
 func TestGatherApplicationInspectFailed(t *testing.T) {
-	cmd := testCommand(t, inspectApplicationFailed)
+	cmd := testCommand(t, helpers.InspectApplicationFailed)
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
 	}
@@ -304,7 +262,7 @@ func TestGatherApplicationInspectS3ProfilesFailed(t *testing.T) {
 }
 
 func TestGatherApplicationInspectS3ProfilesCanceled(t *testing.T) {
-	cmd := testCommand(t, inspectS3ProfilesCanceled)
+	cmd := testCommand(t, helpers.GetSecretCanceled)
 	helpers.AddGatheredData(t, cmd.dataDir(), "appset-deploy-rbd", "validate-application")
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
@@ -329,7 +287,7 @@ func TestGatherApplicationInspectS3ProfilesCanceled(t *testing.T) {
 }
 
 func TestGatherApplicationGetSecretFailed(t *testing.T) {
-	cmd := testCommand(t, getSecretFailed)
+	cmd := testCommand(t, helpers.GetSecretFailed)
 	helpers.AddGatheredData(t, cmd.dataDir(), "appset-deploy-rbd", "validate-application")
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")
@@ -358,7 +316,7 @@ func TestGatherApplicationGetSecretFailed(t *testing.T) {
 }
 
 func TestGatherApplicationGetSecretInvalid(t *testing.T) {
-	cmd := testCommand(t, getSecretInvalid)
+	cmd := testCommand(t, helpers.GetSecretInvalid)
 	helpers.AddGatheredData(t, cmd.dataDir(), "appset-deploy-rbd", "validate-application")
 	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
 		t.Fatal("command did not fail")

--- a/pkg/helpers/testing.go
+++ b/pkg/helpers/testing.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package testing
+package helpers
 
 import (
 	"bytes"
@@ -11,29 +11,26 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ramendr/ramenctl/pkg/gathering"
-	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/s3"
+	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
-type ContextFunc func(types.Context) error
-type TestContextFunc func(types.TestContext) error
-
-// Mock implements the testing.Testing interface. All operations succeed without accessing
+// TestingMock implements the testing.Testing interface. All operations succeed without accessing
 // the clusters. To cause operations to fail, set a function returning an error.
-type Mock struct {
+type TestingMock struct {
 	// Operations on types.Context
-	ValidateFunc ContextFunc
-	SetupFunc    ContextFunc
-	CleanupFunc  ContextFunc
+	ValidateFunc func(types.Context) error
+	SetupFunc    func(types.Context) error
+	CleanupFunc  func(types.Context) error
 
 	// Operations on types.TestContext
-	DeployFunc    TestContextFunc
-	UndeployFunc  TestContextFunc
-	ProtectFunc   TestContextFunc
-	UnprotectFunc TestContextFunc
-	FailoverFunc  TestContextFunc
-	RelocateFunc  TestContextFunc
-	PurgeFunc     TestContextFunc
+	DeployFunc    func(types.TestContext) error
+	UndeployFunc  func(types.TestContext) error
+	ProtectFunc   func(types.TestContext) error
+	UnprotectFunc func(types.TestContext) error
+	FailoverFunc  func(types.TestContext) error
+	RelocateFunc  func(types.TestContext) error
+	PurgeFunc     func(types.TestContext) error
 
 	// Handling failures.
 	GatherFunc    func(ctx types.Context, clsuters []*types.Cluster, options gathering.Options) <-chan gathering.Result
@@ -41,79 +38,79 @@ type Mock struct {
 	GatherS3Func  func(ctx types.Context, profiles []*s3.Profile, prefixes []string, outputDir string) <-chan s3.Result
 }
 
-var _ Testing = &Mock{}
+var _ testing.Testing = &TestingMock{}
 
-func (m *Mock) Validate(ctx types.Context) error {
+func (m *TestingMock) Validate(ctx types.Context) error {
 	if m.ValidateFunc != nil {
 		return m.ValidateFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Setup(ctx types.Context) error {
+func (m *TestingMock) Setup(ctx types.Context) error {
 	if m.SetupFunc != nil {
 		return m.SetupFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Cleanup(ctx types.Context) error {
+func (m *TestingMock) Cleanup(ctx types.Context) error {
 	if m.CleanupFunc != nil {
 		return m.CleanupFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Deploy(ctx types.TestContext) error {
+func (m *TestingMock) Deploy(ctx types.TestContext) error {
 	if m.DeployFunc != nil {
 		return m.DeployFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Undeploy(ctx types.TestContext) error {
+func (m *TestingMock) Undeploy(ctx types.TestContext) error {
 	if m.UndeployFunc != nil {
 		return m.UndeployFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Protect(ctx types.TestContext) error {
+func (m *TestingMock) Protect(ctx types.TestContext) error {
 	if m.ProtectFunc != nil {
 		return m.ProtectFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Unprotect(ctx types.TestContext) error {
+func (m *TestingMock) Unprotect(ctx types.TestContext) error {
 	if m.UnprotectFunc != nil {
 		return m.UnprotectFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Failover(ctx types.TestContext) error {
+func (m *TestingMock) Failover(ctx types.TestContext) error {
 	if m.FailoverFunc != nil {
 		return m.FailoverFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Relocate(ctx types.TestContext) error {
+func (m *TestingMock) Relocate(ctx types.TestContext) error {
 	if m.RelocateFunc != nil {
 		return m.RelocateFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Purge(ctx types.TestContext) error {
+func (m *TestingMock) Purge(ctx types.TestContext) error {
 	if m.PurgeFunc != nil {
 		return m.PurgeFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) Gather(
+func (m *TestingMock) Gather(
 	ctx types.Context,
 	clusters []*types.Cluster,
 	options gathering.Options,
@@ -130,7 +127,7 @@ func (m *Mock) Gather(
 	return results
 }
 
-func (m *Mock) GetSecret(
+func (m *TestingMock) GetSecret(
 	ctx types.Context,
 	cluster *types.Cluster,
 	name, namespace string,
@@ -140,13 +137,13 @@ func (m *Mock) GetSecret(
 	}
 	return &corev1.Secret{
 		Data: map[string][]byte{
-			"AWS_ACCESS_KEY_ID":     []byte(helpers.FakeAWSKeyID),
-			"AWS_SECRET_ACCESS_KEY": []byte(helpers.FakeAWSKey),
+			"AWS_ACCESS_KEY_ID":     []byte(FakeAWSKeyID),
+			"AWS_SECRET_ACCESS_KEY": []byte(FakeAWSKey),
 		},
 	}, nil
 }
 
-func (m *Mock) GatherS3(
+func (m *TestingMock) GatherS3(
 	ctx types.Context,
 	profiles []*s3.Profile,
 	prefixes []string,
@@ -157,9 +154,8 @@ func (m *Mock) GatherS3(
 	}
 	results := make(chan s3.Result, len(profiles))
 	for _, profile := range profiles {
-		// Fail if s3 secret credentials don't match expected testdata values.
-		if !bytes.Equal(profile.AWSAccessKeyID, []byte(helpers.FakeAWSKeyID)) ||
-			!bytes.Equal(profile.AWSSecretAccessKey, []byte(helpers.FakeAWSKey)) {
+		if !bytes.Equal(profile.AWSAccessKeyID, []byte(FakeAWSKeyID)) ||
+			!bytes.Equal(profile.AWSSecretAccessKey, []byte(FakeAWSKey)) {
 			results <- s3.Result{ProfileName: profile.Name, Err: errors.New("invalid credentials")}
 		} else {
 			results <- s3.Result{ProfileName: profile.Name, Err: nil}

--- a/pkg/helpers/validation.go
+++ b/pkg/helpers/validation.go
@@ -163,3 +163,80 @@ var (
 		},
 	}
 )
+
+// Mock functions for composing mock instances in tests.
+
+func GatherDataFailed(
+	ctx validation.Context,
+	clusters []*types.Cluster,
+	options gathering.Options,
+) <-chan gathering.Result {
+	results := make(chan gathering.Result, 3)
+	for _, cluster := range clusters {
+		if cluster.Name == "hub" {
+			results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you")}
+		} else {
+			results <- gathering.Result{Name: cluster.Name}
+		}
+	}
+	close(results)
+	return results
+}
+
+func GatherS3DataFailed(
+	ctx validation.Context,
+	profiles []*s3.Profile,
+	prefixes []string,
+	outputDir string,
+) <-chan s3.Result {
+	results := make(chan s3.Result, 2)
+	for i, profile := range profiles {
+		if i == 0 {
+			results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you")}
+		} else {
+			results <- s3.Result{ProfileName: profile.Name}
+		}
+	}
+	close(results)
+	return results
+}
+
+func GatherS3DataCanceled(
+	ctx validation.Context,
+	profiles []*s3.Profile,
+	prefixes []string,
+	outputDir string,
+) <-chan s3.Result {
+	results := make(chan s3.Result, 2)
+	for i, profile := range profiles {
+		if i == 0 {
+			results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+		} else {
+			results <- s3.Result{ProfileName: profile.Name}
+		}
+	}
+	close(results)
+	return results
+}
+
+func CheckS3DataFailed(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
+	results := make(chan s3.Result, 2)
+	for i, profile := range profiles {
+		if i == 0 {
+			results <- s3.Result{ProfileName: profile.Name, Err: errors.New("connection refused")}
+		} else {
+			results <- s3.Result{ProfileName: profile.Name}
+		}
+	}
+	close(results)
+	return results
+}
+
+func CheckS3DataCanceled(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
+	results := make(chan s3.Result, 2)
+	for _, profile := range profiles {
+		results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+	}
+	close(results)
+	return results
+}

--- a/pkg/helpers/validation.go
+++ b/pkg/helpers/validation.go
@@ -5,6 +5,7 @@ package helpers
 
 import (
 	"bytes"
+	"context"
 	"errors"
 
 	"github.com/ramendr/ramen/e2e/types"
@@ -117,3 +118,48 @@ func (m *ValidationMock) CheckS3(ctx validation.Context, profiles []*s3.Profile)
 	close(results)
 	return results
 }
+
+// Pre-configured ValidationMock instances for common test scenarios.
+
+var (
+	ValidateConfigFailed = &ValidationMock{
+		ValidateFunc: func(ctx validation.Context) error {
+			return errors.New("no validate for you")
+		},
+	}
+
+	ValidateConfigCanceled = &ValidationMock{
+		ValidateFunc: func(ctx validation.Context) error {
+			return context.Canceled
+		},
+	}
+
+	InspectApplicationFailed = &ValidationMock{
+		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
+			return nil, errors.New("no namespaces for you")
+		},
+	}
+
+	GetSecretCanceled = &ValidationMock{
+		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
+			return nil, context.Canceled
+		},
+	}
+
+	GetSecretFailed = &ValidationMock{
+		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
+			return nil, errors.New("secret not found")
+		},
+	}
+
+	GetSecretInvalid = &ValidationMock{
+		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
+			return &corev1.Secret{
+				Data: map[string][]byte{
+					"AWS_ACCESS_KEY_ID":     []byte("invalid id"),
+					"AWS_SECRET_ACCESS_KEY": []byte("invalid key"),
+				},
+			}, nil
+		},
+	}
+)

--- a/pkg/helpers/validation.go
+++ b/pkg/helpers/validation.go
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: The RamenDR authors
 // SPDX-License-Identifier: Apache-2.0
 
-package validation
+package helpers
 
 import (
 	"bytes"
@@ -11,34 +11,33 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/ramendr/ramenctl/pkg/gathering"
-	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/s3"
+	"github.com/ramendr/ramenctl/pkg/validation"
 )
 
-type ContextFunc func(Context) error
-
-// Mock implements the Validation interface. All operations succeed without accessing the clusters.
-// To cause operations to fail or return non default values, set a function returning an error.
-type Mock struct {
-	ValidateFunc              ContextFunc
-	ApplicationNamespacesFunc func(ctx Context, drpcName, drpcNamespace string) ([]string, error)
-	GatherFunc                func(ctx Context, clsuters []*types.Cluster, options gathering.Options) <-chan gathering.Result
-	GatherS3Func              func(ctx Context, profiles []*s3.Profile, prefixes []string, outputDir string) <-chan s3.Result
-	GetSecretFunc             func(ctx Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error)
-	CheckS3Func               func(ctx Context, profiles []*s3.Profile) <-chan s3.Result
+// ValidationMock implements the validation.Validation interface. All operations succeed without
+// accessing the clusters. To cause operations to fail or return non default values, set a function
+// returning an error.
+type ValidationMock struct {
+	ValidateFunc              func(validation.Context) error
+	ApplicationNamespacesFunc func(ctx validation.Context, drpcName, drpcNamespace string) ([]string, error)
+	GatherFunc                func(ctx validation.Context, clsuters []*types.Cluster, options gathering.Options) <-chan gathering.Result
+	GatherS3Func              func(ctx validation.Context, profiles []*s3.Profile, prefixes []string, outputDir string) <-chan s3.Result
+	GetSecretFunc             func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error)
+	CheckS3Func               func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result
 }
 
-var _ Validation = &Mock{}
+var _ validation.Validation = &ValidationMock{}
 
-func (m *Mock) Validate(ctx Context) error {
+func (m *ValidationMock) Validate(ctx validation.Context) error {
 	if m.ValidateFunc != nil {
 		return m.ValidateFunc(ctx)
 	}
 	return nil
 }
 
-func (m *Mock) ApplicationNamespaces(
-	ctx Context,
+func (m *ValidationMock) ApplicationNamespaces(
+	ctx validation.Context,
 	drpcName, drpcNamespace string,
 ) ([]string, error) {
 	if m.ApplicationNamespacesFunc != nil {
@@ -47,8 +46,8 @@ func (m *Mock) ApplicationNamespaces(
 	return nil, nil
 }
 
-func (m *Mock) Gather(
-	ctx Context,
+func (m *ValidationMock) Gather(
+	ctx validation.Context,
 	clusters []*types.Cluster,
 	options gathering.Options,
 ) <-chan gathering.Result {
@@ -64,8 +63,8 @@ func (m *Mock) Gather(
 	return results
 }
 
-func (m *Mock) GetSecret(
-	ctx Context,
+func (m *ValidationMock) GetSecret(
+	ctx validation.Context,
 	cluster *types.Cluster,
 	name, namespace string,
 ) (*corev1.Secret, error) {
@@ -74,14 +73,14 @@ func (m *Mock) GetSecret(
 	}
 	return &corev1.Secret{
 		Data: map[string][]byte{
-			"AWS_ACCESS_KEY_ID":     []byte(helpers.FakeAWSKeyID),
-			"AWS_SECRET_ACCESS_KEY": []byte(helpers.FakeAWSKey),
+			"AWS_ACCESS_KEY_ID":     []byte(FakeAWSKeyID),
+			"AWS_SECRET_ACCESS_KEY": []byte(FakeAWSKey),
 		},
 	}, nil
 }
 
-func (m *Mock) GatherS3(
-	ctx Context,
+func (m *ValidationMock) GatherS3(
+	ctx validation.Context,
 	profiles []*s3.Profile,
 	prefixes []string,
 	outputDir string,
@@ -91,9 +90,8 @@ func (m *Mock) GatherS3(
 	}
 	results := make(chan s3.Result, len(profiles))
 	for _, profile := range profiles {
-		// Fail if s3 secret credentials don't match expected testdata values.
-		if !bytes.Equal(profile.AWSAccessKeyID, []byte(helpers.FakeAWSKeyID)) ||
-			!bytes.Equal(profile.AWSSecretAccessKey, []byte(helpers.FakeAWSKey)) {
+		if !bytes.Equal(profile.AWSAccessKeyID, []byte(FakeAWSKeyID)) ||
+			!bytes.Equal(profile.AWSSecretAccessKey, []byte(FakeAWSKey)) {
 			results <- s3.Result{ProfileName: profile.Name, Err: errors.New("invalid credentials")}
 		} else {
 			results <- s3.Result{ProfileName: profile.Name, Err: nil}
@@ -103,15 +101,14 @@ func (m *Mock) GatherS3(
 	return results
 }
 
-func (m *Mock) CheckS3(ctx Context, profiles []*s3.Profile) <-chan s3.Result {
+func (m *ValidationMock) CheckS3(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
 	if m.CheckS3Func != nil {
 		return m.CheckS3Func(ctx, profiles)
 	}
 	results := make(chan s3.Result, len(profiles))
 	for _, profile := range profiles {
-		// Fail if s3 secret credentials don't match expected testdata values.
-		if !bytes.Equal(profile.AWSAccessKeyID, []byte(helpers.FakeAWSKeyID)) ||
-			!bytes.Equal(profile.AWSSecretAccessKey, []byte(helpers.FakeAWSKey)) {
+		if !bytes.Equal(profile.AWSAccessKeyID, []byte(FakeAWSKeyID)) ||
+			!bytes.Equal(profile.AWSSecretAccessKey, []byte(FakeAWSKey)) {
 			results <- s3.Result{ProfileName: profile.Name, Err: errors.New("invalid credentials")}
 		} else {
 			results <- s3.Result{ProfileName: profile.Name, Err: nil}

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -76,55 +76,55 @@ var (
 		C2:  &types.Cluster{Name: "c2"},
 	}
 
-	validateFailed = &rtesting.Mock{
+	validateFailed = &helpers.TestingMock{
 		ValidateFunc: func(ctx types.Context) error {
 			return errors.New("No validate for you!")
 		},
 	}
 
-	validateCanceled = &rtesting.Mock{
+	validateCanceled = &helpers.TestingMock{
 		ValidateFunc: func(ctx types.Context) error {
 			return context.Canceled
 		},
 	}
 
-	setupFailed = &rtesting.Mock{
+	setupFailed = &helpers.TestingMock{
 		SetupFunc: func(ctx types.Context) error {
 			return errors.New("No setup for you!")
 		},
 	}
 
-	setupCanceled = &rtesting.Mock{
+	setupCanceled = &helpers.TestingMock{
 		SetupFunc: func(ctx types.Context) error {
 			return context.Canceled
 		},
 	}
 
-	cleanupFailed = &rtesting.Mock{
+	cleanupFailed = &helpers.TestingMock{
 		CleanupFunc: func(ctx types.Context) error {
 			return errors.New("No cleanup for you!")
 		},
 	}
 
-	cleanupCanceled = &rtesting.Mock{
+	cleanupCanceled = &helpers.TestingMock{
 		CleanupFunc: func(ctx types.Context) error {
 			return context.Canceled
 		},
 	}
 
-	failoverFailed = &rtesting.Mock{
+	failoverFailed = &helpers.TestingMock{
 		FailoverFunc: func(ctx types.TestContext) error {
 			return errors.New("No failover for you!")
 		},
 	}
 
-	failoverCanceled = &rtesting.Mock{
+	failoverCanceled = &helpers.TestingMock{
 		FailoverFunc: func(ctx types.TestContext) error {
 			return context.Canceled
 		},
 	}
 
-	disappFailoverFailed = &rtesting.Mock{
+	disappFailoverFailed = &helpers.TestingMock{
 		FailoverFunc: func(ctx types.TestContext) error {
 			if ctx.Deployer().IsDiscovered() {
 				return errors.New("No failover for you!")
@@ -133,13 +133,13 @@ var (
 		},
 	}
 
-	purgeFailed = &rtesting.Mock{
+	purgeFailed = &helpers.TestingMock{
 		PurgeFunc: func(ctx types.TestContext) error {
 			return errors.New("No purge for you!")
 		},
 	}
 
-	purgeCanceled = &rtesting.Mock{
+	purgeCanceled = &helpers.TestingMock{
 		PurgeFunc: func(ctx types.TestContext) error {
 			return context.Canceled
 		},
@@ -149,7 +149,7 @@ var (
 )
 
 func TestRunPassed(t *testing.T) {
-	test := testCommand(t, testRun, &rtesting.Mock{})
+	test := testCommand(t, testRun, &helpers.TestingMock{})
 
 	if err := test.Run(); err != nil {
 		t.Fatal(err)
@@ -329,7 +329,7 @@ func TestRunTestsCanceled(t *testing.T) {
 }
 
 func TestCleanPassed(t *testing.T) {
-	test := testCommand(t, testClean, &rtesting.Mock{})
+	test := testCommand(t, testClean, &helpers.TestingMock{})
 
 	if err := test.Clean(); err != nil {
 		t.Fatal(err)

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -122,6 +122,64 @@ var (
 		return results
 	}
 
+	gatherS3DataFailed = func(
+		ctx validation.Context,
+		profiles []*s3.Profile,
+		prefixes []string,
+		outputDir string,
+	) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for i, profile := range profiles {
+			if i == 0 {
+				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
+			} else {
+				results <- s3.Result{ProfileName: profile.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	gatherS3DataCanceled = func(
+		ctx validation.Context,
+		profiles []*s3.Profile,
+		prefixes []string,
+		outputDir string,
+	) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for i, profile := range profiles {
+			if i == 0 {
+				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+			} else {
+				results <- s3.Result{ProfileName: profile.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	checkS3DataFailed = func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for i, profile := range profiles {
+			if i == 0 {
+				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("connection refused")}
+			} else {
+				results <- s3.Result{ProfileName: profile.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	checkS3DataCanceled = func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
+		results := make(chan s3.Result, 2)
+		for _, profile := range profiles {
+			results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+		}
+		close(results)
+		return results
+	}
+
 	// Mock instances composing shared mock functions and helpers.
 
 	applicationMock = &helpers.ValidationMock{
@@ -162,70 +220,20 @@ var (
 
 	gatherS3Failed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherS3Func: func(
-			ctx validation.Context,
-			profiles []*s3.Profile,
-			prefixes []string,
-			outputDir string,
-		) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for i, profile := range profiles {
-				if i == 0 {
-					results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
-				} else {
-					results <- s3.Result{ProfileName: profile.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		GatherS3Func:             gatherS3DataFailed,
 	}
 
 	gatherS3Canceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherS3Func: func(
-			ctx validation.Context,
-			profiles []*s3.Profile,
-			prefixes []string,
-			outputDir string,
-		) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for i, profile := range profiles {
-				if i == 0 {
-					results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-				} else {
-					results <- s3.Result{ProfileName: profile.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		GatherS3Func:             gatherS3DataCanceled,
 	}
 
 	checkS3Failed = &helpers.ValidationMock{
-		CheckS3Func: func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for i, profile := range profiles {
-				if i == 0 {
-					results <- s3.Result{ProfileName: profile.Name, Err: errors.New("connection refused")}
-				} else {
-					results <- s3.Result{ProfileName: profile.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		CheckS3Func: checkS3DataFailed,
 	}
 
 	checkS3Canceled = &helpers.ValidationMock{
-		CheckS3Func: func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
-			results := make(chan s3.Result, 2)
-			for _, profile := range profiles {
-				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-			}
-			close(results)
-			return results
-		},
+		CheckS3Func: checkS3DataCanceled,
 	}
 )
 

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -5,7 +5,6 @@ package validate
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -20,11 +19,9 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/config"
-	"github.com/ramendr/ramenctl/pkg/gathering"
 	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/ramen"
 	"github.com/ramendr/ramenctl/pkg/report"
-	"github.com/ramendr/ramenctl/pkg/s3"
 	"github.com/ramendr/ramenctl/pkg/sets"
 	"github.com/ramendr/ramenctl/pkg/time"
 	"github.com/ramendr/ramenctl/pkg/validation"
@@ -103,83 +100,6 @@ var (
 		applicationNamespace,
 	})
 
-	// Mock functions used by mock instances below.
-
-	gatherDataFailed = func(
-		ctx validation.Context,
-		clusters []*types.Cluster,
-		options gathering.Options,
-	) <-chan gathering.Result {
-		results := make(chan gathering.Result, 3)
-		for _, cluster := range clusters {
-			if cluster.Name == "hub" {
-				results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
-			} else {
-				results <- gathering.Result{Name: cluster.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	gatherS3DataFailed = func(
-		ctx validation.Context,
-		profiles []*s3.Profile,
-		prefixes []string,
-		outputDir string,
-	) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for i, profile := range profiles {
-			if i == 0 {
-				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("no S3 data for you!")}
-			} else {
-				results <- s3.Result{ProfileName: profile.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	gatherS3DataCanceled = func(
-		ctx validation.Context,
-		profiles []*s3.Profile,
-		prefixes []string,
-		outputDir string,
-	) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for i, profile := range profiles {
-			if i == 0 {
-				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-			} else {
-				results <- s3.Result{ProfileName: profile.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	checkS3DataFailed = func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for i, profile := range profiles {
-			if i == 0 {
-				results <- s3.Result{ProfileName: profile.Name, Err: errors.New("connection refused")}
-			} else {
-				results <- s3.Result{ProfileName: profile.Name}
-			}
-		}
-		close(results)
-		return results
-	}
-
-	checkS3DataCanceled = func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
-		results := make(chan s3.Result, 2)
-		for _, profile := range profiles {
-			results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
-		}
-		close(results)
-		return results
-	}
-
 	// Mock instances composing shared mock functions and helpers.
 
 	applicationMock = &helpers.ValidationMock{
@@ -196,11 +116,11 @@ var (
 
 	applicationGatherDataFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherFunc:               gatherDataFailed,
+		GatherFunc:                helpers.GatherDataFailed,
 	}
 
 	clustersGatherDataFailed = &helpers.ValidationMock{
-		GatherFunc: gatherDataFailed,
+		GatherFunc: helpers.GatherDataFailed,
 	}
 
 	inspectApplicationS3ProfilesCanceled = &helpers.ValidationMock{
@@ -220,20 +140,20 @@ var (
 
 	gatherS3Failed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherS3Func:             gatherS3DataFailed,
+		GatherS3Func:              helpers.GatherS3DataFailed,
 	}
 
 	gatherS3Canceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherS3Func:             gatherS3DataCanceled,
+		GatherS3Func:              helpers.GatherS3DataCanceled,
 	}
 
 	checkS3Failed = &helpers.ValidationMock{
-		CheckS3Func: checkS3DataFailed,
+		CheckS3Func: helpers.CheckS3DataFailed,
 	}
 
 	checkS3Canceled = &helpers.ValidationMock{
-		CheckS3Func: checkS3DataCanceled,
+		CheckS3Func: helpers.CheckS3DataCanceled,
 	}
 )
 

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -103,37 +103,37 @@ var (
 		applicationNamespace,
 	})
 
-	applicationMock = &validation.Mock{
+	applicationMock = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return applicationNamespaces, nil
 		},
 	}
 
-	validateConfigFailed = &validation.Mock{
+	validateConfigFailed = &helpers.ValidationMock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return errors.New("No validate for you!")
 		},
 	}
 
-	validateConfigCanceled = &validation.Mock{
+	validateConfigCanceled = &helpers.ValidationMock{
 		ValidateFunc: func(ctx validation.Context) error {
 			return context.Canceled
 		},
 	}
 
-	inspectApplicationFailed = &validation.Mock{
+	inspectApplicationFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return nil, errors.New("No namespaces for you!")
 		},
 	}
 
-	inspectApplicationCanceled = &validation.Mock{
+	inspectApplicationCanceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return nil, context.Canceled
 		},
 	}
 
-	gatherClusterFailed = &validation.Mock{
+	gatherClusterFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GatherFunc: func(
 			ctx validation.Context,
@@ -153,26 +153,26 @@ var (
 		},
 	}
 
-	inspectApplicationS3ProfilesCanceled = &validation.Mock{
+	inspectApplicationS3ProfilesCanceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return nil, context.Canceled
 		},
 	}
 
-	inspectClustersS3ProfilesCanceled = &validation.Mock{
+	inspectClustersS3ProfilesCanceled = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return nil, context.Canceled
 		},
 	}
 
-	clustersGetSecretFailed = &validation.Mock{
+	clustersGetSecretFailed = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return nil, errors.New("secret not found")
 		},
 	}
 
-	clustersGetSecretInvalid = &validation.Mock{
+	clustersGetSecretInvalid = &helpers.ValidationMock{
 		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
 			return &corev1.Secret{
 				Data: map[string][]byte{
@@ -183,17 +183,17 @@ var (
 		},
 	}
 
-	applicationGetSecretFailed = &validation.Mock{
+	applicationGetSecretFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GetSecretFunc:             clustersGetSecretFailed.GetSecret,
 	}
 
-	applicationGetSecretInvalid = &validation.Mock{
+	applicationGetSecretInvalid = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GetSecretFunc:             clustersGetSecretInvalid.GetSecret,
 	}
 
-	gatherS3Failed = &validation.Mock{
+	gatherS3Failed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GatherS3Func: func(
 			ctx validation.Context,
@@ -214,7 +214,7 @@ var (
 		},
 	}
 
-	gatherS3Canceled = &validation.Mock{
+	gatherS3Canceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
 		GatherS3Func: func(
 			ctx validation.Context,
@@ -231,7 +231,7 @@ var (
 		},
 	}
 
-	checkS3Failed = &validation.Mock{
+	checkS3Failed = &helpers.ValidationMock{
 		CheckS3Func: func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
 			results := make(chan s3.Result, 2)
 			for i, profile := range profiles {
@@ -246,7 +246,7 @@ var (
 		},
 	}
 
-	checkS3Canceled = &validation.Mock{
+	checkS3Canceled = &helpers.ValidationMock{
 		CheckS3Func: func(ctx validation.Context, profiles []*s3.Profile) <-chan s3.Result {
 			results := make(chan s3.Result, 2)
 			for _, profile := range profiles {
@@ -261,7 +261,7 @@ var (
 // Command common tests
 
 func TestValidatedDeleted(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	t.Run("nil", func(t *testing.T) {
 		validated := cmd.validatedDeleted(nil)
@@ -318,7 +318,7 @@ func TestValidatedDeleted(t *testing.T) {
 // Command application tests
 
 func TestValidatedDRPCAction(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 	known := []struct {
 		name   string
 		action string
@@ -372,7 +372,7 @@ func TestValidatedDRPCPhaseError(t *testing.T) {
 		phase  ramenapi.DRState
 	}
 
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	unstable := []struct {
 		stable ramenapi.DRState
@@ -450,7 +450,7 @@ func TestValidatedDRPCPhaseError(t *testing.T) {
 }
 
 func TestValidatedDRPCPhaseOK(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	cases := []struct {
 		name   string
@@ -492,7 +492,7 @@ func TestValidatedDRPCPhaseOK(t *testing.T) {
 }
 
 func TestValidatedDRPCProgressionOK(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 	progression := ramenapi.ProgressionCompleted
 
 	t.Run(string(progression), func(t *testing.T) {
@@ -520,7 +520,7 @@ func TestValidatedDRPCProgressionOK(t *testing.T) {
 }
 
 func TestValidatedDRPCProgressionError(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	progressions := []ramenapi.ProgressionStatus{
 		ramenapi.ProgressionCreatingMW,
@@ -577,7 +577,7 @@ func TestValidatedDRPCProgressionError(t *testing.T) {
 }
 
 func TestValidatedVRGSTateOK(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	cases := []struct {
 		name        string
@@ -614,7 +614,7 @@ func TestValidatedVRGSTateOK(t *testing.T) {
 }
 
 func TestValidatedVRGSTateError(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	cases := []struct {
 		name        string
@@ -657,7 +657,7 @@ func TestValidatedVRGSTateError(t *testing.T) {
 }
 
 func TestValidatedProtectedPVCOK(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	t.Run("bound", func(t *testing.T) {
 		pvc := &corev1.PersistentVolumeClaim{
@@ -684,7 +684,7 @@ func TestValidatedProtectedPVCOK(t *testing.T) {
 }
 
 func TestValidatedProtectedPVCError(t *testing.T) {
-	cmd := testCommand(t, validateApplication, &validation.Mock{}, testK8s)
+	cmd := testCommand(t, validateApplication, &helpers.ValidationMock{}, testK8s)
 
 	cases := []struct {
 		name  string
@@ -726,7 +726,7 @@ func TestValidatedProtectedPVCError(t *testing.T) {
 // Validate clusters tests.
 
 func TestValidateClustersK8s(t *testing.T) {
-	validate := testCommand(t, validateClusters, &validation.Mock{}, testK8s)
+	validate := testCommand(t, validateClusters, &helpers.ValidationMock{}, testK8s)
 	helpers.AddGatheredData(t, validate.dataDir(), "clusters/"+testK8s.name, validate.report.Name)
 	if err := validate.Clusters(); err != nil {
 		dumpCommandLog(t, validate)
@@ -1310,7 +1310,7 @@ func TestValidateClustersK8s(t *testing.T) {
 }
 
 func TestValidateClustersOcp(t *testing.T) {
-	validate := testCommand(t, validateClusters, &validation.Mock{}, testOcp)
+	validate := testCommand(t, validateClusters, &helpers.ValidationMock{}, testOcp)
 	helpers.AddGatheredData(t, validate.dataDir(), "clusters/"+testOcp.name, validate.report.Name)
 	if err := validate.Clusters(); err != nil {
 		dumpCommandLog(t, validate)
@@ -1940,7 +1940,7 @@ func TestValidateClusterGatherClusterFailed(t *testing.T) {
 }
 
 func TestValidateClustersInspectS3ProfilesFailed(t *testing.T) {
-	validate := testCommand(t, validateClusters, &validation.Mock{}, testK8s)
+	validate := testCommand(t, validateClusters, &helpers.ValidationMock{}, testK8s)
 	// We don't add test data to cause inspect S3 profiles to fail.
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -109,24 +109,6 @@ var (
 		},
 	}
 
-	validateConfigFailed = &helpers.ValidationMock{
-		ValidateFunc: func(ctx validation.Context) error {
-			return errors.New("No validate for you!")
-		},
-	}
-
-	validateConfigCanceled = &helpers.ValidationMock{
-		ValidateFunc: func(ctx validation.Context) error {
-			return context.Canceled
-		},
-	}
-
-	inspectApplicationFailed = &helpers.ValidationMock{
-		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
-			return nil, errors.New("No namespaces for you!")
-		},
-	}
-
 	inspectApplicationCanceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return nil, context.Canceled
@@ -155,42 +137,17 @@ var (
 
 	inspectApplicationS3ProfilesCanceled = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return nil, context.Canceled
-		},
-	}
-
-	inspectClustersS3ProfilesCanceled = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return nil, context.Canceled
-		},
-	}
-
-	clustersGetSecretFailed = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return nil, errors.New("secret not found")
-		},
-	}
-
-	clustersGetSecretInvalid = &helpers.ValidationMock{
-		GetSecretFunc: func(ctx validation.Context, cluster *types.Cluster, name, namespace string) (*corev1.Secret, error) {
-			return &corev1.Secret{
-				Data: map[string][]byte{
-					"AWS_ACCESS_KEY_ID":     []byte("invalid id"),
-					"AWS_SECRET_ACCESS_KEY": []byte("invalid key"),
-				},
-			}, nil
-		},
+		GetSecretFunc:             helpers.GetSecretCanceled.GetSecret,
 	}
 
 	applicationGetSecretFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GetSecretFunc:             clustersGetSecretFailed.GetSecret,
+		GetSecretFunc:             helpers.GetSecretFailed.GetSecret,
 	}
 
 	applicationGetSecretInvalid = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GetSecretFunc:             clustersGetSecretInvalid.GetSecret,
+		GetSecretFunc:             helpers.GetSecretInvalid.GetSecret,
 	}
 
 	gatherS3Failed = &helpers.ValidationMock{
@@ -1877,7 +1834,7 @@ func TestValidateClustersOcp(t *testing.T) {
 }
 
 func TestValidateClustersValidateFailed(t *testing.T) {
-	validate := testCommand(t, validateClusters, validateConfigFailed, testK8s)
+	validate := testCommand(t, validateClusters, helpers.ValidateConfigFailed, testK8s)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
@@ -1895,7 +1852,7 @@ func TestValidateClustersValidateFailed(t *testing.T) {
 }
 
 func TestValidateClustersValidateCanceled(t *testing.T) {
-	validate := testCommand(t, validateClusters, validateConfigCanceled, testK8s)
+	validate := testCommand(t, validateClusters, helpers.ValidateConfigCanceled, testK8s)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
@@ -1971,7 +1928,7 @@ func TestValidateClustersInspectS3ProfilesFailed(t *testing.T) {
 }
 
 func TestValidateClustersInspectS3ProfilesCanceled(t *testing.T) {
-	validate := testCommand(t, validateClusters, inspectClustersS3ProfilesCanceled, testK8s)
+	validate := testCommand(t, validateClusters, helpers.GetSecretCanceled, testK8s)
 	helpers.AddGatheredData(t, validate.dataDir(), "clusters/"+testK8s.name, validate.report.Name)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
@@ -2000,7 +1957,7 @@ func TestValidateClustersInspectS3ProfilesCanceled(t *testing.T) {
 }
 
 func TestValidateClustersGetSecretFailed(t *testing.T) {
-	validate := testCommand(t, validateClusters, clustersGetSecretFailed, testK8s)
+	validate := testCommand(t, validateClusters, helpers.GetSecretFailed, testK8s)
 	helpers.AddGatheredData(t, validate.dataDir(), "clusters/"+testK8s.name, validate.report.Name)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
@@ -2032,7 +1989,7 @@ func TestValidateClustersGetSecretFailed(t *testing.T) {
 }
 
 func TestValidateClustersGetSecretInvalid(t *testing.T) {
-	validate := testCommand(t, validateClusters, clustersGetSecretInvalid, testK8s)
+	validate := testCommand(t, validateClusters, helpers.GetSecretInvalid, testK8s)
 	helpers.AddGatheredData(t, validate.dataDir(), "clusters/"+testK8s.name, validate.report.Name)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
@@ -2354,7 +2311,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 }
 
 func TestValidateApplicationValidateFailed(t *testing.T) {
-	validate := testCommand(t, validateApplication, validateConfigFailed, testK8s)
+	validate := testCommand(t, validateApplication, helpers.ValidateConfigFailed, testK8s)
 	if err := validate.Application(drpcName, drpcNamespace); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
@@ -2371,7 +2328,7 @@ func TestValidateApplicationValidateFailed(t *testing.T) {
 }
 
 func TestValidateApplicationValidateCanceled(t *testing.T) {
-	validate := testCommand(t, validateApplication, validateConfigCanceled, testK8s)
+	validate := testCommand(t, validateApplication, helpers.ValidateConfigCanceled, testK8s)
 	if err := validate.Application(drpcName, drpcNamespace); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
@@ -2388,7 +2345,7 @@ func TestValidateApplicationValidateCanceled(t *testing.T) {
 }
 
 func TestValidateApplicationInspectApplicationFailed(t *testing.T) {
-	validate := testCommand(t, validateApplication, inspectApplicationFailed, testK8s)
+	validate := testCommand(t, validateApplication, helpers.InspectApplicationFailed, testK8s)
 	if err := validate.Application(drpcName, drpcNamespace); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -103,6 +103,27 @@ var (
 		applicationNamespace,
 	})
 
+	// Mock functions used by mock instances below.
+
+	gatherDataFailed = func(
+		ctx validation.Context,
+		clusters []*types.Cluster,
+		options gathering.Options,
+	) <-chan gathering.Result {
+		results := make(chan gathering.Result, 3)
+		for _, cluster := range clusters {
+			if cluster.Name == "hub" {
+				results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
+			} else {
+				results <- gathering.Result{Name: cluster.Name}
+			}
+		}
+		close(results)
+		return results
+	}
+
+	// Mock instances composing shared mock functions and helpers.
+
 	applicationMock = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: func(validation.Context, string, string) ([]string, error) {
 			return applicationNamespaces, nil
@@ -115,24 +136,13 @@ var (
 		},
 	}
 
-	gatherClusterFailed = &helpers.ValidationMock{
+	applicationGatherDataFailed = &helpers.ValidationMock{
 		ApplicationNamespacesFunc: applicationMock.ApplicationNamespaces,
-		GatherFunc: func(
-			ctx validation.Context,
-			clusters []*types.Cluster,
-			options gathering.Options,
-		) <-chan gathering.Result {
-			results := make(chan gathering.Result, 3)
-			for _, cluster := range clusters {
-				if cluster.Name == "hub" {
-					results <- gathering.Result{Name: cluster.Name, Err: errors.New("no data for you!")}
-				} else {
-					results <- gathering.Result{Name: cluster.Name}
-				}
-			}
-			close(results)
-			return results
-		},
+		GatherFunc:               gatherDataFailed,
+	}
+
+	clustersGatherDataFailed = &helpers.ValidationMock{
+		GatherFunc: gatherDataFailed,
 	}
 
 	inspectApplicationS3ProfilesCanceled = &helpers.ValidationMock{
@@ -1870,7 +1880,7 @@ func TestValidateClustersValidateCanceled(t *testing.T) {
 }
 
 func TestValidateClusterGatherClusterFailed(t *testing.T) {
-	validate := testCommand(t, validateClusters, gatherClusterFailed, testK8s)
+	validate := testCommand(t, validateClusters, clustersGatherDataFailed, testK8s)
 	if err := validate.Clusters(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
@@ -2393,7 +2403,7 @@ func TestValidateApplicationInspectApplicationCanceled(t *testing.T) {
 }
 
 func TestValidateApplicationGatherClusterFailed(t *testing.T) {
-	validate := testCommand(t, validateApplication, gatherClusterFailed, testK8s)
+	validate := testCommand(t, validateApplication, applicationGatherDataFailed, testK8s)
 	if err := validate.Application(drpcName, drpcNamespace); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")

--- a/pkg/validate/command_test.go
+++ b/pkg/validate/command_test.go
@@ -190,8 +190,12 @@ var (
 			outputDir string,
 		) <-chan s3.Result {
 			results := make(chan s3.Result, 2)
-			for _, profile := range profiles {
-				results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+			for i, profile := range profiles {
+				if i == 0 {
+					results <- s3.Result{ProfileName: profile.Name, Err: context.Canceled}
+				} else {
+					results <- s3.Result{ProfileName: profile.Name}
+				}
 			}
 			close(results)
 			return results
@@ -2613,7 +2617,7 @@ func TestValidateApplicationGatherS3Canceled(t *testing.T) {
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
 		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Canceled},
-		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Canceled},
+		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Passed},
 	}
 	checkItems(t, validate.report.Steps[1], items)
 	checkSummary(t, validate.report, report.Summary{})


### PR DESCRIPTION
## Summary

- Move `ValidationMock` and `TestingMock` types from `pkg/validation/` and
  `pkg/testing/` to `pkg/helpers/`, separating test infrastructure from
  production code
- Consolidate duplicate mock instances and functions shared between
  `pkg/gather/` and `pkg/validate/` tests into `pkg/helpers/`
- Split validate's `gatherClusterFailed` mock into separate application
  and clusters variants, making each test's dependencies explicit

## Motivation

This is the first step toward splitting `pkg/validate/Command` into
separate `pkg/validate/application/Command` and
`pkg/validate/clusters/Command` types. Each command will use its own
specific report type (`application.Report`, `clusters.Report`) instead
of the shared `report.Report`, enabling each to generate focused HTML
reports with command-specific sections and styling. Consolidating the
test infrastructure now makes the upcoming test split straightforward —
each new test file will compose shared mock functions from helpers with
its own thin mock instances.

## Details

The mock types (`ValidationMock`, `TestingMock`) lived in production
packages alongside the interfaces they implement. This made it awkward
to share pre-configured mock instances across packages without creating
import cycles. Moving them to `pkg/helpers/` solves this and clearly
separates test infrastructure from production code.

With the types in helpers, we consolidate duplicate mock instances
(ValidateConfigFailed, GetSecretFailed, etc.) and shared mock functions
(GatherDataFailed, GatherS3DataFailed, etc.) that were copy-pasted
between gather and validate tests. Mock instances in each test file are
now trivial one-liners that compose shared functions with test-specific
context.

Also fixes `gatherS3Canceled` in validate to cancel only the first S3
profile instead of all, testing the more realistic mixed scenario where
some gathers complete before cancellation propagates.

Net result: 426 lines deleted, 350 added — and the remaining test code
is better organized for the upcoming split of validate into separate
application and clusters test files.