### PR TITLE
validate: Write HTML reports

### DIFF
--- a/docs/validate.md
+++ b/docs/validate.md
@@ -86,10 +86,14 @@ resources, and stored output files in the specified output directory:
 ```console
 $ tree -L1 out
 out
+├── style.css
 ├── validate-application.data
+├── validate-application.html
 ├── validate-application.log
 └── validate-application.yaml
 ```
+
+Open the HTML report in a browser to view the report.
 
 > [!IMPORTANT]
 > When reporting DR related issues, please create an archive with the output
@@ -266,10 +270,14 @@ directory:
 ```console
 $ tree -L1 out
 out
+├── style.css
 ├── validate-clusters.data
+├── validate-clusters.html
 ├── validate-clusters.log
 └── validate-clusters.yaml
 ```
+
+Open the HTML report in a browser to view the report.
 
 > [!IMPORTANT]
 > When reporting DR related issues, please create an archive with the output

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -72,9 +72,6 @@ type Report struct {
 
 	// Application is set by `gather application` command.
 	Application *Application `json:"application,omitempty"`
-
-	// ClustersStatus is set by the `validate clusters` command.
-	ClustersStatus *ClustersStatus `json:"clustersStatus,omitempty"`
 }
 
 // NewBase create a new base report for ramenctl commands reports.

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -70,11 +70,8 @@ type Report struct {
 	// Namespaces is set by `validate` and `gather` commands.
 	Namespaces []string `json:"namespaces,omitempty"`
 
-	// Application is set by `validate application` and `gather application` commands.
+	// Application is set by `gather application` command.
 	Application *Application `json:"application,omitempty"`
-
-	// ApplicationStatus is set by the `validate application` commmnad.
-	ApplicationStatus *ApplicationStatus `json:"applicationStatus,omitempty"`
 
 	// ClustersStatus is set by the `validate clusters` command.
 	ClustersStatus *ClustersStatus `json:"clustersStatus,omitempty"`

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -5,6 +5,7 @@ package application
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"testing"
@@ -70,6 +71,7 @@ func checkReport(t *testing.T, cmd *Command, status report.Status) {
 	if cmd.Report.Duration != duration {
 		t.Fatalf("expected duration %v, got %v", duration, cmd.Report.Duration)
 	}
+	checkOutputFiles(t, cmd)
 }
 
 func checkApplication(t *testing.T, r *Report, expected *report.Application) {
@@ -118,6 +120,15 @@ func checkApplicationStatus(
 func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 	if !r.Summary.Equal(&expected) {
 		t.Fatalf("expected summary %v, got %v", expected, *r.Summary)
+	}
+}
+
+func checkOutputFiles(t *testing.T, cmd *Command) {
+	for _, name := range []string{CommandName + ".yaml", CommandName + ".html", "style.css"} {
+		path := filepath.Join(cmd.OutputDir(), name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("output file %q not found: %s", name, err)
+		}
 	}
 }
 

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -72,14 +72,14 @@ func checkReport(t *testing.T, cmd *Command, status report.Status) {
 	}
 }
 
-func checkApplication(t *testing.T, r *report.Report, expected *report.Application) {
-	if !reflect.DeepEqual(expected, r.Application) {
-		diff := helpers.UnifiedDiff(t, expected, r.Application)
+func checkApplication(t *testing.T, r *Report, expected *report.Application) {
+	if !reflect.DeepEqual(expected, &r.Application) {
+		diff := helpers.UnifiedDiff(t, expected, &r.Application)
 		t.Fatalf("applications not equal\n%s", diff)
 	}
 }
 
-func checkNamespaces(t *testing.T, r *report.Report, expected []string) {
+func checkNamespaces(t *testing.T, r *Report, expected []string) {
 	if !slices.Equal(r.Namespaces, expected) {
 		t.Fatalf("expected namespaces %q, got %q", expected, r.Namespaces)
 	}
@@ -106,21 +106,16 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 
 func checkApplicationStatus(
 	t *testing.T,
-	r *report.Report,
+	r *Report,
 	expected *report.ApplicationStatus,
 ) {
-	if expected != nil {
-		if !expected.Equal(r.ApplicationStatus) {
-			diff := helpers.UnifiedDiff(t, expected, r.ApplicationStatus)
-			t.Fatalf("application statuses not equal\n%s", diff)
-		}
-	} else if r.ApplicationStatus != nil {
-		t.Fatalf("application status not nil\n%s",
-			helpers.MarshalYAML(t, r.ApplicationStatus))
+	if !r.ApplicationStatus.Equal(expected) {
+		diff := helpers.UnifiedDiff(t, expected, &r.ApplicationStatus)
+		t.Fatalf("application statuses not equal\n%s", diff)
 	}
 }
 
-func checkSummary(t *testing.T, r *report.Report, expected report.Summary) {
+func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 	if !r.Summary.Equal(&expected) {
 		t.Fatalf("expected summary %v, got %v", expected, *r.Summary)
 	}

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -36,28 +36,37 @@ const CommandName = "validate-application"
 
 type Command struct {
 	*validatecmd.Command
+	Report *Report
 }
 
 func NewCommand(cmd *basecmd.Command, cfg *config.Config, backend validation.Validation) *Command {
-	r := report.NewReport(cmd.Name(), cfg)
-	r.Summary = &report.Summary{}
+	r := NewReport(cfg)
 	return &Command{
-		Command: validatecmd.New(cmd, cfg, backend, r),
+		Command: validatecmd.New(cmd, cfg, backend, r.Report),
+		Report:  r,
 	}
 }
 
+func (c *Command) passed() {
+	c.WriteReport(c.Report)
+	console.Completed("Validation completed (%s)", summary.String(c.Report.Summary))
+}
+
+func (c *Command) failed() error {
+	c.WriteReport(c.Report)
+	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
+}
+
 func (c *Command) Run(drpcName, drpcNamespace string) error {
-	c.Report.Application = &report.Application{
-		Name:      drpcName,
-		Namespace: drpcNamespace,
-	}
+	c.Report.Application.Name = drpcName
+	c.Report.Application.Namespace = drpcNamespace
 	if !c.ValidateConfig() {
-		return c.Failed()
+		return c.failed()
 	}
 	if !c.validateApplication(drpcName, drpcNamespace) {
-		return c.Failed()
+		return c.failed()
 	}
-	c.Passed()
+	c.passed()
 	return nil
 }
 
@@ -278,8 +287,7 @@ func (c *Command) validateGatheredData(drpcName, drpcNamespace string) bool {
 		c.Current.AddStep(step)
 	}()
 
-	s := &report.ApplicationStatus{}
-	c.Report.ApplicationStatus = s
+	s := &c.Report.ApplicationStatus
 
 	drpc, err := c.validateHub(&s.Hub, drpcName, drpcNamespace)
 	if err != nil {

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -317,7 +317,7 @@ func TestValidateApplicationValidateFailed(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Failed)
-	checkApplicationStatus(t, validate.Report, nil)
+	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -334,7 +334,7 @@ func TestValidateApplicationValidateCanceled(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Canceled)
-	checkApplicationStatus(t, validate.Report, nil)
+	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -358,7 +358,7 @@ func TestValidateApplicationInspectApplicationFailed(t *testing.T) {
 		{Name: "inspect application", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
+	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -382,7 +382,7 @@ func TestValidateApplicationInspectApplicationCanceled(t *testing.T) {
 		{Name: "inspect application", Status: report.Canceled},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
+	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -409,7 +409,7 @@ func TestValidateApplicationGatherClusterFailed(t *testing.T) {
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
+	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -93,14 +93,14 @@ func checkReport(t *testing.T, cmd *Command, status report.Status) {
 	}
 }
 
-func checkApplication(t *testing.T, r *report.Report, expected *report.Application) {
+func checkApplication(t *testing.T, r *Report, expected *report.Application) {
 	if !reflect.DeepEqual(expected, r.Application) {
 		diff := helpers.UnifiedDiff(t, expected, r.Application)
 		t.Fatalf("applications not equal\n%s", diff)
 	}
 }
 
-func checkNamespaces(t *testing.T, r *report.Report, expected []string) {
+func checkNamespaces(t *testing.T, r *Report, expected []string) {
 	if !slices.Equal(r.Namespaces, expected) {
 		t.Fatalf("expected namespaces %q, got %q", expected, r.Namespaces)
 	}
@@ -127,21 +127,16 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 
 func checkClusterStatus(
 	t *testing.T,
-	r *report.Report,
+	r *Report,
 	expected *report.ClustersStatus,
 ) {
-	if expected != nil {
-		if !expected.Equal(r.ClustersStatus) {
-			diff := helpers.UnifiedDiff(t, expected, r.ClustersStatus)
-			t.Fatalf("clusters statuses not equal\n%s", diff)
-		}
-	} else if r.ClustersStatus != nil {
-		t.Fatalf("clusters status not nil\n%s",
-			helpers.MarshalYAML(t, r.ClustersStatus))
+	if !r.ClustersStatus.Equal(expected) {
+		diff := helpers.UnifiedDiff(t, expected, &r.ClustersStatus)
+		t.Fatalf("clusters statuses not equal\n%s", diff)
 	}
 }
 
-func checkSummary(t *testing.T, r *report.Report, expected report.Summary) {
+func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 	if !r.Summary.Equal(&expected) {
 		t.Fatalf("expected summary %v, got %v", expected, *r.Summary)
 	}

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -5,6 +5,7 @@ package clusters
 
 import (
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"testing"
@@ -91,6 +92,7 @@ func checkReport(t *testing.T, cmd *Command, status report.Status) {
 	if cmd.Report.Duration != duration {
 		t.Fatalf("expected duration %v, got %v", duration, cmd.Report.Duration)
 	}
+	checkOutputFiles(t, cmd)
 }
 
 func checkApplication(t *testing.T, r *Report, expected *report.Application) {
@@ -139,6 +141,15 @@ func checkClusterStatus(
 func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 	if !r.Summary.Equal(&expected) {
 		t.Fatalf("expected summary %v, got %v", expected, *r.Summary)
+	}
+}
+
+func checkOutputFiles(t *testing.T, cmd *Command) {
+	for _, name := range []string{CommandName + ".yaml", CommandName + ".html", "style.css"} {
+		path := filepath.Join(cmd.OutputDir(), name)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("output file %q not found: %s", name, err)
+		}
 	}
 }
 

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -125,22 +125,6 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 	}
 }
 
-func checkApplicationStatus(
-	t *testing.T,
-	r *report.Report,
-	expected *report.ApplicationStatus,
-) {
-	if expected != nil {
-		if !expected.Equal(r.ApplicationStatus) {
-			diff := helpers.UnifiedDiff(t, expected, r.ApplicationStatus)
-			t.Fatalf("application statuses not equal\n%s", diff)
-		}
-	} else if r.ApplicationStatus != nil {
-		t.Fatalf("application status not nil\n%s",
-			helpers.MarshalYAML(t, r.ApplicationStatus))
-	}
-}
-
 func checkClusterStatus(
 	t *testing.T,
 	r *report.Report,

--- a/pkg/validate/clusters/command.go
+++ b/pkg/validate/clusters/command.go
@@ -54,14 +54,24 @@ func NewCommand(cmd *basecmd.Command, cfg *config.Config, backend validation.Val
 	}
 }
 
+func (c *Command) passed() {
+	c.WriteReport(c.Report)
+	console.Completed("Validation completed (%s)", summary.String(c.Report.Summary))
+}
+
+func (c *Command) failed() error {
+	c.WriteReport(c.Report)
+	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
+}
+
 func (c *Command) Run() error {
 	if !c.ValidateConfig() {
-		return c.Failed()
+		return c.failed()
 	}
 	if !c.validateClusters() {
-		return c.Failed()
+		return c.failed()
 	}
-	c.Passed()
+	c.passed()
 	return nil
 }
 

--- a/pkg/validate/clusters/command.go
+++ b/pkg/validate/clusters/command.go
@@ -44,13 +44,14 @@ const (
 
 type Command struct {
 	*validatecmd.Command
+	Report *Report
 }
 
 func NewCommand(cmd *basecmd.Command, cfg *config.Config, backend validation.Validation) *Command {
-	r := report.NewReport(cmd.Name(), cfg)
-	r.Summary = &report.Summary{}
+	r := NewReport(cfg)
 	return &Command{
-		Command: validatecmd.New(cmd, cfg, backend, r),
+		Command: validatecmd.New(cmd, cfg, backend, r.Report),
+		Report:  r,
 	}
 }
 
@@ -195,8 +196,7 @@ func (c *Command) validateGatheredData() bool {
 		c.Current.AddStep(step)
 	}()
 
-	s := &report.ClustersStatus{}
-	c.Report.ClustersStatus = s
+	s := &c.Report.ClustersStatus
 
 	if err := c.validateHub(&s.Hub); err != nil {
 		step.Status = report.Failed

--- a/pkg/validate/clusters/command_test.go
+++ b/pkg/validate/clusters/command_test.go
@@ -63,7 +63,6 @@ func TestValidateClustersK8s(t *testing.T) {
 		{Name: "validate clusters data", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
 
 	expected := &report.ClustersStatus{
 		Hub: report.ClustersStatusHub{
@@ -653,7 +652,6 @@ func TestValidateClustersOcp(t *testing.T) {
 		{Name: "validate clusters data", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
 
 	expected := &report.ClustersStatus{
 		Hub: report.ClustersStatusHub{
@@ -1201,7 +1199,6 @@ func TestValidateClustersValidateFailed(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Failed)
-	checkApplicationStatus(t, validate.Report, nil)
 	checkClusterStatus(t, validate.Report, nil)
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -1219,7 +1216,6 @@ func TestValidateClustersValidateCanceled(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Canceled)
-	checkApplicationStatus(t, validate.Report, nil)
 	checkClusterStatus(t, validate.Report, nil)
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -1246,7 +1242,6 @@ func TestValidateClusterGatherClusterFailed(t *testing.T) {
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkApplicationStatus(t, validate.Report, nil)
 	checkClusterStatus(t, validate.Report, nil)
 	checkSummary(t, validate.Report, report.Summary{})
 }

--- a/pkg/validate/clusters/command_test.go
+++ b/pkg/validate/clusters/command_test.go
@@ -1199,7 +1199,7 @@ func TestValidateClustersValidateFailed(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Failed)
-	checkClusterStatus(t, validate.Report, nil)
+	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -1216,7 +1216,7 @@ func TestValidateClustersValidateCanceled(t *testing.T) {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
 	checkStep(t, validate.Report.Steps[0], "validate config", report.Canceled)
-	checkClusterStatus(t, validate.Report, nil)
+	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -1242,7 +1242,7 @@ func TestValidateClusterGatherClusterFailed(t *testing.T) {
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkClusterStatus(t, validate.Report, nil)
+	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -1271,8 +1271,9 @@ func TestValidateClustersInspectS3ProfilesFailed(t *testing.T) {
 		{Name: "validate clusters data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	if validate.Report.ClustersStatus == nil {
-		t.Fatal("clusters status is nil")
+	empty := &report.ClustersStatus{}
+	if validate.Report.ClustersStatus.Equal(empty) {
+		t.Fatal("clusters status is empty")
 	}
 	checkSummary(t, validate.Report, report.Summary{summary.Problem: 9})
 }
@@ -1302,7 +1303,7 @@ func TestValidateClustersInspectS3ProfilesCanceled(t *testing.T) {
 		{Name: "inspect S3 profiles", Status: report.Canceled},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkClusterStatus(t, validate.Report, nil)
+	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
 
@@ -1398,8 +1399,9 @@ func TestValidateClustersCheckS3Failed(t *testing.T) {
 		{Name: "validate clusters data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	if validate.Report.ClustersStatus == nil {
-		t.Fatal("clusters status is nil")
+	empty := &report.ClustersStatus{}
+	if validate.Report.ClustersStatus.Equal(empty) {
+		t.Fatal("clusters status is empty")
 	}
 	checkSummary(
 		t,
@@ -1434,6 +1436,6 @@ func TestValidateClustersCheckS3Canceled(t *testing.T) {
 		{Name: "check S3 profile \"minio-on-dr2\"", Status: report.Canceled},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkClusterStatus(t, validate.Report, nil)
+	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -181,16 +181,9 @@ func (c *Command) DataDir() string {
 	return filepath.Join(c.cmd.OutputDir(), c.cmd.Name()+".data")
 }
 
-// Completing commands.
-
-func (c *Command) Failed() error {
-	c.cmd.WriteYAMLReport(c.Report)
-	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
-}
-
-func (c *Command) Passed() {
-	c.cmd.WriteYAMLReport(c.Report)
-	console.Completed("Validation completed (%s)", summary.String(c.Report.Summary))
+// WriteReport writes the report to the command output directory.
+func (c *Command) WriteReport(report any) {
+	c.cmd.WriteYAMLReport(report)
 }
 
 // Managing steps.

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"path/filepath"
 	stdtime "time"
 
@@ -27,6 +28,11 @@ import (
 	"github.com/ramendr/ramenctl/pkg/validate/summary"
 	"github.com/ramendr/ramenctl/pkg/validation"
 )
+
+// HTMLWriter can write an HTML report.
+type HTMLWriter interface {
+	WriteHTML(io.Writer) error
+}
 
 type Command struct {
 	// Backend implementing the validation interface.
@@ -181,9 +187,26 @@ func (c *Command) DataDir() string {
 	return filepath.Join(c.cmd.OutputDir(), c.cmd.Name()+".data")
 }
 
-// WriteReport writes the report to the command output directory.
-func (c *Command) WriteReport(report any) {
-	c.cmd.WriteYAMLReport(report)
+// WriteReport writes YAML, HTML, and CSS reports to the command output directory.
+func (c *Command) WriteReport(r HTMLWriter) {
+	c.cmd.WriteYAMLReport(r)
+
+	file, err := c.cmd.OpenReport("html")
+	if err != nil {
+		console.Error("failed to open HTML report: %s", err)
+		return
+	}
+	defer file.Close()
+	if err := r.WriteHTML(file); err != nil {
+		console.Error("failed to write HTML report: %s", err)
+	}
+	if err := file.Close(); err != nil {
+		console.Error("failed to close HTML report: %s", err)
+	}
+
+	if err := report.WriteCSS(c.cmd.OutputDir()); err != nil {
+		console.Error("failed to write report CSS: %s", err)
+	}
 }
 
 // Managing steps.

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -183,6 +183,10 @@ func (c *Command) OutputReader(cluster string) gathering.OutputReader {
 	return gather.NewOutputReader(clusterDir)
 }
 
+func (c *Command) OutputDir() string {
+	return c.cmd.OutputDir()
+}
+
 func (c *Command) DataDir() string {
 	return filepath.Join(c.cmd.OutputDir(), c.cmd.Name()+".data")
 }


### PR DESCRIPTION
This change completes the HTML report feature, writing HTML report for `validate application` and `validate clusters` commands.

The user can open the HTML report in a browser to view the report.

## Example output

    out/
        validate-application.yaml
        validate-application.html
        validate-application.log
        validate-application.data/
        style.css

## Changes

- Give `application.Command` and `clusters.Command` their own `Report` fields
  using command-specific report types, so YAML reports include all
  command-specific data (ApplicationStatus, ClustersStatus)

- Write HTML and CSS reports alongside YAML when validation completes,
  using an `HTMLWriter` interface so the generic command handles all
  report formats without knowing the concrete report type

- Verify YAML, HTML, and CSS output files exist in all command tests

## Example runs

### validate clusters: ramen not deployed

```console
% ramenctl validate clusters -o out/ramen-not-deployed
⭐ Using config "config.yaml"
⭐ Using report "out/ramen-not-deployed"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ❌ Failed to inspect S3 profiles
   ❌ Issues found during validation

❌ validation failed (0 ok, 0 stale, 9 problem)
```

<img width="1558" height="1100" alt="ramen-not-deployed" src="https://github.com/user-attachments/assets/dfd4140f-d9f9-47c4-9a76-a59c2c78a148" />

### validate clusters: ramen not configured

```console
% ramenctl validate clusters -o out/ramen-not-configured
⭐ Using config "config.yaml"
⭐ Using report "out/ramen-not-configured"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ❌ Failed to inspect S3 profiles
   ❌ Issues found during validation

❌ validation failed (15 ok, 0 stale, 9 problem)
```

<img width="1558" height="1100" alt="ramen-not-configured" src="https://github.com/user-attachments/assets/125e0fb5-735d-4f11-8b78-239b69da9458" />

### validate clusters: ramen deployed and configured

Known issue: controller type validation broken with ramen main (moved to deployment environment variable).

```console
% ramenctl validate clusters -o out/ramen-deployed-and-configured         
⭐ Using config "config.yaml"
⭐ Using report "out/ramen-deployed-and-configured"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr2"
   ✅ Checked S3 profile "minio-on-dr1"
   ❌ Issues found during validation

❌ validation failed (88 ok, 0 stale, 2 problem)
```

<img width="1558" height="1100" alt="ramen-deployed-and-configured" src="https://github.com/user-attachments/assets/0bbc8c42-b703-45b5-8e44-2e0f1a74952e" />

### validate application: application protected

```console
% ramenctl validate application --namespace argocd --name appset-deploy-rbd -o out/application-protected
⭐ Using config "config.yaml"
⭐ Using report "out/application-protected"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (24 ok, 0 stale, 0 problem)
```

<img width="1558" height="1100" alt="application-protected" src="https://github.com/user-attachments/assets/3268d57b-f04e-4f75-8b9b-118d85358ced" />

### validate application: application failing over

```console
% ramenctl validate application --namespace argocd --name appset-deploy-rbd -o out/application-failing-over
⭐ Using config "config.yaml"
⭐ Using report "out/application-failing-over"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ❌ Issues found during validation

❌ validation failed (22 ok, 1 stale, 6 problem)
```

<img width="1558" height="1100" alt="application-failing-over" src="https://github.com/user-attachments/assets/0d6ae318-b3b9-460e-a035-51cfc5cb938f" />

---

Fixes #295 