### PR TITLE
ci: Update GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
         - goarch: arm64
           goos: windows
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Run codespell
         uses: codespell-project/actions-codespell@v2
         with:
@@ -28,14 +28,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -44,9 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -68,11 +68,11 @@ jobs:
             goos: windows
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create build tag
         run: git tag build-${{ github.run_id }}-${{ github.run_attempt }}
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false
@@ -81,7 +81,7 @@ jobs:
       - name: Build binary
         run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} make
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ramenctl-${{ matrix.goos }}-${{ matrix.goarch }}
           path: ramenctl*
@@ -103,11 +103,11 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create build tag
         run: git tag latest
       - name: Setup go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -114,5 +114,4 @@ jobs:
       - name: Download modules
         run: go mod download
       - name: Run tests
-        # https://github.com/golang/go/issues/75031
-        run: make test GOTOOLCHAIN=$(go mod edit -json | jq -r .Toolchain)
+        run: make test


### PR DESCRIPTION
Update all actions to latest major versions using Node.js 24 runtime, fixing the deprecation warning for Node.js 20 actions.

- actions/checkout v4 -> v6
- actions/setup-go v5 -> v6
- actions/upload-artifact v4 -> v7
- golangci/golangci-lint-action v7 -> v9

This also removes the need for make test workaround, since setup-go@v6 uses the go toolchain (go1.26.1) instead of go version (1.25.0).

Fixes #395
