### PR TITLE
Consolidate CLI options into structured Go types

### DIFF
--- a/cmd/commands/gather.go
+++ b/cmd/commands/gather.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/gather"
 )
@@ -19,7 +20,14 @@ var GatherApplicationCmd = &cobra.Command{
 	Use:   "application",
 	Short: "Collect data for a protected application",
 	Run: func(c *cobra.Command, args []string) {
-		if err := gather.Gather(configFile, outputDir, drpcName, drpcNamespace); err != nil {
+		if err := gather.Gather(command.ApplicationOptions{
+			Options: command.Options{
+				ConfigFile: configFile,
+				OutputDir:  outputDir,
+			},
+			DRPCName:      drpcName,
+			DRPCNamespace: drpcNamespace,
+		}); err != nil {
 			console.Fatal(err)
 		}
 	},

--- a/cmd/commands/test.go
+++ b/cmd/commands/test.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/test"
 )
@@ -19,7 +20,10 @@ var TestRunCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run disaster recovery flow",
 	Run: func(c *cobra.Command, args []string) {
-		if err := test.Run(configFile, outputDir); err != nil {
+		if err := test.Run(command.Options{
+			ConfigFile: configFile,
+			OutputDir:  outputDir,
+		}); err != nil {
 			console.Fatal(err)
 		}
 	},
@@ -29,7 +33,10 @@ var TestCleanCmd = &cobra.Command{
 	Use:   "clean",
 	Short: "Delete test artifacts",
 	Run: func(c *cobra.Command, args []string) {
-		if err := test.Clean(configFile, outputDir); err != nil {
+		if err := test.Clean(command.Options{
+			ConfigFile: configFile,
+			OutputDir:  outputDir,
+		}); err != nil {
 			console.Fatal(err)
 		}
 	},

--- a/cmd/commands/validate.go
+++ b/cmd/commands/validate.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/ramendr/ramenctl/pkg/command"
 	"github.com/ramendr/ramenctl/pkg/console"
 	"github.com/ramendr/ramenctl/pkg/validate"
 )
@@ -19,7 +20,10 @@ var ValidateClustersCmd = &cobra.Command{
 	Use:   "clusters",
 	Short: "Detect problems in disaster recovery clusters",
 	Run: func(c *cobra.Command, args []string) {
-		if err := validate.Clusters(configFile, outputDir); err != nil {
+		if err := validate.Clusters(command.Options{
+			ConfigFile: configFile,
+			OutputDir:  outputDir,
+		}); err != nil {
 			console.Fatal(err)
 		}
 	},
@@ -29,7 +33,14 @@ var ValidateApplicationCmd = &cobra.Command{
 	Use:   "application",
 	Short: "Detect problems in disaster recovery protected application",
 	Run: func(c *cobra.Command, args []string) {
-		if err := validate.Application(configFile, outputDir, drpcName, drpcNamespace); err != nil {
+		if err := validate.Application(command.ApplicationOptions{
+			Options: command.Options{
+				ConfigFile: configFile,
+				OutputDir:  outputDir,
+			},
+			DRPCName:      drpcName,
+			DRPCNamespace: drpcNamespace,
+		}); err != nil {
 			console.Fatal(err)
 		}
 	},

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -46,15 +46,15 @@ type Command struct {
 func New(
 	commandName string,
 	clusters map[string]e2econfig.Cluster,
-	outputDir string,
+	opts Options,
 ) (*Command, error) {
 	// Create the logger first so we can log early command errors to the command log.
-	log, closeLog, err := newLogger(outputDir, commandName+".log")
+	log, closeLog, err := newLogger(opts.OutputDir, commandName+".log")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create logger: %w", err)
 	}
 
-	console.Info("Using report %q", outputDir)
+	console.Info("Using report %q", opts.OutputDir)
 
 	// Create the context before creating the env so we can cancel the command cleanly if accessing
 	// the clusters block for long time. The log will contain the cancellation error.
@@ -70,7 +70,7 @@ func New(
 
 	return &Command{
 		name:      commandName,
-		outputDir: outputDir,
+		outputDir: opts.OutputDir,
 		env:       env,
 		log:       log,
 		closeLog:  closeLog,

--- a/pkg/command/options.go
+++ b/pkg/command/options.go
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+// Options shared by all commands except init.
+type Options struct {
+	ConfigFile string
+	OutputDir  string
+}
+
+// ApplicationOptions shared by commands operating on a protected application.
+type ApplicationOptions struct {
+	Options
+	DRPCName      string
+	DRPCNamespace string
+}

--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -32,6 +32,9 @@ type Command struct {
 	// command is the generic command used by all ramenctl commands.
 	command *command.Command
 
+	// opts are the command options from the caller.
+	opts command.ApplicationOptions
+
 	// config is the config for this command.
 	config *config.Config
 
@@ -79,9 +82,15 @@ func (c *Command) dataDir() string {
 	return filepath.Join(c.command.OutputDir(), c.command.Name()+".data")
 }
 
-func newCommand(cmd *command.Command, cfg *config.Config, backend validation.Validation) *Command {
+func newCommand(
+	cmd *command.Command,
+	cfg *config.Config,
+	backend validation.Validation,
+	opts command.ApplicationOptions,
+) *Command {
 	return &Command{
 		command: cmd,
+		opts:    opts,
 		config:  cfg,
 		backend: backend,
 		context: cmd.Context(),
@@ -89,15 +98,15 @@ func newCommand(cmd *command.Command, cfg *config.Config, backend validation.Val
 	}
 }
 
-func (c *Command) Application(drpcName string, drpcNamespace string) error {
+func (c *Command) Run() error {
 	c.report.Application = &report.Application{
-		Name:      drpcName,
-		Namespace: drpcNamespace,
+		Name:      c.opts.DRPCName,
+		Namespace: c.opts.DRPCNamespace,
 	}
 	if !c.validateConfig() {
 		return c.failed()
 	}
-	if !c.gatherData(drpcName, drpcNamespace) {
+	if !c.gatherData() {
 		return c.failed()
 	}
 	c.passed()
@@ -117,11 +126,11 @@ func (c *Command) validateConfig() bool {
 	return true
 }
 
-func (c *Command) gatherData(drpcName string, drpcNamespace string) bool {
+func (c *Command) gatherData() bool {
 	console.Step("Gather application data")
 	c.startStep("gather data")
 
-	namespaces, ok := c.inspectApplication(drpcName, drpcNamespace)
+	namespaces, ok := c.inspectApplication()
 	if !ok {
 		return c.finishStep()
 	}
@@ -135,7 +144,7 @@ func (c *Command) gatherData(drpcName string, drpcNamespace string) bool {
 		return c.finishStep()
 	}
 
-	profiles, prefix, ok := c.inspectS3Profiles(drpcName, drpcNamespace)
+	profiles, prefix, ok := c.inspectS3Profiles()
 	if !ok {
 		return c.finishStep()
 	}
@@ -148,12 +157,12 @@ func (c *Command) gatherData(drpcName string, drpcNamespace string) bool {
 	return true
 }
 
-func (c *Command) inspectApplication(drpcName, drpcNamespace string) ([]string, bool) {
+func (c *Command) inspectApplication() ([]string, bool) {
 	start := time.Now()
 	step := &report.Step{Name: "inspect application"}
 	c.Logger().Infof("Step %q started", step.Name)
 
-	namespaces, err := c.namespacesToGather(drpcName, drpcNamespace)
+	namespaces, err := c.namespacesToGather()
 	if err != nil {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
@@ -207,15 +216,13 @@ func (c *Command) gatherApplication(options gathering.Options) bool {
 	return c.current.Status == report.Passed
 }
 
-func (c *Command) inspectS3Profiles(
-	drpcName, drpcNamespace string,
-) ([]*s3.Profile, string, bool) {
+func (c *Command) inspectS3Profiles() ([]*s3.Profile, string, bool) {
 	start := time.Now()
 	step := &report.Step{Name: "inspect S3 profiles"}
 
 	c.Logger().Infof("Step %q started", step.Name)
 
-	profiles, prefix, err := c.applicationS3Info(drpcName, drpcNamespace)
+	profiles, prefix, err := c.applicationS3Info()
 	if err != nil {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
@@ -296,14 +303,14 @@ func (c *Command) passed() {
 	console.Completed("Gather completed")
 }
 
-func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]string, error) {
+func (c *Command) namespacesToGather() ([]string, error) {
 	set := map[string]struct{}{
 		// Gather ramen namespaces to get ramen hub and dr-cluster logs and related resources.
 		c.config.Namespaces.RamenHubNamespace:       {},
 		c.config.Namespaces.RamenDRClusterNamespace: {},
 	}
 
-	appNamespaces, err := c.backend.ApplicationNamespaces(c, drpcName, drpcNamespace)
+	appNamespaces, err := c.backend.ApplicationNamespaces(c, c.opts.DRPCName, c.opts.DRPCNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -316,9 +323,7 @@ func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]s
 }
 
 // applicationS3Info reads S3 profiles and application prefix from gathered hub data.
-func (c *Command) applicationS3Info(
-	drpcName, drpcNamespace string,
-) ([]*s3.Profile, string, error) {
+func (c *Command) applicationS3Info() ([]*s3.Profile, string, error) {
 	// Read S3 profiles from the ramen hub configmap, the source of truth
 	// synced to managed clusters.
 	hub := c.Env().Hub
@@ -347,7 +352,7 @@ func (c *Command) applicationS3Info(
 		profiles = append(profiles, ramen.S3ProfileFromStore(sp, secret))
 	}
 
-	prefix, err := ramen.ApplicationS3Prefix(reader, drpcName, drpcNamespace)
+	prefix, err := ramen.ApplicationS3Prefix(reader, c.opts.DRPCName, c.opts.DRPCNamespace)
 	if err != nil {
 		return nil, "", err
 	}

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -71,7 +71,7 @@ var (
 func TestGatherApplicationPassed(t *testing.T) {
 	cmd := testCommand(t, &helpers.ValidationMock{})
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err != nil {
+	if err := cmd.Run(); err != nil {
 		t.Fatal(err)
 	}
 	checkReport(t, cmd.report, report.Passed)
@@ -97,7 +97,7 @@ func TestGatherApplicationPassed(t *testing.T) {
 
 func TestGatherApplicationValidateFailed(t *testing.T) {
 	cmd := testCommand(t, helpers.ValidateConfigFailed)
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -111,7 +111,7 @@ func TestGatherApplicationValidateFailed(t *testing.T) {
 
 func TestGatherApplicationValidateCanceled(t *testing.T) {
 	cmd := testCommand(t, helpers.ValidateConfigCanceled)
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
@@ -125,7 +125,7 @@ func TestGatherApplicationValidateCanceled(t *testing.T) {
 
 func TestGatherApplicationInspectFailed(t *testing.T) {
 	cmd := testCommand(t, helpers.InspectApplicationFailed)
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -145,7 +145,7 @@ func TestGatherApplicationInspectFailed(t *testing.T) {
 
 func TestGatherApplicationGatherClusterFailed(t *testing.T) {
 	cmd := testCommand(t, gatherClusterFailed)
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -178,7 +178,7 @@ func TestGatherApplicationNamespaces(t *testing.T) {
 
 	cmd := testCommand(t, mockBackend)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	err := cmd.Application(drpcName, drpcNamespace)
+	err := cmd.Run()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -191,7 +191,7 @@ func TestGatherApplicationNamespaces(t *testing.T) {
 
 func TestGatherApplicationInspectS3ProfilesFailed(t *testing.T) {
 	cmd := testCommand(t, &helpers.ValidationMock{})
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -216,7 +216,7 @@ func TestGatherApplicationInspectS3ProfilesFailed(t *testing.T) {
 func TestGatherApplicationInspectS3ProfilesCanceled(t *testing.T) {
 	cmd := testCommand(t, helpers.GetSecretCanceled)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
@@ -241,7 +241,7 @@ func TestGatherApplicationInspectS3ProfilesCanceled(t *testing.T) {
 func TestGatherApplicationGetSecretFailed(t *testing.T) {
 	cmd := testCommand(t, helpers.GetSecretFailed)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -270,7 +270,7 @@ func TestGatherApplicationGetSecretFailed(t *testing.T) {
 func TestGatherApplicationGetSecretInvalid(t *testing.T) {
 	cmd := testCommand(t, helpers.GetSecretInvalid)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -298,7 +298,7 @@ func TestGatherApplicationGetSecretInvalid(t *testing.T) {
 func TestGatherApplicationS3DataFailed(t *testing.T) {
 	cmd := testCommand(t, gatherS3Failed)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
@@ -325,7 +325,7 @@ func TestGatherApplicationS3DataFailed(t *testing.T) {
 func TestGatherApplicationS3DataCanceled(t *testing.T) {
 	cmd := testCommand(t, gatherS3Canceled)
 	helpers.AddGatheredData(t, cmd.dataDir(), applicationTestdata, "validate-application")
-	if err := cmd.Application(drpcName, drpcNamespace); err == nil {
+	if err := cmd.Run(); err == nil {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
@@ -359,7 +359,11 @@ func testCommand(t *testing.T, backend validation.Validation) *Command {
 	t.Cleanup(func() {
 		cmd.Close()
 	})
-	return newCommand(cmd, testConfig, backend)
+	opts := command.ApplicationOptions{
+		DRPCName:      drpcName,
+		DRPCNamespace: drpcNamespace,
+	}
+	return newCommand(cmd, testConfig, backend, opts)
 }
 
 func checkReport(t *testing.T, report *report.Report, status report.Status) {

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -11,18 +11,18 @@ import (
 	"github.com/ramendr/ramenctl/pkg/validation"
 )
 
-func Gather(configFile string, outputDir string, drpcName string, drpcNamespace string) error {
-	config, err := config.ReadConfig(configFile)
+func Gather(opts command.ApplicationOptions) error {
+	config, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
 		return fmt.Errorf("unable to read config: %w", err)
 	}
 
-	cmd, err := command.New("gather-application", config.Clusters, outputDir)
+	cmd, err := command.New("gather-application", config.Clusters, opts.Options)
 	if err != nil {
 		return err
 	}
 	defer cmd.Close()
 
 	gather := newCommand(cmd, config, validation.Backend{})
-	return gather.Application(drpcName, drpcNamespace)
+	return gather.Application(opts.DRPCName, opts.DRPCNamespace)
 }

--- a/pkg/gather/gather.go
+++ b/pkg/gather/gather.go
@@ -23,6 +23,6 @@ func Gather(opts command.ApplicationOptions) error {
 	}
 	defer cmd.Close()
 
-	gather := newCommand(cmd, config, validation.Backend{})
-	return gather.Application(opts.DRPCName, opts.DRPCNamespace)
+	gather := newCommand(cmd, config, validation.Backend{}, opts)
+	return gather.Run()
 }

--- a/pkg/test/clean.go
+++ b/pkg/test/clean.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
-func Clean(configFile string, outputDir string) error {
-	cfg, err := readConfig(configFile)
+func Clean(opts command.Options) error {
+	cfg, err := readConfig(opts.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	cmd, err := command.New("test-clean", cfg.Clusters, outputDir)
+	cmd, err := command.New("test-clean", cfg.Clusters, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/run.go
+++ b/pkg/test/run.go
@@ -8,13 +8,13 @@ import (
 	"github.com/ramendr/ramenctl/pkg/testing"
 )
 
-func Run(configFile string, outputDir string) error {
-	cfg, err := readConfig(configFile)
+func Run(opts command.Options) error {
+	cfg, err := readConfig(opts.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	cmd, err := command.New("test-run", cfg.Clusters, outputDir)
+	cmd, err := command.New("test-run", cfg.Clusters, opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -57,7 +57,11 @@ func testCommand(
 	t.Cleanup(func() {
 		cmd.Close()
 	})
-	return NewCommand(cmd, system.config, backend)
+	opts := basecmd.ApplicationOptions{
+		DRPCName:      drpcName,
+		DRPCNamespace: drpcNamespace,
+	}
+	return NewCommand(cmd, system.config, backend, opts)
 }
 
 func checkReport(t *testing.T, cmd *Command, status report.Status) {

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -36,13 +36,20 @@ const CommandName = "validate-application"
 
 type Command struct {
 	*validatecmd.Command
+	opts   basecmd.ApplicationOptions
 	Report *Report
 }
 
-func NewCommand(cmd *basecmd.Command, cfg *config.Config, backend validation.Validation) *Command {
+func NewCommand(
+	cmd *basecmd.Command,
+	cfg *config.Config,
+	backend validation.Validation,
+	opts basecmd.ApplicationOptions,
+) *Command {
 	r := NewReport(cfg)
 	return &Command{
 		Command: validatecmd.New(cmd, cfg, backend, r.Report),
+		opts:    opts,
 		Report:  r,
 	}
 }
@@ -57,24 +64,24 @@ func (c *Command) failed() error {
 	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
 }
 
-func (c *Command) Run(drpcName, drpcNamespace string) error {
-	c.Report.Application.Name = drpcName
-	c.Report.Application.Namespace = drpcNamespace
+func (c *Command) Run() error {
+	c.Report.Application.Name = c.opts.DRPCName
+	c.Report.Application.Namespace = c.opts.DRPCNamespace
 	if !c.ValidateConfig() {
 		return c.failed()
 	}
-	if !c.validateApplication(drpcName, drpcNamespace) {
+	if !c.validateApplication() {
 		return c.failed()
 	}
 	c.passed()
 	return nil
 }
 
-func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
+func (c *Command) validateApplication() bool {
 	console.Step("Validate application")
 	c.StartStep("validate application")
 
-	namespaces, ok := c.inspectApplication(drpcName, drpcNamespace)
+	namespaces, ok := c.inspectApplication()
 	if !ok {
 		return c.FinishStep()
 	}
@@ -89,11 +96,11 @@ func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
 		return c.FinishStep()
 	}
 
-	if !c.gatherS3Data(drpcName, drpcNamespace) {
+	if !c.gatherS3Data() {
 		return c.FinishStep()
 	}
 
-	if !c.validateGatheredData(drpcName, drpcNamespace) {
+	if !c.validateGatheredData() {
 		return c.FinishStep()
 	}
 
@@ -101,12 +108,12 @@ func (c *Command) validateApplication(drpcName, drpcNamespace string) bool {
 	return true
 }
 
-func (c *Command) inspectApplication(drpcName, drpcNamespace string) ([]string, bool) {
+func (c *Command) inspectApplication() ([]string, bool) {
 	start := time.Now()
 	step := &report.Step{Name: "inspect application"}
 	c.Logger().Infof("Step %q started", step.Name)
 
-	namespaces, err := c.namespacesToGather(drpcName, drpcNamespace)
+	namespaces, err := c.namespacesToGather()
 	if err != nil {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
@@ -135,23 +142,21 @@ func (c *Command) inspectApplication(drpcName, drpcNamespace string) ([]string, 
 // gatherS3Data inspects application S3 profiles and gathers data. It returns false only if the
 // user cancelled, otherwise true if there were errors during inspection, as those will be reported
 // in the validation results.
-func (c *Command) gatherS3Data(drpcName, drpcNamespace string) bool {
-	profiles, prefix, err := c.inspectS3Profiles(drpcName, drpcNamespace)
+func (c *Command) gatherS3Data() bool {
+	profiles, prefix, err := c.inspectS3Profiles()
 	if err != nil {
 		return !errors.Is(err, context.Canceled)
 	}
 	return c.gatherS3Profiles(profiles, prefix)
 }
 
-func (c *Command) inspectS3Profiles(
-	drpcName, drpcNamespace string,
-) ([]*s3.Profile, string, error) {
+func (c *Command) inspectS3Profiles() ([]*s3.Profile, string, error) {
 	start := time.Now()
 	step := &report.Step{Name: "inspect S3 profiles"}
 
 	c.Logger().Infof("Step %q started", step.Name)
 
-	profiles, prefix, err := c.s3Info(drpcName, drpcNamespace)
+	profiles, prefix, err := c.s3Info()
 	if err != nil {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
@@ -218,14 +223,14 @@ func (c *Command) gatherS3Profiles(profiles []*s3.Profile, prefix string) bool {
 	return c.Current.Status != report.Canceled
 }
 
-func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]string, error) {
+func (c *Command) namespacesToGather() ([]string, error) {
 	set := map[string]struct{}{
 		// Gather ramen namespaces to get ramen hub and dr-cluster logs and related resources.
 		c.Config().Namespaces.RamenHubNamespace:       {},
 		c.Config().Namespaces.RamenDRClusterNamespace: {},
 	}
 
-	appNamespaces, err := c.Backend.ApplicationNamespaces(c, drpcName, drpcNamespace)
+	appNamespaces, err := c.Backend.ApplicationNamespaces(c, c.opts.DRPCName, c.opts.DRPCNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -238,9 +243,7 @@ func (c *Command) namespacesToGather(drpcName string, drpcNamespace string) ([]s
 }
 
 // s3Info reads S3 profiles and application prefix from gathered hub data.
-func (c *Command) s3Info(
-	drpcName, drpcNamespace string,
-) ([]*s3.Profile, string, error) {
+func (c *Command) s3Info() ([]*s3.Profile, string, error) {
 	// Read S3 profiles from the ramen hub configmap, the source of truth
 	// synced to managed clusters.
 	hub := c.Env().Hub
@@ -269,7 +272,7 @@ func (c *Command) s3Info(
 		profiles = append(profiles, ramen.S3ProfileFromStore(sp, secret))
 	}
 
-	prefix, err := ramen.ApplicationS3Prefix(reader, drpcName, drpcNamespace)
+	prefix, err := ramen.ApplicationS3Prefix(reader, c.opts.DRPCName, c.opts.DRPCNamespace)
 	if err != nil {
 		return nil, "", err
 	}
@@ -277,7 +280,7 @@ func (c *Command) s3Info(
 	return profiles, prefix, nil
 }
 
-func (c *Command) validateGatheredData(drpcName, drpcNamespace string) bool {
+func (c *Command) validateGatheredData() bool {
 	log := c.Logger()
 
 	start := time.Now()
@@ -289,7 +292,7 @@ func (c *Command) validateGatheredData(drpcName, drpcNamespace string) bool {
 
 	s := &c.Report.ApplicationStatus
 
-	drpc, err := c.validateHub(&s.Hub, drpcName, drpcNamespace)
+	drpc, err := c.validateHub(&s.Hub)
 	if err != nil {
 		step.Status = report.Failed
 		msg := "Failed to validate hub"
@@ -331,11 +334,10 @@ func (c *Command) validateGatheredData(drpcName, drpcNamespace string) bool {
 
 func (c *Command) validateHub(
 	s *report.ApplicationStatusHub,
-	drpcName, drpcNamespace string,
 ) (*ramenapi.DRPlacementControl, error) {
 	log := c.Logger()
 	reader := c.OutputReader(c.Env().Hub.Name)
-	drpc, err := ramen.ReadDRPC(reader, drpcName, drpcNamespace)
+	drpc, err := ramen.ReadDRPC(reader, c.opts.DRPCName, c.opts.DRPCNamespace)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read drpc: %w", err)
 	}

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -87,7 +87,7 @@ var (
 func TestValidateApplicationPassed(t *testing.T) {
 	validate := testCommand(t, applicationMock, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err != nil {
+	if err := validate.Run(); err != nil {
 		dumpCommandLog(t, validate)
 		t.Fatal(err)
 	}
@@ -306,7 +306,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 
 func TestValidateApplicationValidateFailed(t *testing.T) {
 	validate := testCommand(t, helpers.ValidateConfigFailed, testK8s)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -323,7 +323,7 @@ func TestValidateApplicationValidateFailed(t *testing.T) {
 
 func TestValidateApplicationValidateCanceled(t *testing.T) {
 	validate := testCommand(t, helpers.ValidateConfigCanceled, testK8s)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -340,7 +340,7 @@ func TestValidateApplicationValidateCanceled(t *testing.T) {
 
 func TestValidateApplicationInspectApplicationFailed(t *testing.T) {
 	validate := testCommand(t, helpers.InspectApplicationFailed, testK8s)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -364,7 +364,7 @@ func TestValidateApplicationInspectApplicationFailed(t *testing.T) {
 
 func TestValidateApplicationInspectApplicationCanceled(t *testing.T) {
 	validate := testCommand(t, inspectApplicationCanceled, testK8s)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -388,7 +388,7 @@ func TestValidateApplicationInspectApplicationCanceled(t *testing.T) {
 
 func TestValidateApplicationGatherClusterFailed(t *testing.T) {
 	validate := testCommand(t, gatherDataFailed, testK8s)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -416,7 +416,7 @@ func TestValidateApplicationGatherClusterFailed(t *testing.T) {
 func TestValidateApplicationInspectS3ProfilesFailed(t *testing.T) {
 	validate := testCommand(t, applicationMock, testK8s)
 	// We don't add test data to cause inspect application s3 to fail.
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -446,7 +446,7 @@ func TestValidateApplicationInspectS3ProfilesFailed(t *testing.T) {
 func TestValidateApplicationInspectS3ProfilesCanceled(t *testing.T) {
 	validate := testCommand(t, inspectS3ProfilesCanceled, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -474,7 +474,7 @@ func TestValidateApplicationInspectS3ProfilesCanceled(t *testing.T) {
 func TestValidateApplicationGetSecretFailed(t *testing.T) {
 	validate := testCommand(t, getSecretFailed, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -507,7 +507,7 @@ func TestValidateApplicationGetSecretFailed(t *testing.T) {
 func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 	validate := testCommand(t, getSecretInvalid, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -540,7 +540,7 @@ func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 func TestValidateApplicationGatherS3Failed(t *testing.T) {
 	validate := testCommand(t, gatherS3Failed, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}
@@ -576,7 +576,7 @@ func TestValidateApplicationGatherS3Failed(t *testing.T) {
 func TestValidateApplicationGatherS3Canceled(t *testing.T) {
 	validate := testCommand(t, gatherS3Canceled, testK8s)
 	helpers.AddGatheredData(t, validate.DataDir(), applicationTestdata, validate.Report.Name)
-	if err := validate.Run(drpcName, drpcNamespace); err == nil {
+	if err := validate.Run(); err == nil {
 		dumpCommandLog(t, validate)
 		t.Fatal("command did not fail")
 	}

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -39,6 +39,6 @@ func Application(opts command.ApplicationOptions) error {
 	}
 	defer cmd.Close()
 
-	validate := application.NewCommand(cmd, cfg, validation.Backend{})
-	return validate.Run(opts.DRPCName, opts.DRPCNamespace)
+	validate := application.NewCommand(cmd, cfg, validation.Backend{}, opts)
+	return validate.Run()
 }

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -11,13 +11,13 @@ import (
 	"github.com/ramendr/ramenctl/pkg/validation"
 )
 
-func Clusters(configFile string, outputDir string) error {
-	cfg, err := config.ReadConfig(configFile)
+func Clusters(opts command.Options) error {
+	cfg, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	cmd, err := command.New(clusters.CommandName, cfg.Clusters, outputDir)
+	cmd, err := command.New(clusters.CommandName, cfg.Clusters, opts)
 	if err != nil {
 		return err
 	}
@@ -27,18 +27,18 @@ func Clusters(configFile string, outputDir string) error {
 	return validate.Run()
 }
 
-func Application(configFile, outputDir, drpcName, drpcNamespace string) error {
-	cfg, err := config.ReadConfig(configFile)
+func Application(opts command.ApplicationOptions) error {
+	cfg, err := config.ReadConfig(opts.ConfigFile)
 	if err != nil {
 		return err
 	}
 
-	cmd, err := command.New(application.CommandName, cfg.Clusters, outputDir)
+	cmd, err := command.New(application.CommandName, cfg.Clusters, opts.Options)
 	if err != nil {
 		return err
 	}
 	defer cmd.Close()
 
 	validate := application.NewCommand(cmd, cfg, validation.Backend{})
-	return validate.Run(drpcName, drpcNamespace)
+	return validate.Run(opts.DRPCName, opts.DRPCNamespace)
 }


### PR DESCRIPTION
Consolidate CLI options into structured Go types for better
maintainability and extensibility.

- Add `Options` (ConfigFile, OutputDir) and `ApplicationOptions`
  (embedding Options + DRPCName, DRPCNamespace) structs in
  `pkg/command/options.go`
- Update `command.New`, all pkg-level entry points, and cobra handlers
  to pass options structs instead of individual parameters
- Store `ApplicationOptions` in gather and validate application commands,
  eliminating threading of drpcName/drpcNamespace through internal
  methods that never use them
- Rename `gather.Application()` to `gather.Run()` for consistency

This lays the groundwork for adding new flags (e.g. `--interactive`,
`--dry-run`) without modifying function signatures throughout the call
chain.