### PR TITLE
s3: Report error when object downloads fail

### DIFF
--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -239,9 +239,8 @@ func (s *objectStore) downloadObjects(ctx context.Context, prefix, outputDir str
 	}
 
 	if len(keys) == 0 {
-		s.log.Warnf("No objects found in bucket %q with prefix %q",
+		return fmt.Errorf("no objects found in bucket %q for prefix %q",
 			s.profile.Bucket, prefix)
-		return nil
 	}
 
 	profileDir := filepath.Join(outputDir, dirName, s.profile.Name)
@@ -250,18 +249,23 @@ func (s *objectStore) downloadObjects(ctx context.Context, prefix, outputDir str
 			profileDir, prefix, err)
 	}
 
-	downloaded := 0
+	var failed int
 	for _, key := range keys {
 		if err := s.downloadObject(ctx, key, profileDir); err != nil {
 			s.log.Warnf("Failed to download object %q from bucket %q: %v",
 				key, s.profile.Bucket, err)
+			failed++
 			continue
 		}
-		downloaded++
 	}
 
-	s.log.Debugf("Downloaded %d/%d objects from bucket %q in %.3f seconds",
-		downloaded, len(keys), s.profile.Bucket, time.Since(start).Seconds())
+	if failed > 0 {
+		return fmt.Errorf("failed to download %d of %d objects from bucket %q",
+			failed, len(keys), s.profile.Bucket)
+	}
+
+	s.log.Debugf("Downloaded %d objects from bucket %q in %.3f seconds",
+		len(keys), s.profile.Bucket, time.Since(start).Seconds())
 
 	return nil
 }

--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -173,8 +173,10 @@ func checkBucket(
 		Bucket: aws.String(profile.Bucket),
 	})
 	if err != nil {
-		return fmt.Errorf("failed to access bucket %q for profile %q: %w",
+		log.Warnf("Failed to access bucket %q for profile %q: %v",
 			profile.Bucket, profile.Name, err)
+		return fmt.Errorf("failed to access bucket %q for profile %q",
+			profile.Bucket, profile.Name)
 	}
 
 	return nil
@@ -289,8 +291,10 @@ func (s *objectStore) listObjects(ctx context.Context, prefix string) ([]string,
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
-			return nil, fmt.Errorf("failed to list objects in bucket %q with prefix %q: %w",
+			s.log.Warnf("Failed to list objects in bucket %q with prefix %q: %v",
 				s.profile.Bucket, prefix, err)
+			return nil, fmt.Errorf("failed to list objects in bucket %q with prefix %q",
+				s.profile.Bucket, prefix)
 		}
 		for _, obj := range page.Contents {
 			keys = append(keys, *obj.Key)


### PR DESCRIPTION
When downloading objects from S3, individual download failures were logged as warnings but not returned as errors. This caused callers like validate-application to mark S3 profiles as "gathered: ok" when objects were listed and couldnt actually be downloaded.

Collect per-object download errors and return them when any downloads fail.

Fixes #425 