### PR TITLE
chore: add pre-commit hook to run make fmt and make lint (#429)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pre-commit hooks for ramenctl. Closes
+# https://github.com/RamenDR/ramenctl/issues/429.
+#
+# Mirrors the project's existing Make targets so a contributor's local
+# commit catches the same issues CI would otherwise catch on the PR:
+#
+#   - `make fmt`  → `golangci-lint fmt`  (run via the local-system hook)
+#   - `make lint` → `golangci-lint run ./...`
+#
+# One-time setup (per machine):
+#
+#   pip install pre-commit         # or: brew install pre-commit
+#
+# One-time setup (per clone):
+#
+#   pre-commit install
+#
+# Run all hooks against the whole tree:
+#
+#   pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+      - id: check-yaml
+      - id: check-json
+
+  # Use system-resolved hooks rather than vendored Go binaries so the
+  # exact same `golangci-lint` version that `make lint` uses runs at
+  # commit time. Contributors install golangci-lint per CONTRIBUTING.md
+  # (or via the `make` recipes).
+  - repo: local
+    hooks:
+      - id: make-fmt
+        name: make fmt (golangci-lint fmt)
+        description: Format Go sources with the project's golangci-lint config.
+        entry: make fmt
+        language: system
+        types_or: [go]
+        pass_filenames: false
+
+      - id: make-lint
+        name: make lint (golangci-lint run ./...)
+        description: Run the project's full linter suite.
+        entry: make lint
+        language: system
+        types_or: [go]
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,25 @@ easier to get your contribution accepted.
 1. Play with the *ramenctl* tool
 1. Open issues, create pull requests
 
+### Pre-commit hooks
+
+The repo ships a [`.pre-commit-config.yaml`](.pre-commit-config.yaml)
+that wires `make fmt` and `make lint` into a git pre-commit hook so
+CI never has to push you back for a missed format/lint pass. Setup
+is two one-time commands (per machine and per clone):
+
+```bash
+pip install pre-commit          # or: brew install pre-commit
+pre-commit install              # in this repo
+```
+
+The hook then runs automatically on every `git commit`. To run all
+hooks across the tree (useful right after cloning, or in CI), use:
+
+```bash
+pre-commit run --all-files
+```
+
 ## Contribution Flow
 
 This is a rough outline of what a contributor's workflow looks like:


### PR DESCRIPTION
Closes #429.

## Summary
CI was the only place \`make fmt\` and \`make lint\` ran, which made the round-trip for a missed format/lint pass a full GitHub Actions cycle. Both humans and AI agents forgot to run the local Make targets before committing.

## Change
Two files:

1. **\`.pre-commit-config.yaml\`** — wires the existing Make targets into a pre-commit hook:
   - `make fmt` → `golangci-lint fmt` (existing target, unchanged).
   - `make lint` → `golangci-lint run ./...` (existing target, unchanged).
   - Both use \`language: system\` local hooks so the same \`golangci-lint\` binary the contributor already installs (per CONTRIBUTING.md / \`make lint\`) is what runs at commit time. No separately-vendored Go binary to drift versions.
   - Plus a small set of file-hygiene hooks from \`pre-commit/pre-commit-hooks\` (trailing whitespace, final newline, mixed line endings, merge-conflict markers, accidental large binaries, basic YAML/JSON validation) — the issues that most often make it into PR diffs.

2. **\`CONTRIBUTING.md\`** — new \"Pre-commit hooks\" subsection under Getting Started showing the two one-time setup commands and the \`pre-commit run --all-files\` escape hatch.

## Test plan
- [x] `pre-commit run --all-files` succeeds locally on a clean checkout.
- [x] `make fmt` and `make lint` are unchanged — the hook calls them verbatim.
- [x] Hook invocation cost is bounded: \`pass_filenames: false\` means the Make targets see the whole tree (matching CI), not a per-file subset.

Signed-off per the project's DCO.