### PR TITLE
Support multiple command runs without overwriting previous output

### DIFF
--- a/pkg/command/browser.go
+++ b/pkg/command/browser.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 
 	"github.com/ramendr/ramenctl/pkg/console"
@@ -17,8 +16,7 @@ import (
 // BrowseReport opens the HTML report in the default browser. If the report cannot be opened, it
 // logs a notice suggesting to open the file manually to view the report.
 func (c *Command) BrowseReport() {
-	path := filepath.Join(c.outputDir, c.name+".html")
-
+	path := c.ReportFile("html")
 	if _, err := os.Stat(path); err != nil {
 		c.log.Warnf("Skipping browse %q: %s", path, err)
 		return

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -86,7 +86,7 @@ func ForTest(
 	env *types.Env,
 	outputDir string,
 ) (*Command, error) {
-	log, closeLog, err := newLogger(outputDir, logName(commandName))
+	log, closeLog, err := newLogger(outputDir, commandName+".log")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create logger: %w", err)
 	}
@@ -109,7 +109,7 @@ func (c *Command) OutputDir() string {
 }
 
 func (c *Command) LogFile() string {
-	return filepath.Join(c.outputDir, logName(c.name))
+	return filepath.Join(c.outputDir, c.name+".log")
 }
 
 func (c *Command) DataDir() string {
@@ -170,8 +170,4 @@ func (c *Command) WriteYAMLReport(r any) {
 	if err := file.Close(); err != nil {
 		console.Error("failed to close report file: %s", err)
 	}
-}
-
-func logName(commandName string) string {
-	return commandName + ".log"
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -26,6 +26,10 @@ type Command struct {
 	// name is the command name (e.g. "test-run")
 	name string
 
+	// suffix is empty for the first run. Subsequent runs of the same command use "-" + sequence
+	// number (e.g. -2).
+	suffix string
+
 	// outputDir contains the command log, summary, and gathered files.
 	outputDir string
 
@@ -48,8 +52,13 @@ func New(
 	clusters map[string]e2econfig.Cluster,
 	opts Options,
 ) (*Command, error) {
+	suffix, err := findNextSuffix(opts.OutputDir, commandName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find next suffix: %w", err)
+	}
+
 	// Create the logger first so we can log early command errors to the command log.
-	log, closeLog, err := newLogger(opts.OutputDir, commandName+".log")
+	log, closeLog, err := newLogger(opts.OutputDir, commandName+suffix+".log")
 	if err != nil {
 		return nil, fmt.Errorf("failed to create logger: %w", err)
 	}
@@ -70,6 +79,7 @@ func New(
 
 	return &Command{
 		name:      commandName,
+		suffix:    suffix,
 		outputDir: opts.OutputDir,
 		env:       env,
 		log:       log,
@@ -109,16 +119,16 @@ func (c *Command) OutputDir() string {
 }
 
 func (c *Command) LogFile() string {
-	return filepath.Join(c.outputDir, c.name+".log")
+	return filepath.Join(c.outputDir, c.name+c.suffix+".log")
 }
 
 func (c *Command) DataDir() string {
-	return filepath.Join(c.outputDir, c.name+".data")
+	return filepath.Join(c.outputDir, c.name+c.suffix+".data")
 }
 
 // ReportFile returns the path to a report file for the given format (e.g. "yaml", "html").
 func (c *Command) ReportFile(format string) string {
-	return filepath.Join(c.outputDir, c.name+"."+format)
+	return filepath.Join(c.outputDir, c.name+c.suffix+"."+format)
 }
 
 func (c *Command) Logger() *zap.SugaredLogger {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -112,6 +112,10 @@ func (c *Command) LogFile() string {
 	return filepath.Join(c.outputDir, logName(c.name))
 }
 
+func (c *Command) DataDir() string {
+	return filepath.Join(c.outputDir, c.name+".data")
+}
+
 func (c *Command) Logger() *zap.SugaredLogger {
 	return c.log
 }

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -116,6 +116,11 @@ func (c *Command) DataDir() string {
 	return filepath.Join(c.outputDir, c.name+".data")
 }
 
+// ReportFile returns the path to a report file for the given format (e.g. "yaml", "html").
+func (c *Command) ReportFile(format string) string {
+	return filepath.Join(c.outputDir, c.name+"."+format)
+}
+
 func (c *Command) Logger() *zap.SugaredLogger {
 	return c.log
 }
@@ -140,7 +145,7 @@ func (c *Command) Close() {
 
 // OpenReport opens a report file for writing in the specified format.
 func (c *Command) OpenReport(format string) (*os.File, error) {
-	path := filepath.Join(c.outputDir, c.name+"."+format)
+	path := c.ReportFile(format)
 	file, err := os.Create(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create report file %s: %w", path, err)

--- a/pkg/command/suffix.go
+++ b/pkg/command/suffix.go
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// findNextSuffix finds previous files for the same command and selects the next available suffix
+// to avoid overwriting previous command output.
+//
+// Notes:
+//   - We ignore unexpected files (e.g. validate-application-error.log) since they cannot clash with
+//     real output file (validate-application-2.log).
+//   - We check all files matching the command name, so partial output will be considered and we
+//     never overwrite an existing file.
+func findNextSuffix(outDir, commandName string) (string, error) {
+	// Glob for all files starting with commandName to handle multi-file output.
+	pattern := filepath.Join(outDir, commandName+"*.*")
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return "", err
+	}
+
+	// 0: No files, 1: Base file exists, N: Highest suffix found.
+	last := 0
+
+	for _, match := range matches {
+		fileName := filepath.Base(match)
+		if n := parseSequenceNumber(fileName, commandName); n > last {
+			last = n
+		}
+	}
+
+	// Result logic: 0 -> "", 1 -> "-2", N -> "-(N+1)".
+	if last > 0 {
+		return fmt.Sprintf("-%d", last+1), nil
+	}
+
+	return "", nil
+}
+
+// parseSequenceNumber extracts the sequence number from a filename based on the commandName.
+// It returns:
+//   - 1 for the base file (command-name.ext)
+//   - N for numbered files (command-name-N.ext)
+//   - 0 if the file does not follow the expected format and should be ignored.
+func parseSequenceNumber(fileName, commandName string) int {
+	base := strings.TrimSuffix(fileName, filepath.Ext(fileName))
+	suffix := strings.TrimPrefix(base, commandName)
+
+	// The first run does not have a suffix (command-name.log).
+	if suffix == "" {
+		return 1
+	}
+
+	// Must start with '-' and have at least one character after it.
+	if len(suffix) < 2 || suffix[0] != '-' {
+		return 0
+	}
+
+	// Try to parse the numeric part, ignoring invalid number.
+	n, err := strconv.Atoi(suffix[1:])
+	if err != nil {
+		return 0
+	}
+
+	return n
+}

--- a/pkg/command/suffix_test.go
+++ b/pkg/command/suffix_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: The RamenDR authors
+// SPDX-License-Identifier: Apache-2.0
+
+package command
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFindNextSuffix(t *testing.T) {
+	const commandName = "validate-clusters"
+
+	tests := []struct {
+		name   string
+		files  []string
+		suffix string
+	}{
+		{
+			name:   "missing output dir",
+			suffix: "",
+		},
+		{
+			name:   "empty output dir",
+			files:  []string{},
+			suffix: "",
+		},
+		{
+			name: "second run",
+			files: []string{
+				"validate-clusters.log",
+				"validate-clusters.yaml",
+				"validate-clusters.html",
+				"validate-clusters.data",
+			},
+			suffix: "-2",
+		},
+		{
+			name: "third run",
+			files: []string{
+				"validate-clusters.log",
+				"validate-clusters.yaml",
+				"validate-clusters.html",
+				"validate-clusters.data",
+				"validate-clusters-2.log",
+				"validate-clusters-2.yaml",
+				"validate-clusters-2.html",
+				"validate-clusters-2.data",
+			},
+			suffix: "-3",
+		},
+		{
+			name: "partial previous run",
+			files: []string{
+				"validate-clusters.log",
+			},
+			suffix: "-2",
+		},
+		{
+			name: "ignored files",
+			files: []string{
+				"validate-clusters.log",
+				"validate-clusters.yaml",
+				"validate-clusters.html",
+				"validate-clusters.data",
+				"validate-clusters.yaml.bak",
+				"validate-clusters-error.log",
+			},
+			suffix: "-2",
+		},
+		{
+			name: "gap in sequence numbers",
+			files: []string{
+				"validate-clusters.log",
+				"validate-clusters-3.log",
+			},
+			suffix: "-4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			outDir := createOutDir(t, tt.files)
+			suffix, err := findNextSuffix(outDir, commandName)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if suffix != tt.suffix {
+				t.Errorf("expected %q, got %q", tt.suffix, suffix)
+			}
+		})
+	}
+}
+
+// createOutDir creates an output directory with the given files. If files is nil, returns a
+// non-existent directory path.
+func createOutDir(t *testing.T, files []string) string {
+	outDir := t.TempDir()
+	if files == nil {
+		return filepath.Join(outDir, "missing")
+	}
+	for _, name := range files {
+		if err := os.WriteFile(filepath.Join(outDir, name), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return outDir
+}

--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -79,7 +79,7 @@ func (c *Command) outputReader(cluster string) gathering.OutputReader {
 }
 
 func (c *Command) dataDir() string {
-	return filepath.Join(c.command.OutputDir(), c.command.Name()+".data")
+	return c.command.DataDir()
 }
 
 func newCommand(

--- a/pkg/helpers/helpers.go
+++ b/pkg/helpers/helpers.go
@@ -55,6 +55,7 @@ func UnifiedDiff(t *testing.T, expected, actual any) string {
 // AddGatheredData adds fake gathered data to the output directory.
 // path is the directory containing the gathered data relative to the caller's package.
 func AddGatheredData(t *testing.T, dataDir, path, commandName string) {
+	// Test fixtures never use a suffix since tests always run with a clean output directory.
 	testData := filepath.Join(path, commandName+".data")
 	source, err := filepath.Abs(testData)
 	if err != nil {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -154,7 +154,7 @@ func (c *Command) outputReader(cluster string) gathering.OutputReader {
 }
 
 func (c *Command) dataDir() string {
-	return filepath.Join(c.command.OutputDir(), c.command.Name()+".data")
+	return c.command.DataDir()
 }
 
 func (c *Command) validate() bool {

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -128,10 +128,13 @@ func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 }
 
 func checkOutputFiles(t *testing.T, cmd *Command) {
-	for _, name := range []string{CommandName + ".yaml", CommandName + ".html", "style.css"} {
-		path := filepath.Join(cmd.OutputDir(), name)
+	for _, path := range []string{
+		cmd.ReportFile("yaml"),
+		cmd.ReportFile("html"),
+		filepath.Join(cmd.OutputDir(), "style.css"),
+	} {
 		if _, err := os.Stat(path); err != nil {
-			t.Errorf("output file %q not found: %s", name, err)
+			t.Errorf("output file %q not found: %s", path, err)
 		}
 	}
 }

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -145,10 +145,13 @@ func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 }
 
 func checkOutputFiles(t *testing.T, cmd *Command) {
-	for _, name := range []string{CommandName + ".yaml", CommandName + ".html", "style.css"} {
-		path := filepath.Join(cmd.OutputDir(), name)
+	for _, path := range []string{
+		cmd.ReportFile("yaml"),
+		cmd.ReportFile("html"),
+		filepath.Join(cmd.OutputDir(), "style.css"),
+	} {
 		if _, err := os.Stat(path); err != nil {
-			t.Errorf("output file %q not found: %s", name, err)
+			t.Errorf("output file %q not found: %s", path, err)
 		}
 	}
 }

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -188,7 +188,7 @@ func (c *Command) OutputDir() string {
 }
 
 func (c *Command) DataDir() string {
-	return filepath.Join(c.cmd.OutputDir(), c.cmd.Name()+".data")
+	return c.cmd.DataDir()
 }
 
 // WriteReport writes YAML, HTML, and CSS reports to the command output directory.

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -191,6 +191,10 @@ func (c *Command) DataDir() string {
 	return c.cmd.DataDir()
 }
 
+func (c *Command) ReportFile(format string) string {
+	return c.cmd.ReportFile(format)
+}
+
 // WriteReport writes YAML, HTML, and CSS reports to the command output directory.
 func (c *Command) WriteReport(r HTMLWriter) {
 	c.cmd.WriteYAMLReport(r)


### PR DESCRIPTION
Support running the same command multiple times with the same output directory
without overwriting previous output.

The second run appends `-2` to file names, the third `-3`, and so on:

    out/
      validate-clusters.log       # first run
      validate-clusters.yaml
      validate-clusters.html
      validate-clusters-2.log     # second run
      validate-clusters-2.yaml
      validate-clusters-2.html

Preparation commits centralize file path construction in the base command:

- **Add DataDir()** — replaces inline `OutputDir() + Name() + ".data"` in gather,
  test, and validate commands.
- **Add ReportFile()** — replaces inline `CommandName + ".yaml"` etc. in
  OpenReport(), BrowseReport(), and tests. This also fixes a latent bug where
  BrowseReport() would have opened the wrong report file after adding the suffix.
- **Inline logName()** — removes a helper that only concatenated `name + ".log"`,
  inconsistent with how all other file names were built.

The final commit adds the suffix field and findNextSuffix() which scans existing
files to pick the next sequence number. Partial output from crashed runs is
considered so we never overwrite an existing file.

## Example run

### Run 1 - ramen not installed

```console
% ramenctl validate clusters -o out/multi
⭐ Using config "config.yaml"
⭐ Using report "out/multi"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ❌ Failed to inspect S3 profiles
   ❌ Issues found during validation

❌ validation failed (0 ok, 0 stale, 12 problem)
```

<img width="1746" height="1119" alt="run1" src="https://github.com/user-attachments/assets/c2a38e28-479d-4c86-bf51-ae31e264ab24" />


### Run 2 - ramen not configured

```console
% ramenctl validate clusters -o out/multi
⭐ Using config "config.yaml"
⭐ Using report "out/multi"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ❌ Failed to inspect S3 profiles
   ❌ Issues found during validation

❌ validation failed (21 ok, 0 stale, 6 problem)
```

<img width="1790" height="1163" alt="rn2" src="https://github.com/user-attachments/assets/ec15e873-bc27-4dae-be84-0ed045eab8ef" />

### Run 3 - peer classes not found

```console
% ramenctl validate clusters -o out/multi
⭐ Using config "config.yaml"
⭐ Using report "out/multi"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr2"
   ✅ Checked S3 profile "minio-on-dr1"
   ❌ Issues found during validation

❌ validation failed (91 ok, 0 stale, 2 problem)
```

<img width="1790" height="1163" alt="rn3" src="https://github.com/user-attachments/assets/9f11b1cc-860d-4a45-8b24-cb5e75d41847" />

### Run 4 - ok

```console
% ramenctl validate clusters -o out/multi
⭐ Using config "config.yaml"
⭐ Using report "out/multi"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "minio-on-dr2"
   ✅ Checked S3 profile "minio-on-dr1"
   ✅ Clusters validated

✅ Validation completed (93 ok, 0 stale, 0 problem)
```

<img width="1790" height="1163" alt="run4" src="https://github.com/user-attachments/assets/e3b02db4-4f18-4f9a-b83d-db5e6d1d73dd" />

### Output directory

```console
% tree -L1 out/multi
out/multi
├── style.css
├── validate-clusters-2.data
├── validate-clusters-2.html
├── validate-clusters-2.log
├── validate-clusters-2.yaml
├── validate-clusters-3.data
├── validate-clusters-3.html
├── validate-clusters-3.log
├── validate-clusters-3.yaml
├── validate-clusters-4.data
├── validate-clusters-4.html
├── validate-clusters-4.log
├── validate-clusters-4.yaml
├── validate-clusters.data
├── validate-clusters.html
├── validate-clusters.log
└── validate-clusters.yaml
```

[out-multi.tar.gz](https://github.com/user-attachments/files/27250236/out-multi.tar.gz)


---

Fixes #154