### PR TITLE
Improve HTML report structure for nested content and lists

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,7 +4,6 @@
 version: "2"
 linters:
   enable:
-    - goconst
     - gocritic
     - gosec
     - misspell

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -230,15 +230,15 @@ header footer {
  *   key ... value
  *
  * dl.validation - key/value pairs with state icon,
- * optional description, and optional nested dl:
+ * optional description, and nested dl (dd.nested):
  *
  *   key ... value text .............................. icon
  *           optional description
  *
- *   key ... nested key ... value .................... icon
- *
- *       ... nested key ... value .................... icon
- *                          optional description
+ *   key
+ *       nested key ... value ........................ icon
+ *       nested key ... value ........................ icon
+ *                      optional description
  */
 
 dl.metadata,
@@ -272,6 +272,12 @@ dl.validation dd {
     margin: 0;
     min-width: 0;
     font-weight: 600;
+}
+
+dl.validation > dd.nested {
+    grid-column: 1 / -1;
+    /* Match section section padding-left. */
+    padding-left: 12px;
 }
 
 .value {

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -290,11 +290,18 @@ dl.validation > dd.nested {
     font-size: 0.85em;
 }
 
-.pvc {
+.main-grid ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.main-grid li {
     background: #f9fafb;
     border-left: 3px solid #d1d5db;
     border-radius: 4px;
     margin: 8px 0;
+    padding-left: 12px;
 }
 
 .description {

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -31,7 +31,7 @@ h6 {
 
 .main-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(540px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(37em, 1fr));
     gap: 12px;
     background: #e8e8e8;
     padding: 12px;
@@ -71,7 +71,7 @@ section section > h6 {
 
 .details-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(540px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(37em, 1fr));
     gap: 12px;
     background: #e8e8e8;
     padding: 12px;

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -106,11 +106,6 @@ func (v *Validated) MaxLen() int {
 	return 32
 }
 
-// MaxLen returns the maximum display length for fingerprint truncation.
-func (v *ValidatedFingerprint) MaxLen() int {
-	return 16
-}
-
 func (v *ValidatedDRClustersList) Equal(o *ValidatedDRClustersList) bool {
 	if v == o {
 		return true

--- a/pkg/validate/application/templates/vrg.tmpl
+++ b/pkg/validate/application/templates/vrg.tmpl
@@ -22,11 +22,11 @@
 {{- with .ProtectedPVCs}}
 <section>
     <h5>Protected PVCs</h5>
-    {{- range .}}
-    <section class="pvc">
-        {{template "pvc" .}}
-    </section>
-    {{- end}}
+    <ul>
+        {{- range .}}
+        <li>{{template "pvc" .}}</li>
+        {{- end}}
+    </ul>
 </section>
 {{- end}}
 {{- end}}

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -79,29 +79,31 @@
               </section>
               <section>
                 <h5>Protected PVCs</h5>
-                <section class="pvc">
-                  <dl class="metadata">
-                    <dt>Name</dt>
-                    <dd>busybox-pvc</dd>
-                    <dt>Namespace</dt>
-                    <dd>test-appset-deploy-rbd</dd>
-                    <dt>Replication</dt>
-                    <dd>volrep</dd>
-                  </dl>
-                  <dl class="validation">
-                    <dt>Phase</dt>
-                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                  </dl>
-                  <section>
-                    <h6>Conditions</h6>
-                    <dl class="validation">
-                      <dt>DataReady</dt>
-                      <dd><span class="state">✅</span></dd>
-                      <dt>ClusterDataProtected</dt>
-                      <dd><span class="state">✅</span></dd>
+                <ul>
+                  <li>
+                    <dl class="metadata">
+                      <dt>Name</dt>
+                      <dd>busybox-pvc</dd>
+                      <dt>Namespace</dt>
+                      <dd>test-appset-deploy-rbd</dd>
+                      <dt>Replication</dt>
+                      <dd>volrep</dd>
                     </dl>
-                  </section>
-                </section>
+                    <dl class="validation">
+                      <dt>Phase</dt>
+                      <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                    </dl>
+                    <section>
+                      <h6>Conditions</h6>
+                      <dl class="validation">
+                        <dt>DataReady</dt>
+                        <dd><span class="state">✅</span></dd>
+                        <dt>ClusterDataProtected</dt>
+                        <dd><span class="state">✅</span></dd>
+                      </dl>
+                    </section>
+                  </li>
+                </ul>
               </section>
             </section>
           </section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -88,29 +88,31 @@
               </section>
               <section>
                 <h5>Protected PVCs</h5>
-                <section class="pvc">
-                  <dl class="metadata">
-                    <dt>Name</dt>
-                    <dd>busybox-pvc</dd>
-                    <dt>Namespace</dt>
-                    <dd>test-appset-deploy-rbd</dd>
-                    <dt>Replication</dt>
-                    <dd>volrep</dd>
-                  </dl>
-                  <dl class="validation">
-                    <dt>Phase</dt>
-                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                  </dl>
-                  <section>
-                    <h6>Conditions</h6>
-                    <dl class="validation">
-                      <dt>DataReady</dt>
-                      <dd><span class="state">✅</span></dd>
-                      <dt>ClusterDataProtected</dt>
-                      <dd><span class="state">✅</span></dd>
+                <ul>
+                  <li>
+                    <dl class="metadata">
+                      <dt>Name</dt>
+                      <dd>busybox-pvc</dd>
+                      <dt>Namespace</dt>
+                      <dd>test-appset-deploy-rbd</dd>
+                      <dt>Replication</dt>
+                      <dd>volrep</dd>
                     </dl>
-                  </section>
-                </section>
+                    <dl class="validation">
+                      <dt>Phase</dt>
+                      <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                    </dl>
+                    <section>
+                      <h6>Conditions</h6>
+                      <dl class="validation">
+                        <dt>DataReady</dt>
+                        <dd><span class="state">✅</span></dd>
+                        <dt>ClusterDataProtected</dt>
+                        <dd><span class="state">✅</span></dd>
+                      </dl>
+                    </section>
+                  </li>
+                </ul>
               </section>
             </section>
           </section>
@@ -145,40 +147,42 @@
               </section>
               <section>
                 <h5>Protected PVCs</h5>
-                <section class="pvc">
-                  <dl class="metadata">
-                    <dt>Name</dt>
-                    <dd>busybox-pvc</dd>
-                    <dt>Namespace</dt>
-                    <dd>test-appset-deploy-rbd</dd>
-                    <dt>Replication</dt>
-                    <dd>volrep</dd>
-                  </dl>
-                  <dl class="validation">
-                    <dt>Phase</dt>
-                    <dd><span class="value">Bound</span><span class="state">✅</span></dd>
-                    <dt>Deleted</dt>
-                    <dd>
-                      <span class="value">true</span><span class="state">❌</span>
-                      <p class="description">Resource was deleted</p>
-                    </dd>
-                  </dl>
-                  <section>
-                    <h6>Conditions</h6>
+                <ul>
+                  <li>
+                    <dl class="metadata">
+                      <dt>Name</dt>
+                      <dd>busybox-pvc</dd>
+                      <dt>Namespace</dt>
+                      <dd>test-appset-deploy-rbd</dd>
+                      <dt>Replication</dt>
+                      <dd>volrep</dd>
+                    </dl>
                     <dl class="validation">
-                      <dt>DataReady</dt>
+                      <dt>Phase</dt>
+                      <dd><span class="value">Bound</span><span class="state">✅</span></dd>
+                      <dt>Deleted</dt>
                       <dd>
-                        <span class="state">❌</span>
-                        <p class="description">failed to demote volume</p>
-                      </dd>
-                      <dt>ClusterDataProtected</dt>
-                      <dd>
-                        <span class="state">⭕</span>
-                        <p class="description">Observed generation 1 does not match object generation 2</p>
+                        <span class="value">true</span><span class="state">❌</span>
+                        <p class="description">Resource was deleted</p>
                       </dd>
                     </dl>
-                  </section>
-                </section>
+                    <section>
+                      <h6>Conditions</h6>
+                      <dl class="validation">
+                        <dt>DataReady</dt>
+                        <dd>
+                          <span class="state">❌</span>
+                          <p class="description">failed to demote volume</p>
+                        </dd>
+                        <dt>ClusterDataProtected</dt>
+                        <dd>
+                          <span class="state">⭕</span>
+                          <p class="description">Observed generation 1 does not match object generation 2</p>
+                        </dd>
+                      </dl>
+                    </section>
+                  </li>
+                </ul>
               </section>
             </section>
           </section>

--- a/pkg/validate/clusters/templates/drpolicies.tmpl
+++ b/pkg/validate/clusters/templates/drpolicies.tmpl
@@ -21,30 +21,35 @@
         <dd>{{range $i, $c := .DRClusters}}{{if $i}}, {{end}}{{$c}}{{end}}</dd>
     </dl>
     {{- with .PeerClasses}}
-    <dl class="validation">
-        <dt>Peer Classes</dt>
-        <dd>
-            <span class="value">{{len .Value}}</span>
-            <span class="state">{{icon .State}}</span>
-            {{- if .Description}}
-                <p class="description">{{.Description}}</p>
-            {{- end}}
-            <ul>
-                {{- range .Value}}
-                <li>
-                    <dl class="metadata">
-                        <dt>Storage Class</dt>
-                        <dd>{{.StorageClassName}}</dd>
-                        {{- if .ReplicationID}}
-                            <dt>Replication ID</dt>
-                            <dd>{{.ReplicationID}}</dd>
-                        {{- end}}
-                    </dl>
-                </li>
+    <section>
+        <h6>Peer Classes</h6>
+        <dl class="validation">
+            <dt>Classes</dt>
+            <dd>
+                <span class="value">{{len .Value}}</span>
+                <span class="state">{{icon .State}}</span>
+                {{- if .Description}}
+                    <p class="description">{{.Description}}</p>
                 {{- end}}
-            </ul>
-        </dd>
-    </dl>
+            </dd>
+        </dl>
+        {{- with .Value}}
+        <ul>
+            {{- range .}}
+            <li>
+                <dl class="metadata">
+                    <dt>Storage Class</dt>
+                    <dd>{{.StorageClassName}}</dd>
+                    {{- if .ReplicationID}}
+                        <dt>Replication ID</dt>
+                        <dd>{{.ReplicationID}}</dd>
+                    {{- end}}
+                </dl>
+            </li>
+            {{- end}}
+        </ul>
+        {{- end}}
+    </section>
     {{- end}}
     <section>
         <h6>Conditions</h6>

--- a/pkg/validate/clusters/templates/s3profile.tmpl
+++ b/pkg/validate/clusters/templates/s3profile.tmpl
@@ -13,7 +13,7 @@
         <dt>CA Certificate</dt>
         <dd>{{template "validated" .CACertificate}}</dd>
         <dt>Secret</dt>
-        <dd>
+        <dd class="nested">
             <dl class="validation">
                 <dt>Name</dt>
                 <dd>{{template "validated" .S3SecretRef.Name}}</dd>

--- a/pkg/validate/clusters/testdata/invalid-configmap.html
+++ b/pkg/validate/clusters/testdata/invalid-configmap.html
@@ -74,13 +74,13 @@
                   <dt>DRClusters</dt>
                   <dd></dd>
                 </dl>
-                <dl class="validation">
-                  <dt>Peer Classes</dt>
-                  <dd>
-                    <span class="value">0</span><span class="state"></span>
-                    <ul></ul>
-                  </dd>
-                </dl>
+                <section>
+                  <h6>Peer Classes</h6>
+                  <dl class="validation">
+                    <dt>Classes</dt>
+                    <dd><span class="value">0</span><span class="state"></span></dd>
+                  </dl>
+                </section>
                 <section>
                   <h6>Conditions</h6>
                   <dl class="validation">

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -70,7 +70,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
@@ -78,12 +78,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>
@@ -102,7 +102,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
@@ -110,12 +110,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>
@@ -307,7 +307,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
@@ -315,12 +315,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>
@@ -339,7 +339,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
@@ -347,12 +347,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>
@@ -418,7 +418,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr1</span><span class="state">✅</span></dd>
@@ -426,12 +426,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>
@@ -450,7 +450,7 @@
                       <dt>CA Certificate</dt>
                       <dd><span class="value"></span><span class="state">✅</span></dd>
                       <dt>Secret</dt>
-                      <dd>
+                      <dd class="nested">
                         <dl class="validation">
                           <dt>Name</dt>
                           <dd><span class="value">ramen-s3-secret-dr2</span><span class="state">✅</span></dd>
@@ -458,12 +458,12 @@
                           <dd><span class="value">ramen-system</span><span class="state">✅</span></dd>
                           <dt>Key ID</dt>
                           <dd>
-                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:4...</span>
+                            <span class="value" title="57:91:B6:22:67:43:C5:6F:44:F8:27:4C:C6:7B:8B:EB:97:51:B6:40:3E:69:72:43:AD:00:FD:37:AF:56:35:E3">57:91:B6:22:67:43:C5:6F:44:F8:27...</span>
                             <span class="state">✅</span>
                           </dd>
                           <dt>Access Key</dt>
                           <dd>
-                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:2...</span>
+                            <span class="value" title="17:9C:07:6A:C5:22:15:9D:BB:D5:0D:4F:1D:84:FA:F0:55:51:FE:5B:59:D7:E5:82:4A:80:0D:46:55:9F:B1:D1">17:9C:07:6A:C5:22:15:9D:BB:D5:0D...</span>
                             <span class="state">✅</span>
                           </dd>
                         </dl>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -139,28 +139,29 @@
                   <dt>DRClusters</dt>
                   <dd>dr1, dr2</dd>
                 </dl>
-                <dl class="validation">
-                  <dt>Peer Classes</dt>
-                  <dd>
-                    <span class="value">2</span><span class="state">✅</span>
-                    <ul>
-                      <li>
-                        <dl class="metadata">
-                          <dt>Storage Class</dt>
-                          <dd>rook-ceph-block</dd>
-                          <dt>Replication ID</dt>
-                          <dd>rook-ceph-replication-1</dd>
-                        </dl>
-                      </li>
-                      <li>
-                        <dl class="metadata">
-                          <dt>Storage Class</dt>
-                          <dd>rook-cephfs-fs1</dd>
-                        </dl>
-                      </li>
-                    </ul>
-                  </dd>
-                </dl>
+                <section>
+                  <h6>Peer Classes</h6>
+                  <dl class="validation">
+                    <dt>Classes</dt>
+                    <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  </dl>
+                  <ul>
+                    <li>
+                      <dl class="metadata">
+                        <dt>Storage Class</dt>
+                        <dd>rook-ceph-block</dd>
+                        <dt>Replication ID</dt>
+                        <dd>rook-ceph-replication-1</dd>
+                      </dl>
+                    </li>
+                    <li>
+                      <dl class="metadata">
+                        <dt>Storage Class</dt>
+                        <dd>rook-cephfs-fs1</dd>
+                      </dl>
+                    </li>
+                  </ul>
+                </section>
                 <section>
                   <h6>Conditions</h6>
                   <dl class="validation">
@@ -177,28 +178,29 @@
                   <dt>DRClusters</dt>
                   <dd>dr1, dr2</dd>
                 </dl>
-                <dl class="validation">
-                  <dt>Peer Classes</dt>
-                  <dd>
-                    <span class="value">2</span><span class="state">✅</span>
-                    <ul>
-                      <li>
-                        <dl class="metadata">
-                          <dt>Storage Class</dt>
-                          <dd>rook-ceph-block</dd>
-                          <dt>Replication ID</dt>
-                          <dd>rook-ceph-replication-1</dd>
-                        </dl>
-                      </li>
-                      <li>
-                        <dl class="metadata">
-                          <dt>Storage Class</dt>
-                          <dd>rook-cephfs-fs1</dd>
-                        </dl>
-                      </li>
-                    </ul>
-                  </dd>
-                </dl>
+                <section>
+                  <h6>Peer Classes</h6>
+                  <dl class="validation">
+                    <dt>Classes</dt>
+                    <dd><span class="value">2</span><span class="state">✅</span></dd>
+                  </dl>
+                  <ul>
+                    <li>
+                      <dl class="metadata">
+                        <dt>Storage Class</dt>
+                        <dd>rook-ceph-block</dd>
+                        <dt>Replication ID</dt>
+                        <dd>rook-ceph-replication-1</dd>
+                      </dl>
+                    </li>
+                    <li>
+                      <dl class="metadata">
+                        <dt>Storage Class</dt>
+                        <dd>rook-cephfs-fs1</dd>
+                      </dl>
+                    </li>
+                  </ul>
+                </section>
                 <section>
                   <h6>Conditions</h6>
                   <dl class="validation">


### PR DESCRIPTION
Fix the HTML structure and visual rendering of nested definition lists
and item lists in the HTML report.

## Changes

1. **Disable goconst linter**: After upgrading golangci-lint, goconst
   reports 50 issues — mostly test values that are more readable as
   inline literals. Kubernetes does not use goconst either.
   Related: #388

1. **Fix extreme indentation of nested dl**: Add `dd.nested`
   CSS class to span the full grid width, so nested dl elements (e.g.
   S3 secret info) render with proper indentation instead of being
   squeezed into the value column. Remove the extra-aggressive
   fingerprint truncation that was a workaround for the indentation.

1. **Use semantic list markup for protected PVCs**: Replace
   `<section>` elements with `<ul><li>` for correct HTML semantics.
   Adapt CSS with `.main-grid ul` and `.main-grid li` selectors to
   preserve the card visual style.

1. **Use section with heading for peer classes**: Render peer
   classes as a `<section>` with `<h6>` heading, matching the pattern
   used by S3 Store Profiles and Conditions. The list items get full
   section width instead of being constrained to the grid value column.

1. **Use relative units for grid column minimum width**: Change from
   540px to 37em so the layout scales with font size. Users with a
   larger base font no longer get columns too narrow for the content.

## Example validate clusters - before

<img width="650" height="778" alt="before" src="https://github.com/user-attachments/assets/c8de0569-a1e5-4be4-bc5a-eec102d2adf0" />

## Example validate clusters - after

<img width="648" height="855" alt="after" src="https://github.com/user-attachments/assets/b82f747d-6bf3-441a-8ab8-8a2ced571981" />

---
Fixes #432 
Fixes #433