### PR TITLE
Add pre-commit target and sample git hooks

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -21,9 +21,9 @@ alwaysApply: true
 
 ## After making code changes
 
-- Run `make fmt` to format code with golangci-lint formatters
+- Run `make pre-commit` to format code and check lint and spelling errors
 - Use package tests for quick iteration: `go test ./pkg/foo/...`
-- Before committing, run `make lint` and `make test` to catch issues early
+- Before committing, run `make test` to catch issues early
 
 ## File organization
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ This is a rough outline of what a contributor's workflow looks like:
 1. Make sure your commit messages are in the proper format (see below).
 1. Push your changes to the branch in your fork of the repository.
 1. Make sure all tests pass, and add any new tests as appropriate.
+1. Run `make pre-commit` to format code and check lint and spelling errors.
 1. Create a pull request in the original repository.
 
 ## Commit message

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,3 +94,10 @@ To format the code automatically before committing a change run:
 ```console
 make fmt
 ```
+
+## Git configuration
+
+The `tools/git` directory contains git hooks that you may want to install. See
+the hook documentation for more info:
+- pre-commit - automatically run `make pre-commit`
+- commit-msg - automatically add Signed-off-by footer

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ build := github.com/ramendr/ramenctl/pkg/build
 ldflags := -X '$(build).Version=$(version)' \
 		   -X '$(build).Commit=$(commit)'
 
-.PHONY: ramenctl examples test clean coverage lint fmt htmlfmt
+.PHONY: ramenctl examples test clean coverage pre-commit lint fmt htmlfmt
 
 all: ramenctl examples
 
@@ -25,6 +25,8 @@ ramenctl:
 
 examples:
 	$(GO) build -o examples/odf examples/odf.go
+
+pre-commit: fmt htmlfmt spell lint
 
 fmt:
 	golangci-lint fmt

--- a/tools/git/commit-msg
+++ b/tools/git/commit-msg
@@ -1,0 +1,6 @@
+#!/bin/sh
+#
+# Copy to .git/hooks/ to automatically add Signed-off-by trailer.
+
+sob=$(git var GIT_AUTHOR_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+git interpret-trailers --in-place --trailer "$sob" "$1"

--- a/tools/git/pre-commit
+++ b/tools/git/pre-commit
@@ -1,0 +1,5 @@
+#!/bin/sh
+#
+# Copy to .git/hooks/ to run pre-commit check automatically.
+
+make pre-commit


### PR DESCRIPTION
Developers typically forget to format, spell, and lint before commit,
and find the issues in CI. Fixing issues before commit avoids CI
failures and painful rebase.

## Changes

1. **Add `make pre-commit` target**: runs `fmt`, `htmlfmt`, `spell`,
   and `lint` in one command.

2. **Add sample git hooks** in `tools/git/`:
   - `pre-commit` - runs `make pre-commit` automatically
   - `commit-msg` - adds Signed-off-by trailer

   Developers can copy these to `.git/hooks/` to opt in.

3. **Update CONTRIBUTING.md and project rules** to reference the
   new workflow.

Fixes #429 