### PR TITLE
report: Decrease nested steps indent to match other sections

### DIFF
--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -123,7 +123,7 @@ section section > h6 {
 .steps ul {
     list-style: none;
     padding: 0;
-    padding-left: 32px;
+    padding-left: 12px;
     margin-right: -8px;
     flex-basis: 100%;
 }


### PR DESCRIPTION
The nested steps indent (32px) was inconsistent with the 12px indent used for nested sections and other indented content in the report.

## Before

<img width="679" height="334" alt="Screenshot 2026-05-06 at 15 12 05" src="https://github.com/user-attachments/assets/d3780031-f9b5-484d-bb39-395ae27c250b" />

## After

<img width="679" height="334" alt="Screenshot 2026-05-06 at 15 11 28" src="https://github.com/user-attachments/assets/a5910c9c-9c09-4753-8cb0-037b0c0ee4c9" />
