### PR TITLE
Validate replication freshness

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/aws/smithy-go v1.24.2
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/go-logr/zapr v1.3.0
-	github.com/nirs/kubectl-gather v0.12.0
+	github.com/nirs/kubectl-gather v0.13.0
 	github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30
 	github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -197,8 +197,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nirs/kubectl-gather v0.12.0 h1:jRCbo8n3uTHobBz5R4B+KdPYD+XP1JRNccjTTyzNG/c=
-github.com/nirs/kubectl-gather v0.12.0/go.mod h1:m1P+K5iDF2t2tLDigXHOeTzfvIVpXHLddxLbH+dd2+E=
+github.com/nirs/kubectl-gather v0.13.0 h1:Gldom4SSb74CELtBHDYTA5SWAOm6w0/IJZ+z0SitFPg=
+github.com/nirs/kubectl-gather v0.13.0/go.mod h1:FbyZguoDTZFY9OAib74tBFw2jlOzlzh1m7JjgEwQ2Rs=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -277,6 +277,12 @@ func ReadDRPolicy(reader gathering.OutputReader, name string) (*ramenapi.DRPolic
 	return drPolicy, nil
 }
 
+// ParseSchedulingInterval parses a scheduling interval string (e.g. "5m")
+// into a time.Duration.
+func ParseSchedulingInterval(interval string) (time.Duration, error) {
+	return time.ParseDuration(interval)
+}
+
 // ReadDRCluster reads a ramen DRCluster from the output directory.
 func ReadDRCluster(reader gathering.OutputReader, name string) (*ramenapi.DRCluster, error) {
 	resource := ramenapi.GroupVersion.Group + "/" + drClusterPlural

--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	e2etypes "github.com/ramendr/ramen/e2e/types"
@@ -72,6 +73,9 @@ const (
 )
 
 const (
+	// Annotation added by kubectl-gather with the API server time when the resource was gathered.
+	clusterTimeAnnotation = "kubectl-gather.nirs.github.com/cluster-time"
+
 	// Annotation for application namespace on the managed cluster
 	// from ramen/internal/controllers/drplacementcontrol.go
 	drpcAppNamespaceAnnotation = "drplacementcontrol.ramendr.openshift.io/app-namespace"
@@ -156,6 +160,27 @@ func ApplicationNamespaces(drpc *ramenapi.DRPlacementControl) []string {
 
 func VRGNamespace(drpc *ramenapi.DRPlacementControl) string {
 	return drpc.Annotations[drpcAppNamespaceAnnotation]
+}
+
+// ClusterTime returns the API server time when the resource was gathered,
+// from the annotation added by the gathering tool.
+func ClusterTime(annotations map[string]string) (*time.Time, error) {
+	value := annotations[clusterTimeAnnotation]
+	if value == "" {
+		return nil, fmt.Errorf("annotation %q is missing", clusterTimeAnnotation)
+	}
+
+	t, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"invalid annotation %q value %q: %w",
+			clusterTimeAnnotation,
+			value,
+			err,
+		)
+	}
+
+	return &t, nil
 }
 
 // PrimaryCluster returns the desired cluster for the application. During failover or relocate it

--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -40,6 +40,7 @@ type DRPCSummary struct {
 	Deleted            ValidatedBool        `json:"deleted"`
 	DRPolicy           string               `json:"drPolicy"`
 	SchedulingInterval ValidatedDuration    `json:"schedulingInterval"`
+	LastGroupSyncTime  ValidatedTime        `json:"lastGroupSyncTime"`
 	Action             ValidatedString      `json:"action"`
 	Phase              ValidatedString      `json:"phase"`
 	Progression        ValidatedString      `json:"progression"`
@@ -53,6 +54,7 @@ type VRGSummary struct {
 	ClusterTime        *time.Time            `json:"clusterTime,omitempty"`
 	Deleted            ValidatedBool         `json:"deleted"`
 	SchedulingInterval ValidatedDuration     `json:"schedulingInterval"`
+	LastGroupSyncTime  ValidatedTime         `json:"lastGroupSyncTime"`
 	State              ValidatedString       `json:"state"`
 	Conditions         []ValidatedCondition  `json:"conditions,omitempty"`
 	ProtectedPVCs      []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
@@ -169,6 +171,9 @@ func (d *DRPCSummary) Equal(o *DRPCSummary) bool {
 	if d.SchedulingInterval != o.SchedulingInterval {
 		return false
 	}
+	if !d.LastGroupSyncTime.Equal(&o.LastGroupSyncTime) {
+		return false
+	}
 	if d.Action != o.Action {
 		return false
 	}
@@ -208,6 +213,9 @@ func (v *VRGSummary) Equal(o *VRGSummary) bool {
 		return false
 	}
 	if v.SchedulingInterval != o.SchedulingInterval {
+		return false
+	}
+	if !v.LastGroupSyncTime.Equal(&o.LastGroupSyncTime) {
 		return false
 	}
 	if v.State != o.State {

--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -34,27 +34,29 @@ type PVCGroupsSummary struct {
 
 // DRPCSummary is the summary of a DRPC.
 type DRPCSummary struct {
-	Name        string               `json:"name"`
-	Namespace   string               `json:"namespace"`
-	ClusterTime *time.Time           `json:"clusterTime,omitempty"`
-	Deleted     ValidatedBool        `json:"deleted"`
-	DRPolicy    string               `json:"drPolicy"`
-	Action      ValidatedString      `json:"action"`
-	Phase       ValidatedString      `json:"phase"`
-	Progression ValidatedString      `json:"progression"`
-	Conditions  []ValidatedCondition `json:"conditions,omitempty"`
+	Name               string               `json:"name"`
+	Namespace          string               `json:"namespace"`
+	ClusterTime        *time.Time           `json:"clusterTime,omitempty"`
+	Deleted            ValidatedBool        `json:"deleted"`
+	DRPolicy           string               `json:"drPolicy"`
+	SchedulingInterval ValidatedDuration    `json:"schedulingInterval"`
+	Action             ValidatedString      `json:"action"`
+	Phase              ValidatedString      `json:"phase"`
+	Progression        ValidatedString      `json:"progression"`
+	Conditions         []ValidatedCondition `json:"conditions,omitempty"`
 }
 
 // VRGSummary is the summary of a VRG.
 type VRGSummary struct {
-	Name          string                `json:"name"`
-	Namespace     string                `json:"namespace"`
-	ClusterTime   *time.Time            `json:"clusterTime,omitempty"`
-	Deleted       ValidatedBool         `json:"deleted"`
-	State         ValidatedString       `json:"state"`
-	Conditions    []ValidatedCondition  `json:"conditions,omitempty"`
-	ProtectedPVCs []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
-	PVCGroups     []PVCGroupsSummary    `json:"pvcGroups,omitempty"`
+	Name               string                `json:"name"`
+	Namespace          string                `json:"namespace"`
+	ClusterTime        *time.Time            `json:"clusterTime,omitempty"`
+	Deleted            ValidatedBool         `json:"deleted"`
+	SchedulingInterval ValidatedDuration     `json:"schedulingInterval"`
+	State              ValidatedString       `json:"state"`
+	Conditions         []ValidatedCondition  `json:"conditions,omitempty"`
+	ProtectedPVCs      []ProtectedPVCSummary `json:"protectedPVCs,omitempty"`
+	PVCGroups          []PVCGroupsSummary    `json:"pvcGroups,omitempty"`
 }
 
 // ApplicationHubStaus is the application status on the hub.
@@ -164,6 +166,9 @@ func (d *DRPCSummary) Equal(o *DRPCSummary) bool {
 	if d.DRPolicy != o.DRPolicy {
 		return false
 	}
+	if d.SchedulingInterval != o.SchedulingInterval {
+		return false
+	}
 	if d.Action != o.Action {
 		return false
 	}
@@ -200,6 +205,9 @@ func (v *VRGSummary) Equal(o *VRGSummary) bool {
 		return false
 	}
 	if v.Deleted != o.Deleted {
+		return false
+	}
+	if v.SchedulingInterval != o.SchedulingInterval {
 		return false
 	}
 	if v.State != o.State {

--- a/pkg/report/application.go
+++ b/pkg/report/application.go
@@ -5,6 +5,8 @@ package report
 
 import (
 	"slices"
+
+	"github.com/ramendr/ramenctl/pkg/time"
 )
 
 type ReplicationType string
@@ -34,6 +36,7 @@ type PVCGroupsSummary struct {
 type DRPCSummary struct {
 	Name        string               `json:"name"`
 	Namespace   string               `json:"namespace"`
+	ClusterTime *time.Time           `json:"clusterTime,omitempty"`
 	Deleted     ValidatedBool        `json:"deleted"`
 	DRPolicy    string               `json:"drPolicy"`
 	Action      ValidatedString      `json:"action"`
@@ -46,6 +49,7 @@ type DRPCSummary struct {
 type VRGSummary struct {
 	Name          string                `json:"name"`
 	Namespace     string                `json:"namespace"`
+	ClusterTime   *time.Time            `json:"clusterTime,omitempty"`
 	Deleted       ValidatedBool         `json:"deleted"`
 	State         ValidatedString       `json:"state"`
 	Conditions    []ValidatedCondition  `json:"conditions,omitempty"`
@@ -147,6 +151,13 @@ func (d *DRPCSummary) Equal(o *DRPCSummary) bool {
 	if d.Namespace != o.Namespace {
 		return false
 	}
+	if d.ClusterTime != nil && o.ClusterTime != nil {
+		if !d.ClusterTime.Equal(*o.ClusterTime) {
+			return false
+		}
+	} else if d.ClusterTime != o.ClusterTime {
+		return false
+	}
 	if d.Deleted != o.Deleted {
 		return false
 	}
@@ -179,6 +190,13 @@ func (v *VRGSummary) Equal(o *VRGSummary) bool {
 		return false
 	}
 	if v.Namespace != o.Namespace {
+		return false
+	}
+	if v.ClusterTime != nil && o.ClusterTime != nil {
+		if !v.ClusterTime.Equal(*o.ClusterTime) {
+			return false
+		}
+	} else if v.ClusterTime != o.ClusterTime {
 		return false
 	}
 	if v.Deleted != o.Deleted {

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -5,6 +5,7 @@ package report_test
 
 import (
 	"testing"
+	stdtime "time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,6 +78,16 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2.Hub.DRPC.DRPolicy = helpers.Modified
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("hub drpc schedulingInterval", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.Hub.DRPC.SchedulingInterval = report.ValidatedDuration{
+			Validated: report.Validated{
+				State: report.OK,
+			},
+			Value: 2 * stdtime.Minute,
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("hub drpc phase", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.Hub.DRPC.Phase = report.ValidatedString{
@@ -127,6 +138,16 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2 := testApplicationStatus()
 		modified := time.Now().Add(-1)
 		a2.PrimaryCluster.VRG.ClusterTime = &modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg schedulingInterval", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.PrimaryCluster.VRG.SchedulingInterval = report.ValidatedDuration{
+			Validated: report.Validated{
+				State: report.OK,
+			},
+			Value: 2 * stdtime.Minute,
+		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("primary cluster vrg deleted", func(t *testing.T) {
@@ -244,6 +265,16 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2.SecondaryCluster.VRG.ClusterTime = &modified
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("secondary cluster vrg schedulingInterval", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		a2.SecondaryCluster.VRG.SchedulingInterval = report.ValidatedDuration{
+			Validated: report.Validated{
+				State: report.OK,
+			},
+			Value: 2 * stdtime.Minute,
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("secondary cluster vrg deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.SecondaryCluster.VRG.Deleted = report.ValidatedBool{
@@ -341,6 +372,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 					},
 				},
 				DRPolicy: "dr-policy-1m",
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
+				},
 				Action: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -390,6 +427,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 					Validated: report.Validated{
 						State: report.OK,
 					},
+				},
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
@@ -490,6 +533,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 					Validated: report.Validated{
 						State: report.OK,
 					},
+				},
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/report"
+	"github.com/ramendr/ramenctl/pkg/time"
 )
 
 func TestReportApplicationStatusEqual(t *testing.T) {
+	helpers.FakeTime(t)
 	a1 := testApplicationStatus()
 	t.Run("equal to self", func(t *testing.T) {
 		a2 := a1
@@ -27,6 +29,7 @@ func TestReportApplicationStatusEqual(t *testing.T) {
 }
 
 func TestReportApplicationStatusNotEqual(t *testing.T) {
+	helpers.FakeTime(t)
 	a1 := testApplicationStatus()
 	t.Run("not equal to nil", func(t *testing.T) {
 		var a2 *report.ApplicationStatus
@@ -40,6 +43,12 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	t.Run("hub drpc namespace", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.Hub.DRPC.Namespace = helpers.Modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("hub drpc clusterTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		modified := time.Now().Add(-1)
+		a2.Hub.DRPC.ClusterTime = &modified
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("hub drpc deleted", func(t *testing.T) {
@@ -112,6 +121,12 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	t.Run("primary cluster vrg namespace", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.PrimaryCluster.VRG.Namespace = helpers.Modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg clusterTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		modified := time.Now().Add(-1)
+		a2.PrimaryCluster.VRG.ClusterTime = &modified
 		checkApplicationsNotEqual(t, a1, a2)
 	})
 	t.Run("primary cluster vrg deleted", func(t *testing.T) {
@@ -223,6 +238,12 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		a2.SecondaryCluster.VRG.Namespace = helpers.Modified
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("secondary cluster vrg clusterTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		modified := time.Now().Add(-1)
+		a2.SecondaryCluster.VRG.ClusterTime = &modified
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("secondary cluster vrg deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.SecondaryCluster.VRG.Deleted = report.ValidatedBool{
@@ -293,6 +314,7 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 }
 
 func TestReportApplicationStatusMarshaling(t *testing.T) {
+	helpers.FakeTime(t)
 	a1 := testApplicationStatus()
 	data, err := yaml.Marshal(a1)
 	if err != nil {
@@ -306,11 +328,13 @@ func TestReportApplicationStatusMarshaling(t *testing.T) {
 }
 
 func testApplicationStatus() *report.ApplicationStatus {
+	now := time.Now()
 	a := &report.ApplicationStatus{
 		Hub: report.ApplicationStatusHub{
 			DRPC: report.DRPCSummary{
-				Name:      "drpc-name",
-				Namespace: "drpc-namespace",
+				Name:        "drpc-name",
+				Namespace:   "drpc-namespace",
+				ClusterTime: &now,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,
@@ -359,8 +383,9 @@ func testApplicationStatus() *report.ApplicationStatus {
 		PrimaryCluster: report.ApplicationStatusCluster{
 			Name: "dr1",
 			VRG: report.VRGSummary{
-				Name:      "vrg-name",
-				Namespace: "vrg-namespace",
+				Name:        "vrg-name",
+				Namespace:   "vrg-namespace",
+				ClusterTime: &now,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,
@@ -458,8 +483,9 @@ func testApplicationStatus() *report.ApplicationStatus {
 		SecondaryCluster: report.ApplicationStatusCluster{
 			Name: "dr2",
 			VRG: report.VRGSummary{
-				Name:      "vrg-name",
-				Namespace: "vrg-namespace",
+				Name:        "vrg-name",
+				Namespace:   "vrg-namespace",
+				ClusterTime: &now,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -88,6 +88,18 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("hub drpc lastGroupSyncTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		a2.Hub.DRPC.LastGroupSyncTime = report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Replication is stale",
+			},
+			Value: &staleTime,
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("hub drpc phase", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.Hub.DRPC.Phase = report.ValidatedString{
@@ -147,6 +159,18 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 				State: report.OK,
 			},
 			Value: 2 * stdtime.Minute,
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
+	t.Run("primary cluster vrg lastGroupSyncTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		a2.PrimaryCluster.VRG.LastGroupSyncTime = report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Replication is stale",
+			},
+			Value: &staleTime,
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
@@ -275,6 +299,18 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
+	t.Run("secondary cluster vrg lastGroupSyncTime", func(t *testing.T) {
+		a2 := testApplicationStatus()
+		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		a2.SecondaryCluster.VRG.LastGroupSyncTime = report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Replication is stale",
+			},
+			Value: &staleTime,
+		}
+		checkApplicationsNotEqual(t, a1, a2)
+	})
 	t.Run("secondary cluster vrg deleted", func(t *testing.T) {
 		a2 := testApplicationStatus()
 		a2.SecondaryCluster.VRG.Deleted = report.ValidatedBool{
@@ -378,6 +414,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 					},
 					Value: stdtime.Minute,
 				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: &now,
+				},
 				Action: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -433,6 +475,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						State: report.OK,
 					},
 					Value: stdtime.Minute,
+				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: &now,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
@@ -539,6 +587,12 @@ func testApplicationStatus() *report.ApplicationStatus {
 						State: report.OK,
 					},
 					Value: stdtime.Minute,
+				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: &now,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -75,8 +75,14 @@ func isTruncated(v any, n int) bool {
 	return len(fmt.Sprint(v)) > n
 }
 
-// formatTime formats a time value for display in reports.
-func formatTime(t time.Time) string {
+// formatTime formats a time value for display in reports using RFC3339,
+// matching the format used in Kubernetes resources. Returns an empty
+// string for nil values.
+func formatTime(t *time.Time) string {
+	if t == nil {
+		return ""
+	}
+
 	return t.Format("2006-01-02 15:04:05 -0700")
 }
 

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -9,6 +9,7 @@ import (
 	"html/template"
 	"os"
 	"path/filepath"
+	stdtime "time"
 
 	"github.com/yosssi/gohtml"
 	"sigs.k8s.io/yaml"
@@ -83,7 +84,7 @@ func formatTime(t *time.Time) string {
 		return ""
 	}
 
-	return t.Format("2006-01-02 15:04:05 -0700")
+	return t.Format(stdtime.RFC3339)
 }
 
 // formatDuration formats a duration in seconds for display.

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -44,13 +44,13 @@ type Step struct {
 
 // Base report for ramenctl commands report.
 type Base struct {
-	Host     Host      `json:"host"`
-	Build    *Build    `json:"build,omitempty"`
-	Created  time.Time `json:"created"`
-	Name     string    `json:"name"`
-	Status   Status    `json:"status,omitempty"`
-	Duration float64   `json:"duration,omitempty"`
-	Steps    []*Step   `json:"steps"`
+	Host     Host       `json:"host"`
+	Build    *Build     `json:"build,omitempty"`
+	Created  *time.Time `json:"created"`
+	Name     string     `json:"name"`
+	Status   Status     `json:"status,omitempty"`
+	Duration float64    `json:"duration,omitempty"`
+	Steps    []*Step    `json:"steps"`
 
 	// Summary is set by `validate` and `test` commands.
 	Summary *Summary `json:"summary,omitempty"`
@@ -76,6 +76,8 @@ type Report struct {
 
 // NewBase create a new base report for ramenctl commands reports.
 func NewBase(commandName string) *Base {
+	// time value without monotonic clock reading
+	created := time.Now().Local()
 	r := &Base{
 		Name: commandName,
 		Host: Host{
@@ -83,8 +85,7 @@ func NewBase(commandName string) *Base {
 			Arch: runtime.GOARCH,
 			Cpus: runtime.NumCPU(),
 		},
-		// time value without monotonic clock reading
-		Created: time.Now().Local(),
+		Created: &created,
 	}
 	if build.Version != "" || build.Commit != "" {
 		r.Build = &Build{
@@ -106,7 +107,11 @@ func (r *Base) Equal(o *Base) bool {
 	if r.Host != o.Host {
 		return false
 	}
-	if !r.Created.Equal(o.Created) {
+	if r.Created != nil && o.Created != nil {
+		if !r.Created.Equal(*o.Created) {
+			return false
+		}
+	} else if r.Created != o.Created {
 		return false
 	}
 	if r.Build != nil && o.Build != nil {

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -66,8 +66,8 @@ func TestBuildInfo(t *testing.T) {
 func TestBaseCreatedTime(t *testing.T) {
 	helpers.FakeTime(t)
 	r := report.NewBase("name")
-	if r.Created != time.Now().Local() {
-		t.Fatalf("expected %v, got %v", time.Now().Local(), r.Created)
+	if !r.Created.Equal(time.Now().Local()) {
+		t.Fatalf("expected %v, got %v", time.Now().Local(), *r.Created)
 	}
 }
 
@@ -113,7 +113,8 @@ func TestBaseNotEqual(t *testing.T) {
 	})
 	t.Run("created", func(t *testing.T) {
 		r2 := report.NewBase("name")
-		r2.Created = r2.Created.Add(1)
+		modified := r2.Created.Add(1)
+		r2.Created = &modified
 		if r1.Equal(r2) {
 			t.Fatal("reports with different create time should not be equal")
 		}

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -88,6 +88,35 @@ func (d *ValidatedDuration) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// ValidatedTime is a validated object time property.
+// Value is a pointer to properly omit zero values in JSON/YAML.
+type ValidatedTime struct {
+	Validated
+	Value *time.Time `json:"value,omitempty"`
+}
+
+func (t *ValidatedTime) Equal(o *ValidatedTime) bool {
+	if t == o {
+		return true
+	}
+	if o == nil {
+		return false
+	}
+	if t.Validated != o.Validated {
+		return false
+	}
+
+	if t.Value != nil && o.Value != nil {
+		if !t.Value.Equal(*o.Value) {
+			return false
+		}
+	} else if t.Value != o.Value {
+		return false
+	}
+
+	return true
+}
+
 // ValidatedCondition is a validated condition.
 type ValidatedCondition struct {
 	Validated

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -4,7 +4,9 @@
 package report
 
 import (
+	"encoding/json"
 	"slices"
+	"time"
 )
 
 type ValidationState string
@@ -47,6 +49,43 @@ type ValidatedBool struct {
 type ValidatedInteger struct {
 	Validated
 	Value int64 `json:"value"`
+}
+
+// ValidatedDuration is a validated object duration property.
+// Value marshals as a duration string (e.g. "1m0s") instead of nanoseconds.
+type ValidatedDuration struct {
+	Validated
+	Value time.Duration `json:"value,omitempty"`
+}
+
+func (d ValidatedDuration) MarshalJSON() ([]byte, error) {
+	var value string
+	if d.Value != 0 {
+		value = d.Value.String()
+	}
+
+	return json.Marshal(ValidatedString{Validated: d.Validated, Value: value})
+}
+
+func (d *ValidatedDuration) UnmarshalJSON(data []byte) error {
+	var s ValidatedString
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+
+	d.Validated = s.Validated
+	d.Value = 0
+
+	if s.Value != "" {
+		duration, err := time.ParseDuration(s.Value)
+		if err != nil {
+			return err
+		}
+
+		d.Value = duration
+	}
+
+	return nil
 }
 
 // ValidatedCondition is a validated condition.

--- a/pkg/report/validation_test.go
+++ b/pkg/report/validation_test.go
@@ -6,9 +6,11 @@ package report_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
+	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/report"
 )
 
@@ -36,6 +38,61 @@ func TestEmojiRoundtrip(t *testing.T) {
 			}
 			if v1 != v2 {
 				t.Fatalf("expected %+v, got %+v", v1, v2)
+			}
+		})
+	}
+}
+
+func TestValidatedDurationRoundtrip(t *testing.T) {
+	cases := []struct {
+		name     string
+		original report.ValidatedDuration
+		yaml     string
+	}{
+		{
+			name: "ok",
+			original: report.ValidatedDuration{
+				Validated: report.Validated{State: report.OK},
+				Value:     5 * time.Minute,
+			},
+			yaml: "state: ok ✅\nvalue: 5m0s\n",
+		},
+		{
+			name: "problem",
+			original: report.ValidatedDuration{
+				Validated: report.Validated{
+					State:       report.Problem,
+					Description: "Invalid scheduling interval",
+				},
+			},
+			yaml: "description: Invalid scheduling interval\nstate: problem ❌\n",
+		},
+		{
+			name: "zero value",
+			original: report.ValidatedDuration{
+				Validated: report.Validated{State: report.OK},
+			},
+			yaml: "state: ok ✅\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := yaml.Marshal(&tc.original)
+			if err != nil {
+				t.Fatalf("failed to marshal: %v", err)
+			}
+
+			if string(data) != tc.yaml {
+				t.Fatalf("unexpected yaml\n%s", helpers.UnifiedDiff(t, tc.yaml, string(data)))
+			}
+
+			var decoded report.ValidatedDuration
+			if err := yaml.Unmarshal(data, &decoded); err != nil {
+				t.Fatalf("failed to unmarshal: %v", err)
+			}
+
+			if decoded != tc.original {
+				t.Fatalf("roundtrip mismatch\n%s", helpers.UnifiedDiff(t, tc.original, decoded))
 			}
 		})
 	}

--- a/pkg/testdata/appset-deploy-rbd/validate-application.data/dr1/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
+++ b/pkg/testdata/appset-deploy-rbd/validate-application.data/dr1/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
@@ -6,6 +6,7 @@ metadata:
     drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: ""
     drplacementcontrol.ramendr.openshift.io/drpc-uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
     drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: ""
+    kubectl-gather.nirs.github.com/cluster-time: "2025-07-29T17:24:30Z"
   creationTimestamp: "2025-07-27T20:41:31Z"
   finalizers:
   - volumereplicationgroups.ramendr.openshift.io/vrg-protection

--- a/pkg/testdata/appset-deploy-rbd/validate-application.data/dr2/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
+++ b/pkg/testdata/appset-deploy-rbd/validate-application.data/dr2/namespaces/e2e-appset-deploy-rbd/ramendr.openshift.io/volumereplicationgroups/appset-deploy-rbd.yaml
@@ -6,6 +6,7 @@ metadata:
     drplacementcontrol.ramendr.openshift.io/do-not-delete-pvc: ""
     drplacementcontrol.ramendr.openshift.io/drpc-uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
     drplacementcontrol.ramendr.openshift.io/use-volsync-for-pvc-protection: ""
+    kubectl-gather.nirs.github.com/cluster-time: "2025-07-29T17:24:30Z"
   creationTimestamp: "2025-07-27T20:42:01Z"
   finalizers:
   - volumereplicationgroups.ramendr.openshift.io/vrg-protection

--- a/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/cluster/ramendr.openshift.io/drpolicies/dr-policy-1m.yaml
+++ b/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/cluster/ramendr.openshift.io/drpolicies/dr-policy-1m.yaml
@@ -1,0 +1,95 @@
+apiVersion: ramendr.openshift.io/v1alpha1
+kind: DRPolicy
+metadata:
+  annotations:
+    kubectl.kubernetes.io/last-applied-configuration: |
+      {"apiVersion":"ramendr.openshift.io/v1alpha1","kind":"DRPolicy","metadata":{"annotations":{},"name":"dr-policy-1m"},"spec":{"drClusters":["dr1","dr2"],"replicationClassSelector":{},"schedulingInterval":"1m","volumeSnapshotClassSelector":{}}}
+  creationTimestamp: "2025-08-11T09:46:45Z"
+  finalizers:
+  - drpolicies.ramendr.openshift.io/ramen
+  generation: 2
+  labels:
+    cluster.open-cluster-management.io/backup: ramen
+  managedFields:
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:annotations:
+          .: {}
+          f:kubectl.kubernetes.io/last-applied-configuration: {}
+      f:spec:
+        .: {}
+        f:drClusters: {}
+        f:replicationClassSelector: {}
+        f:schedulingInterval: {}
+        f:volumeSnapshotClassSelector: {}
+    manager: kubectl-client-side-apply
+    operation: Update
+    time: "2025-08-11T09:46:45Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:metadata:
+        f:finalizers:
+          .: {}
+          v:"drpolicies.ramendr.openshift.io/ramen": {}
+        f:labels:
+          .: {}
+          f:cluster.open-cluster-management.io/backup: {}
+      f:spec:
+        f:volumeGroupSnapshotClassSelector: {}
+    manager: manager
+    operation: Update
+    time: "2025-08-11T09:46:46Z"
+  - apiVersion: ramendr.openshift.io/v1alpha1
+    fieldsType: FieldsV1
+    fieldsV1:
+      f:status:
+        .: {}
+        f:async:
+          .: {}
+          f:peerClasses: {}
+        f:conditions: {}
+        f:sync: {}
+    manager: manager
+    operation: Update
+    subresource: status
+    time: "2025-08-11T09:46:47Z"
+  name: dr-policy-1m
+  resourceVersion: "3715"
+  uid: 5d3eb64d-fbdd-451a-93da-412bd243b51d
+spec:
+  drClusters:
+  - dr1
+  - dr2
+  replicationClassSelector: {}
+  schedulingInterval: 1m
+  volumeGroupSnapshotClassSelector: {}
+  volumeSnapshotClassSelector: {}
+status:
+  async:
+    peerClasses:
+    - clusterIDs:
+      - b9382f56-e681-400f-89fa-50b85fd15279
+      - 628066a2-b863-4aed-9d06-84f35ecef1af
+      replicationID: rook-ceph-replication-1
+      storageClassName: rook-ceph-block
+      storageID:
+      - rook-ceph-block-dr1-1
+      - rook-ceph-block-dr2-1
+    - clusterIDs:
+      - b9382f56-e681-400f-89fa-50b85fd15279
+      - 628066a2-b863-4aed-9d06-84f35ecef1af
+      storageClassName: rook-cephfs-fs1
+      storageID:
+      - rook-cephfs-fs1-dr1-1
+      - rook-cephfs-fs1-dr2-1
+  conditions:
+  - lastTransitionTime: "2025-08-11T09:46:46Z"
+    message: drpolicy validated
+    observedGeneration: 2
+    reason: Succeeded
+    status: "True"
+    type: Validated
+  sync: {}

--- a/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
+++ b/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
@@ -95,7 +95,7 @@ metadata:
   uid: 8283cb24-39a9-4ccd-b028-3807cdfed996
 spec:
   drPolicyRef:
-    name: dr-policy
+    name: dr-policy-1m
   placementRef:
     kind: Placement
     name: appset-deploy-rbd

--- a/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
+++ b/pkg/testdata/appset-deploy-rbd/validate-application.data/hub/namespaces/argocd/ramendr.openshift.io/drplacementcontrols/appset-deploy-rbd.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     drplacementcontrol.ramendr.openshift.io/app-namespace: e2e-appset-deploy-rbd
     drplacementcontrol.ramendr.openshift.io/last-app-deployment-cluster: dr1
+    kubectl-gather.nirs.github.com/cluster-time: "2025-07-29T17:24:30Z"
   creationTimestamp: "2025-07-27T20:41:31Z"
   finalizers:
   - drpc.ramendr.openshift.io/finalizer

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	stdtime "time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	e2etypes "github.com/ramendr/ramen/e2e/types"
@@ -437,6 +438,7 @@ func (c *Command) validateDRPC(
 
 	s.Deleted = c.ValidatedDeleted(drpc)
 	s.DRPolicy = drpc.Spec.DRPolicyRef.Name
+	s.SchedulingInterval = c.validatedDRPCSchedulingInterval(drpc)
 	s.Action = c.validatedDRPCAction(string(drpc.Spec.Action))
 	s.Phase = c.validatedDRPCPhase(drpc)
 	s.Progression = c.validatedDRPCProgression(drpc)
@@ -477,6 +479,10 @@ func (c *Command) validateVRG(
 	}
 
 	s.Deleted = c.ValidatedDeleted(vrg)
+	s.SchedulingInterval = c.validatedVRGSchedulingInterval(
+		vrg,
+		&c.Report.ApplicationStatus.Hub.DRPC,
+	)
 	s.Conditions = c.validatedVRGConditions(vrg)
 	s.ProtectedPVCs = c.validatedProtectedPVCs(cluster, vrg)
 	s.PVCGroups = c.pvcGroups(vrg)
@@ -575,6 +581,83 @@ func (c *Command) validatedDRPCAction(action string) report.ValidatedString {
 		validated.Description = fmt.Sprintf("Unknown action %q", action)
 	}
 	summary.AddValidation(c.Report.Summary, &validated)
+	return validated
+}
+
+func (c *Command) validatedDRPCSchedulingInterval(
+	drpc *ramenapi.DRPlacementControl,
+) report.ValidatedDuration {
+	log := c.Logger()
+	reader := c.OutputReader(c.Env().Hub.Name)
+
+	drPolicy, err := ramen.ReadDRPolicy(reader, drpc.Spec.DRPolicyRef.Name)
+	if err != nil {
+		log.Warnf("Failed to read drpolicy %q: %s", drpc.Spec.DRPolicyRef.Name, err)
+
+		return c.validatedSchedulingInterval(0,
+			fmt.Sprintf("Could not read drpolicy %q", drpc.Spec.DRPolicyRef.Name))
+	}
+
+	if drPolicy.Spec.SchedulingInterval == "" {
+		return c.validatedSchedulingInterval(0,
+			fmt.Sprintf("Missing scheduling interval in drpolicy %q", drPolicy.Name))
+	}
+
+	duration, err := ramen.ParseSchedulingInterval(drPolicy.Spec.SchedulingInterval)
+	if err != nil {
+		log.Warnf("Invalid scheduling interval in drpolicy %q: %s", drPolicy.Name, err)
+
+		return c.validatedSchedulingInterval(0,
+			fmt.Sprintf("Invalid scheduling interval in drpolicy %q", drPolicy.Name))
+	}
+
+	return c.validatedSchedulingInterval(duration, "")
+}
+
+func (c *Command) validatedVRGSchedulingInterval(
+	vrg *ramenapi.VolumeReplicationGroup,
+	drpc *report.DRPCSummary,
+) report.ValidatedDuration {
+	// Metro DR does not use async replication.
+	if vrg.Spec.Async == nil {
+		return report.ValidatedDuration{}
+	}
+
+	if vrg.Spec.Async.SchedulingInterval == "" {
+		return c.validatedSchedulingInterval(0, "Missing scheduling interval in vrg")
+	}
+
+	duration, err := ramen.ParseSchedulingInterval(vrg.Spec.Async.SchedulingInterval)
+	if err != nil {
+		c.Logger().Warnf("Invalid scheduling interval in vrg: %s", err)
+
+		return c.validatedSchedulingInterval(0, "Invalid scheduling interval in vrg")
+	}
+
+	if drpc.SchedulingInterval.State == report.OK && duration != drpc.SchedulingInterval.Value {
+		return c.validatedSchedulingInterval(duration,
+			fmt.Sprintf("Does not match drpolicy %q interval %s",
+				drpc.DRPolicy, drpc.SchedulingInterval.Value))
+	}
+
+	return c.validatedSchedulingInterval(duration, "")
+}
+
+func (c *Command) validatedSchedulingInterval(
+	duration stdtime.Duration,
+	description string,
+) report.ValidatedDuration {
+	validated := report.ValidatedDuration{Value: duration}
+
+	if description != "" {
+		validated.State = report.Problem
+		validated.Description = description
+	} else {
+		validated.State = report.OK
+	}
+
+	summary.AddValidation(c.Report.Summary, &validated)
+
 	return validated
 }
 

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -427,6 +427,14 @@ func (c *Command) validateDRPC(
 ) {
 	s.Name = drpc.Name
 	s.Namespace = drpc.Namespace
+
+	var err error
+
+	s.ClusterTime, err = ramen.ClusterTime(drpc.Annotations)
+	if err != nil {
+		c.Logger().Warnf("drpc \"%s/%s\": %s", drpc.Namespace, drpc.Name, err)
+	}
+
 	s.Deleted = c.ValidatedDeleted(drpc)
 	s.DRPolicy = drpc.Spec.DRPolicyRef.Name
 	s.Action = c.validatedDRPCAction(string(drpc.Spec.Action))
@@ -462,6 +470,12 @@ func (c *Command) validateVRG(
 	log.Debugf("Read vrg \"%s/%s\" from cluster %q", vrgNamespace, vrgName, cluster.Name)
 	s.Name = vrgName
 	s.Namespace = vrgNamespace
+
+	s.ClusterTime, err = ramen.ClusterTime(vrg.Annotations)
+	if err != nil {
+		log.Warnf("vrg \"%s/%s\" on cluster %q: %s", vrgNamespace, vrgName, cluster.Name, err)
+	}
+
 	s.Deleted = c.ValidatedDeleted(vrg)
 	s.Conditions = c.validatedVRGConditions(vrg)
 	s.ProtectedPVCs = c.validatedProtectedPVCs(cluster, vrg)

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -439,6 +439,8 @@ func (c *Command) validateDRPC(
 	s.Deleted = c.ValidatedDeleted(drpc)
 	s.DRPolicy = drpc.Spec.DRPolicyRef.Name
 	s.SchedulingInterval = c.validatedDRPCSchedulingInterval(drpc)
+	s.LastGroupSyncTime = c.validateLastGroupSyncTime(
+		drpc.Status.LastGroupSyncTime, s.ClusterTime, s.SchedulingInterval, true)
 	s.Action = c.validatedDRPCAction(string(drpc.Spec.Action))
 	s.Phase = c.validatedDRPCPhase(drpc)
 	s.Progression = c.validatedDRPCProgression(drpc)
@@ -483,6 +485,9 @@ func (c *Command) validateVRG(
 		vrg,
 		&c.Report.ApplicationStatus.Hub.DRPC,
 	)
+	s.LastGroupSyncTime = c.validateLastGroupSyncTime(
+		vrg.Status.LastGroupSyncTime, s.ClusterTime, s.SchedulingInterval,
+		stableState == ramenapi.PrimaryState)
 	s.Conditions = c.validatedVRGConditions(vrg)
 	s.ProtectedPVCs = c.validatedProtectedPVCs(cluster, vrg)
 	s.PVCGroups = c.pvcGroups(vrg)
@@ -657,6 +662,70 @@ func (c *Command) validatedSchedulingInterval(
 	}
 
 	summary.AddValidation(c.Report.Summary, &validated)
+
+	return validated
+}
+
+// validateLastGroupSyncTime checks if replication is fresh by comparing
+// lastGroupSyncTime with clusterTime and schedulingInterval. This is the
+// shared logic for DRPC and VRG, matching the VolumeSynchronizationDelay
+// alert in ramen.
+func (c *Command) validateLastGroupSyncTime(
+	lastGroupSyncTime *metav1.Time,
+	clusterTime *stdtime.Time,
+	schedulingInterval report.ValidatedDuration,
+	primary bool,
+) report.ValidatedTime {
+	if lastGroupSyncTime == nil {
+		if primary {
+			return c.validatedLastGroupSyncTime(nil, report.Stale,
+				"Waiting for first volume synchronization")
+		}
+
+		return c.validatedLastGroupSyncTime(nil, report.OK, "")
+	}
+
+	// metav1.Time.UnmarshalJSON converts timestamps to local time. We convert to UTC
+	// for consistency with other timestamps in YAML and HTML reports.
+	// https://github.com/kubernetes/kubernetes/issues/102316
+	t := lastGroupSyncTime.UTC()
+
+	// Cannot validate without cluster time or valid scheduling interval - should not happen.
+	if clusterTime == nil ||
+		schedulingInterval.State != report.OK ||
+		schedulingInterval.Value == 0 {
+		return report.ValidatedTime{Value: &t}
+	}
+
+	// Thresholds match ramen VolumeSynchronizationDelay alert (>= 3 critical, > 2 warning).
+	intervals := float64(clusterTime.Sub(t)) / float64(schedulingInterval.Value)
+
+	if intervals >= 3 {
+		return c.validatedLastGroupSyncTime(&t, report.Problem,
+			"Replication is exceeding 3x the scheduling interval")
+	}
+
+	if intervals > 2 {
+		return c.validatedLastGroupSyncTime(&t, report.Stale,
+			"Replication is exceeding 2x the scheduling interval")
+	}
+
+	return c.validatedLastGroupSyncTime(&t, report.OK, "")
+}
+
+func (c *Command) validatedLastGroupSyncTime(
+	value *stdtime.Time,
+	state report.ValidationState,
+	description string,
+) report.ValidatedTime {
+	validated := report.ValidatedTime{
+		Validated: report.Validated{State: state, Description: description},
+		Value:     value,
+	}
+
+	if state != "" {
+		summary.AddValidation(c.Report.Summary, &validated)
+	}
 
 	return validated
 }

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -6,6 +6,7 @@ package application
 import (
 	"context"
 	"testing"
+	stdtime "time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,6 +19,9 @@ import (
 )
 
 const applicationTestdata = "../../testdata/appset-deploy-rbd"
+
+// Must match the cluster-time annotation in testdata.
+var testClusterTime = stdtime.Date(2025, 7, 29, 17, 24, 30, 0, stdtime.UTC)
 
 var (
 	testApplication = &report.Application{
@@ -115,8 +119,9 @@ func TestValidateApplicationPassed(t *testing.T) {
 	expectedStatus := &report.ApplicationStatus{
 		Hub: report.ApplicationStatusHub{
 			DRPC: report.DRPCSummary{
-				Name:      drpcName,
-				Namespace: drpcNamespace,
+				Name:        drpcName,
+				Namespace:   drpcNamespace,
+				ClusterTime: &testClusterTime,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,
@@ -165,8 +170,9 @@ func TestValidateApplicationPassed(t *testing.T) {
 		PrimaryCluster: report.ApplicationStatusCluster{
 			Name: "dr1",
 			VRG: report.VRGSummary{
-				Name:      drpcName,
-				Namespace: applicationNamespace,
+				Name:        drpcName,
+				Namespace:   applicationNamespace,
+				ClusterTime: &testClusterTime,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,
@@ -248,8 +254,9 @@ func TestValidateApplicationPassed(t *testing.T) {
 		SecondaryCluster: report.ApplicationStatusCluster{
 			Name: "dr2",
 			VRG: report.VRGSummary{
-				Name:      drpcName,
-				Namespace: applicationNamespace,
+				Name:        drpcName,
+				Namespace:   applicationNamespace,
+				ClusterTime: &testClusterTime,
 				Deleted: report.ValidatedBool{
 					Validated: report.Validated{
 						State: report.OK,

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -133,6 +133,12 @@ func TestValidateApplicationPassed(t *testing.T) {
 					},
 				},
 				DRPolicy: "dr-policy-1m",
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
+				},
 				Phase: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -177,6 +183,12 @@ func TestValidateApplicationPassed(t *testing.T) {
 					Validated: report.Validated{
 						State: report.OK,
 					},
+				},
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
@@ -262,6 +274,12 @@ func TestValidateApplicationPassed(t *testing.T) {
 						State: report.OK,
 					},
 				},
+				SchedulingInterval: report.ValidatedDuration{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: stdtime.Minute,
+				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -308,7 +326,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 	}
 	checkApplicationStatus(t, validate.Report, expectedStatus)
 
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 24})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 27})
 }
 
 func TestValidateApplicationValidateFailed(t *testing.T) {
@@ -508,7 +526,7 @@ func TestValidateApplicationGetSecretFailed(t *testing.T) {
 		{Name: "validate data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 22, summary.Problem: 2})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 25, summary.Problem: 2})
 }
 
 func TestValidateApplicationGetSecretInvalid(t *testing.T) {
@@ -541,7 +559,7 @@ func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 		{Name: "validate data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 22, summary.Problem: 2})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 25, summary.Problem: 2})
 }
 
 func TestValidateApplicationGatherS3Failed(t *testing.T) {
@@ -576,7 +594,7 @@ func TestValidateApplicationGatherS3Failed(t *testing.T) {
 	checkSummary(
 		t,
 		validate.Report,
-		report.Summary{summary.OK: 23, summary.Problem: 1},
+		report.Summary{summary.OK: 26, summary.Problem: 1},
 	)
 }
 

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -20,8 +20,11 @@ import (
 
 const applicationTestdata = "../../testdata/appset-deploy-rbd"
 
-// Must match the cluster-time annotation in testdata.
-var testClusterTime = stdtime.Date(2025, 7, 29, 17, 24, 30, 0, stdtime.UTC)
+// Must match the cluster-time and lastGroupSyncTime in testdata.
+var (
+	testClusterTime       = stdtime.Date(2025, 7, 29, 17, 24, 30, 0, stdtime.UTC)
+	testLastGroupSyncTime = stdtime.Date(2025, 7, 29, 17, 23, 0, 0, stdtime.UTC)
+)
 
 var (
 	testApplication = &report.Application{
@@ -139,6 +142,12 @@ func TestValidateApplicationPassed(t *testing.T) {
 					},
 					Value: stdtime.Minute,
 				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: &testLastGroupSyncTime,
+				},
 				Phase: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -189,6 +198,12 @@ func TestValidateApplicationPassed(t *testing.T) {
 						State: report.OK,
 					},
 					Value: stdtime.Minute,
+				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+					Value: &testLastGroupSyncTime,
 				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
@@ -280,6 +295,11 @@ func TestValidateApplicationPassed(t *testing.T) {
 					},
 					Value: stdtime.Minute,
 				},
+				LastGroupSyncTime: report.ValidatedTime{
+					Validated: report.Validated{
+						State: report.OK,
+					},
+				},
 				State: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,
@@ -326,7 +346,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 	}
 	checkApplicationStatus(t, validate.Report, expectedStatus)
 
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 27})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 30})
 }
 
 func TestValidateApplicationValidateFailed(t *testing.T) {
@@ -526,7 +546,7 @@ func TestValidateApplicationGetSecretFailed(t *testing.T) {
 		{Name: "validate data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 25, summary.Problem: 2})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 28, summary.Problem: 2})
 }
 
 func TestValidateApplicationGetSecretInvalid(t *testing.T) {
@@ -559,7 +579,7 @@ func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 		{Name: "validate data", Status: report.Failed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
-	checkSummary(t, validate.Report, report.Summary{summary.OK: 25, summary.Problem: 2})
+	checkSummary(t, validate.Report, report.Summary{summary.OK: 28, summary.Problem: 2})
 }
 
 func TestValidateApplicationGatherS3Failed(t *testing.T) {
@@ -594,7 +614,7 @@ func TestValidateApplicationGatherS3Failed(t *testing.T) {
 	checkSummary(
 		t,
 		validate.Report,
-		report.Summary{summary.OK: 26, summary.Problem: 1},
+		report.Summary{summary.OK: 29, summary.Problem: 1},
 	)
 }
 

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -132,7 +132,7 @@ func TestValidateApplicationPassed(t *testing.T) {
 						State: report.OK,
 					},
 				},
-				DRPolicy: "dr-policy",
+				DRPolicy: "dr-policy-1m",
 				Phase: report.ValidatedString{
 					Validated: report.Validated{
 						State: report.OK,

--- a/pkg/validate/application/command_validated_test.go
+++ b/pkg/validate/application/command_validated_test.go
@@ -5,10 +5,15 @@ package application
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
+	stdtime "time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 
 	"github.com/ramendr/ramenctl/pkg/helpers"
 	"github.com/ramendr/ramenctl/pkg/report"
@@ -421,5 +426,271 @@ func TestValidatedProtectedPVCError(t *testing.T) {
 	expected := report.Summary{summary.Problem: len(cases)}
 	if !cmd.Report.Summary.Equal(&expected) {
 		t.Fatalf("expected summary %v, got %v", expected, *cmd.Report.Summary)
+	}
+}
+
+func TestValidatedDRPCSchedulingInterval(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+		writeDRPolicy(t, cmd.DataDir(), "dr-policy-5m", "5m")
+
+		drpc := &ramenapi.DRPlacementControl{
+			Spec: ramenapi.DRPlacementControlSpec{
+				DRPolicyRef: corev1.ObjectReference{Name: "dr-policy-5m"},
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{State: report.OK},
+			Value:     5 * stdtime.Minute,
+		}
+		validated := cmd.validatedDRPCSchedulingInterval(drpc)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("drpolicy not found", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		drpc := &ramenapi.DRPlacementControl{
+			Spec: ramenapi.DRPlacementControlSpec{
+				DRPolicyRef: corev1.ObjectReference{Name: "no-such-policy"},
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: `Could not read drpolicy "no-such-policy"`,
+			},
+		}
+		validated := cmd.validatedDRPCSchedulingInterval(drpc)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("empty scheduling interval", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+		writeDRPolicy(t, cmd.DataDir(), "dr-policy-empty", "")
+
+		drpc := &ramenapi.DRPlacementControl{
+			Spec: ramenapi.DRPlacementControlSpec{
+				DRPolicyRef: corev1.ObjectReference{Name: "dr-policy-empty"},
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: `Missing scheduling interval in drpolicy "dr-policy-empty"`,
+			},
+		}
+		validated := cmd.validatedDRPCSchedulingInterval(drpc)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("invalid scheduling interval", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+		writeDRPolicy(t, cmd.DataDir(), "dr-policy-bad", "invalid")
+
+		drpc := &ramenapi.DRPlacementControl{
+			Spec: ramenapi.DRPlacementControlSpec{
+				DRPolicyRef: corev1.ObjectReference{Name: "dr-policy-bad"},
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: `Invalid scheduling interval in drpolicy "dr-policy-bad"`,
+			},
+		}
+		validated := cmd.validatedDRPCSchedulingInterval(drpc)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+}
+
+func TestValidatedVRGSchedulingInterval(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			Spec: ramenapi.VolumeReplicationGroupSpec{
+				Async: &ramenapi.VRGAsyncSpec{
+					SchedulingInterval: "5m",
+				},
+			},
+		}
+		drpcSummary := &report.DRPCSummary{
+			DRPolicy: "dr-policy-5m",
+			SchedulingInterval: report.ValidatedDuration{
+				Validated: report.Validated{State: report.OK},
+				Value:     5 * stdtime.Minute,
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{State: report.OK},
+			Value:     5 * stdtime.Minute,
+		}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("metro dr", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{}
+		drpcSummary := &report.DRPCSummary{}
+
+		expected := report.ValidatedDuration{}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("empty scheduling interval", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			Spec: ramenapi.VolumeReplicationGroupSpec{
+				Async: &ramenapi.VRGAsyncSpec{
+					SchedulingInterval: "",
+				},
+			},
+		}
+		drpcSummary := &report.DRPCSummary{}
+
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Missing scheduling interval in vrg",
+			},
+		}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("invalid scheduling interval", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			Spec: ramenapi.VolumeReplicationGroupSpec{
+				Async: &ramenapi.VRGAsyncSpec{
+					SchedulingInterval: "invalid",
+				},
+			},
+		}
+		drpcSummary := &report.DRPCSummary{}
+
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Invalid scheduling interval in vrg",
+			},
+		}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("mismatch with drpolicy", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			Spec: ramenapi.VolumeReplicationGroupSpec{
+				Async: &ramenapi.VRGAsyncSpec{
+					SchedulingInterval: "1m",
+				},
+			},
+		}
+		drpcSummary := &report.DRPCSummary{
+			DRPolicy: "dr-policy-5m",
+			SchedulingInterval: report.ValidatedDuration{
+				Validated: report.Validated{State: report.OK},
+				Value:     5 * stdtime.Minute,
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{
+				State: report.Problem,
+				Description: fmt.Sprintf(
+					"Does not match drpolicy %q interval %s",
+					"dr-policy-5m", 5*stdtime.Minute,
+				),
+			},
+			Value: stdtime.Minute,
+		}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("drpc interval unknown", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			Spec: ramenapi.VolumeReplicationGroupSpec{
+				Async: &ramenapi.VRGAsyncSpec{
+					SchedulingInterval: "5m",
+				},
+			},
+		}
+		drpcSummary := &report.DRPCSummary{
+			SchedulingInterval: report.ValidatedDuration{
+				Validated: report.Validated{
+					State:       report.Problem,
+					Description: "failed to read drpolicy",
+				},
+			},
+		}
+		expected := report.ValidatedDuration{
+			Validated: report.Validated{State: report.OK},
+			Value:     5 * stdtime.Minute,
+		}
+		validated := cmd.validatedVRGSchedulingInterval(vrg, drpcSummary)
+		if validated != expected {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+}
+
+// writeDRPolicy writes a DRPolicy to the gathered hub data directory.
+func writeDRPolicy(t *testing.T, dataDir, name, schedulingInterval string) {
+	t.Helper()
+
+	drPolicy := &ramenapi.DRPolicy{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: ramenapi.GroupVersion.String(),
+			Kind:       "DRPolicy",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: ramenapi.DRPolicySpec{
+			SchedulingInterval: schedulingInterval,
+		},
+	}
+
+	data, err := yaml.Marshal(drPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := filepath.Join(dataDir, "hub", "cluster", "ramendr.openshift.io", "drpolicies")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, name+".yaml"), data, 0o600); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/pkg/validate/application/command_validated_test.go
+++ b/pkg/validate/application/command_validated_test.go
@@ -663,6 +663,114 @@ func TestValidatedVRGSchedulingInterval(t *testing.T) {
 	})
 }
 
+func TestValidateLastGroupSyncTime(t *testing.T) {
+	cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+	clusterTime := stdtime.Date(2025, 7, 29, 17, 24, 30, 0, stdtime.UTC)
+	schedulingInterval := report.ValidatedDuration{
+		Validated: report.Validated{State: report.OK},
+		Value:     stdtime.Minute,
+	}
+
+	t.Run("nil on primary", func(t *testing.T) {
+		expected := report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Stale,
+				Description: "Waiting for first volume synchronization",
+			},
+		}
+		validated := cmd.validateLastGroupSyncTime(nil, &clusterTime, schedulingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("nil on secondary", func(t *testing.T) {
+		expected := report.ValidatedTime{
+			Validated: report.Validated{State: report.OK},
+		}
+		validated := cmd.validateLastGroupSyncTime(nil, &clusterTime, schedulingInterval, false)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("no cluster time", func(t *testing.T) {
+		syncTime := metav1.NewTime(clusterTime.Add(-5 * stdtime.Minute))
+		expected := report.ValidatedTime{Value: &syncTime.Time}
+		validated := cmd.validateLastGroupSyncTime(&syncTime, nil, schedulingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("no scheduling interval", func(t *testing.T) {
+		syncTime := metav1.NewTime(clusterTime.Add(-5 * stdtime.Minute))
+		missingInterval := report.ValidatedDuration{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Missing scheduling interval",
+			},
+		}
+		expected := report.ValidatedTime{Value: &syncTime.Time}
+		validated := cmd.validateLastGroupSyncTime(&syncTime, &clusterTime, missingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("ok", func(t *testing.T) {
+		maxOK := 2 * stdtime.Minute
+		// Simulate metav1.Time.UnmarshalJSON which converts to local time.
+		syncTime := metav1.NewTime(clusterTime.Add(-maxOK).Local())
+		expected := report.ValidatedTime{
+			Validated: report.Validated{State: report.OK},
+			Value:     &syncTime.Time,
+		}
+		validated := cmd.validateLastGroupSyncTime(
+			&syncTime, &clusterTime, schedulingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+		if validated.Value.Location() != stdtime.UTC {
+			t.Fatalf("expected UTC time, got %v", validated.Value)
+		}
+	})
+
+	t.Run("stale", func(t *testing.T) {
+		maxStale := 2*stdtime.Minute + 59*stdtime.Second
+		syncTime := metav1.NewTime(clusterTime.Add(-maxStale))
+		expected := report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Stale,
+				Description: "Replication is exceeding 2x the scheduling interval",
+			},
+			Value: &syncTime.Time,
+		}
+		validated := cmd.validateLastGroupSyncTime(
+			&syncTime, &clusterTime, schedulingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("problem", func(t *testing.T) {
+		minProblem := 3 * stdtime.Minute
+		syncTime := metav1.NewTime(clusterTime.Add(-minProblem))
+		expected := report.ValidatedTime{
+			Validated: report.Validated{
+				State:       report.Problem,
+				Description: "Replication is exceeding 3x the scheduling interval",
+			},
+			Value: &syncTime.Time,
+		}
+		validated := cmd.validateLastGroupSyncTime(
+			&syncTime, &clusterTime, schedulingInterval, true)
+		if !validated.Equal(&expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+}
+
 // writeDRPolicy writes a DRPolicy to the gathered hub data directory.
 func writeDRPolicy(t *testing.T, dataDir, name, schedulingInterval string) {
 	t.Helper()

--- a/pkg/validate/application/html_test.go
+++ b/pkg/validate/application/html_test.go
@@ -30,6 +30,7 @@ func TestTemplate(t *testing.T) {
 		"drpc",
 		"pvc",
 		"s3",
+		"lastGroupSyncTime",
 		"vrg",
 	}
 	for _, name := range expected {

--- a/pkg/validate/application/templates/drpc.tmpl
+++ b/pkg/validate/application/templates/drpc.tmpl
@@ -12,6 +12,8 @@
     <dd>{{formatTime .ClusterTime}}</dd>
 </dl>
 <dl class="validation">
+    <dt>Scheduling Interval</dt>
+    <dd>{{template "validated" .SchedulingInterval}}</dd>
     <dt>Action</dt>
     <dd>{{template "validated" .Action}}</dd>
     <dt>Phase</dt>

--- a/pkg/validate/application/templates/drpc.tmpl
+++ b/pkg/validate/application/templates/drpc.tmpl
@@ -14,6 +14,8 @@
 <dl class="validation">
     <dt>Scheduling Interval</dt>
     <dd>{{template "validated" .SchedulingInterval}}</dd>
+    <dt>Last Group Sync Time</dt>
+    <dd>{{template "lastGroupSyncTime" .LastGroupSyncTime}}</dd>
     <dt>Action</dt>
     <dd>{{template "validated" .Action}}</dd>
     <dt>Phase</dt>

--- a/pkg/validate/application/templates/drpc.tmpl
+++ b/pkg/validate/application/templates/drpc.tmpl
@@ -8,6 +8,8 @@
     <dd>{{.Namespace}}</dd>
     <dt>DRPolicy</dt>
     <dd>{{.DRPolicy}}</dd>
+    <dt>Cluster Time</dt>
+    <dd>{{formatTime .ClusterTime}}</dd>
 </dl>
 <dl class="validation">
     <dt>Action</dt>

--- a/pkg/validate/application/templates/lastGroupSyncTime.tmpl
+++ b/pkg/validate/application/templates/lastGroupSyncTime.tmpl
@@ -1,0 +1,9 @@
+{{/* SPDX-FileCopyrightText: The RamenDR authors */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+{{define "lastGroupSyncTime" -}}
+<span class="value">{{formatTime .Value}}</span>
+{{- if .State}}<span class="state">{{icon .State}}</span>{{- end}}
+{{- if .Description}}
+<p class="description">{{.Description}}</p>
+{{- end}}
+{{- end}}

--- a/pkg/validate/application/templates/vrg.tmpl
+++ b/pkg/validate/application/templates/vrg.tmpl
@@ -6,6 +6,8 @@
     <dd>{{.Name}}</dd>
     <dt>Namespace</dt>
     <dd>{{.Namespace}}</dd>
+    <dt>Cluster Time</dt>
+    <dd>{{formatTime .ClusterTime}}</dd>
 </dl>
 <dl class="validation">
     <dt>State</dt>

--- a/pkg/validate/application/templates/vrg.tmpl
+++ b/pkg/validate/application/templates/vrg.tmpl
@@ -10,6 +10,10 @@
     <dd>{{formatTime .ClusterTime}}</dd>
 </dl>
 <dl class="validation">
+    {{- if .SchedulingInterval.State}}
+        <dt>Scheduling Interval</dt>
+        <dd>{{template "validated" .SchedulingInterval}}</dd>
+    {{- end}}
     <dt>State</dt>
     <dd>{{template "validated" .State}}</dd>
     {{- if isProblem .Deleted.State}}

--- a/pkg/validate/application/templates/vrg.tmpl
+++ b/pkg/validate/application/templates/vrg.tmpl
@@ -14,6 +14,8 @@
         <dt>Scheduling Interval</dt>
         <dd>{{template "validated" .SchedulingInterval}}</dd>
     {{- end}}
+    <dt>Last Group Sync Time</dt>
+    <dd>{{template "lastGroupSyncTime" .LastGroupSyncTime}}</dd>
     <dt>State</dt>
     <dd>{{template "validated" .State}}</dd>
     {{- if isProblem .Deleted.State}}

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -32,6 +32,8 @@
               <dl class="validation">
                 <dt>Scheduling Interval</dt>
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
+                <dt>Last Group Sync Time</dt>
+                <dd><span class="value">2025-07-29T17:23:00Z</span><span class="state">✅</span></dd>
                 <dt>Action</dt>
                 <dd><span class="value"></span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
@@ -67,6 +69,8 @@
               <dl class="validation">
                 <dt>Scheduling Interval</dt>
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
+                <dt>Last Group Sync Time</dt>
+                <dd><span class="value">2025-07-29T17:23:00Z</span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Primary</span><span class="state">✅</span></dd>
               </dl>
@@ -130,6 +134,8 @@
               <dl class="validation">
                 <dt>Scheduling Interval</dt>
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
+                <dt>Last Group Sync Time</dt>
+                <dd><span class="value"></span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Secondary</span><span class="state">✅</span></dd>
               </dl>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status passed">passed</span><span class="summary">27 ok, 0 stale, 0 problem</span></div>
+      <div class="result"><span class="status passed">passed</span><span class="summary">30 ok, 0 stale, 0 problem</span></div>
       <footer><span>Created 2026-03-16T20:16:31&#43;02:00</span><span>Duration 2.21s</span></footer>
     </header>
     <main>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status passed">passed</span><span class="summary">24 ok, 0 stale, 0 problem</span></div>
+      <div class="result"><span class="status passed">passed</span><span class="summary">27 ok, 0 stale, 0 problem</span></div>
       <footer><span>Created 2026-03-16T20:16:31&#43;02:00</span><span>Duration 2.21s</span></footer>
     </header>
     <main>
@@ -30,6 +30,8 @@
                 <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>Action</dt>
                 <dd><span class="value"></span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
@@ -63,6 +65,8 @@
                 <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Primary</span><span class="state">✅</span></dd>
               </dl>
@@ -124,6 +128,8 @@
                 <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Secondary</span><span class="state">✅</span></dd>
               </dl>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -26,6 +26,8 @@
                 <dd>argocd</dd>
                 <dt>DRPolicy</dt>
                 <dd>dr-policy-1m</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>Action</dt>
@@ -57,6 +59,8 @@
                 <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
                 <dd>test-appset-deploy-rbd</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>State</dt>
@@ -116,6 +120,8 @@
                 <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
                 <dd>test-appset-deploy-rbd</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:24:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>State</dt>

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -9,7 +9,7 @@
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
       <div class="result"><span class="status passed">passed</span><span class="summary">24 ok, 0 stale, 0 problem</span></div>
-      <footer><span>Created 2026-03-16 20:16:31 &#43;0200</span><span>Duration 2.21s</span></footer>
+      <footer><span>Created 2026-03-16T20:16:31&#43;02:00</span><span>Duration 2.21s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/application/testdata/ok.yaml
+++ b/pkg/validate/application/testdata/ok.yaml
@@ -19,6 +19,9 @@ applicationStatus:
       drPolicy: dr-policy-1m
       name: appset-deploy-rbd
       namespace: argocd
+      lastGroupSyncTime:
+        state: ok ✅
+        value: "2025-07-29T17:23:00Z"
       schedulingInterval:
         state: ok ✅
         value: 1m0s
@@ -45,6 +48,9 @@ applicationStatus:
         type: NoClusterDataConflict
       deleted:
         state: ok ✅
+      lastGroupSyncTime:
+        state: ok ✅
+        value: "2025-07-29T17:23:00Z"
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
       schedulingInterval:
@@ -87,6 +93,8 @@ applicationStatus:
       - state: ok ✅
         type: NoClusterDataConflict
       deleted:
+        state: ok ✅
+      lastGroupSyncTime:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
@@ -161,4 +169,4 @@ steps:
   name: validate application
   status: passed
 summary:
-  ok: 27
+  ok: 30

--- a/pkg/validate/application/testdata/ok.yaml
+++ b/pkg/validate/application/testdata/ok.yaml
@@ -19,6 +19,9 @@ applicationStatus:
       drPolicy: dr-policy-1m
       name: appset-deploy-rbd
       namespace: argocd
+      schedulingInterval:
+        state: ok ✅
+        value: 1m0s
       phase:
         state: ok ✅
         value: Deployed
@@ -44,6 +47,9 @@ applicationStatus:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
+      schedulingInterval:
+        state: ok ✅
+        value: 1m0s
       protectedPVCs:
       - conditions:
         - state: ok ✅
@@ -84,6 +90,9 @@ applicationStatus:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
+      schedulingInterval:
+        state: ok ✅
+        value: 1m0s
       state:
         state: ok ✅
         value: Secondary
@@ -152,4 +161,4 @@ steps:
   name: validate application
   status: passed
 summary:
-  ok: 24
+  ok: 27

--- a/pkg/validate/application/testdata/ok.yaml
+++ b/pkg/validate/application/testdata/ok.yaml
@@ -6,6 +6,7 @@ applicationStatus:
     drpc:
       action:
         state: ok ✅
+      clusterTime: "2025-07-29T17:24:30Z"
       conditions:
       - state: ok ✅
         type: Available
@@ -27,6 +28,7 @@ applicationStatus:
   primaryCluster:
     name: dr1
     vrg:
+      clusterTime: "2025-07-29T17:24:30Z"
       conditions:
       - state: ok ✅
         type: DataReady
@@ -74,6 +76,7 @@ applicationStatus:
   secondaryCluster:
     name: dr2
     vrg:
+      clusterTime: "2025-07-29T17:24:30Z"
       conditions:
       - state: ok ✅
         type: NoClusterDataConflict

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -9,7 +9,7 @@
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
       <div class="result"><span class="status failed">failed</span><span class="summary">21 ok, 1 stale, 7 problem</span></div>
-      <footer><span>Created 2026-03-16 20:19:49 &#43;0200</span><span>Duration 2.30s</span></footer>
+      <footer><span>Created 2026-03-16T20:19:49&#43;02:00</span><span>Duration 2.30s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status failed">failed</span><span class="summary">23 ok, 1 stale, 8 problem</span></div>
+      <div class="result"><span class="status failed">failed</span><span class="summary">25 ok, 2 stale, 8 problem</span></div>
       <footer><span>Created 2026-03-16T20:19:49&#43;02:00</span><span>Duration 2.30s</span></footer>
     </header>
     <main>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status failed">failed</span><span class="summary">21 ok, 1 stale, 7 problem</span></div>
+      <div class="result"><span class="status failed">failed</span><span class="summary">23 ok, 1 stale, 8 problem</span></div>
       <footer><span>Created 2026-03-16T20:19:49&#43;02:00</span><span>Duration 2.30s</span></footer>
     </header>
     <main>
@@ -30,6 +30,8 @@
                 <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>Action</dt>
                 <dd><span class="value">Failover</span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
@@ -72,6 +74,8 @@
                 <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Primary</span><span class="state">✅</span></dd>
               </dl>
@@ -133,6 +137,11 @@
                 <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
+                <dt>Scheduling Interval</dt>
+                <dd>
+                  <span class="value">5m0s</span><span class="state">❌</span>
+                  <p class="description">Does not match drpolicy &#34;dr-policy-1m&#34; interval 1m0s</p>
+                </dd>
                 <dt>State</dt>
                 <dd>
                   <span class="value">Unknown</span><span class="state">❌</span>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -32,6 +32,11 @@
               <dl class="validation">
                 <dt>Scheduling Interval</dt>
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
+                <dt>Last Group Sync Time</dt>
+                <dd>
+                  <span class="value">2025-07-29T17:23:00Z</span><span class="state">⭕</span>
+                  <p class="description">Replication is exceeding 2x the scheduling interval</p>
+                </dd>
                 <dt>Action</dt>
                 <dd><span class="value">Failover</span><span class="state">✅</span></dd>
                 <dt>Phase</dt>
@@ -76,6 +81,8 @@
               <dl class="validation">
                 <dt>Scheduling Interval</dt>
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
+                <dt>Last Group Sync Time</dt>
+                <dd><span class="value">2025-07-29T17:24:30Z</span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd><span class="value">Primary</span><span class="state">✅</span></dd>
               </dl>
@@ -142,6 +149,8 @@
                   <span class="value">5m0s</span><span class="state">❌</span>
                   <p class="description">Does not match drpolicy &#34;dr-policy-1m&#34; interval 1m0s</p>
                 </dd>
+                <dt>Last Group Sync Time</dt>
+                <dd><span class="value"></span><span class="state">✅</span></dd>
                 <dt>State</dt>
                 <dd>
                   <span class="value">Unknown</span><span class="state">❌</span>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -26,6 +26,8 @@
                 <dd>argocd</dd>
                 <dt>DRPolicy</dt>
                 <dd>dr-policy-1m</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>Action</dt>
@@ -66,6 +68,8 @@
                 <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
                 <dd>test-appset-deploy-rbd</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>State</dt>
@@ -125,6 +129,8 @@
                 <dd>appset-deploy-rbd</dd>
                 <dt>Namespace</dt>
                 <dd>test-appset-deploy-rbd</dd>
+                <dt>Cluster Time</dt>
+                <dd>2025-07-29T17:25:30Z</dd>
               </dl>
               <dl class="validation">
                 <dt>State</dt>

--- a/pkg/validate/application/testdata/problem.yaml
+++ b/pkg/validate/application/testdata/problem.yaml
@@ -7,6 +7,7 @@ applicationStatus:
       action:
         state: ok ✅
         value: Failover
+      clusterTime: "2025-07-29T17:25:30Z"
       conditions:
       - state: ok ✅
         type: Available
@@ -33,6 +34,7 @@ applicationStatus:
   primaryCluster:
     name: dr2
     vrg:
+      clusterTime: "2025-07-29T17:25:30Z"
       conditions:
       - state: ok ✅
         type: DataReady
@@ -80,6 +82,7 @@ applicationStatus:
   secondaryCluster:
     name: dr1
     vrg:
+      clusterTime: "2025-07-29T17:25:30Z"
       conditions:
       - description: All PVCs of the VolumeReplicationGroup are not ready
         state: problem ❌

--- a/pkg/validate/application/testdata/problem.yaml
+++ b/pkg/validate/application/testdata/problem.yaml
@@ -24,6 +24,9 @@ applicationStatus:
       drPolicy: dr-policy-1m
       name: appset-deploy-rbd
       namespace: argocd
+      schedulingInterval:
+        state: ok ✅
+        value: 1m0s
       phase:
         state: ok ✅
         value: FailedOver
@@ -50,6 +53,9 @@ applicationStatus:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
+      schedulingInterval:
+        state: ok ✅
+        value: 1m0s
       protectedPVCs:
       - conditions:
         - state: ok ✅
@@ -93,6 +99,10 @@ applicationStatus:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
+      schedulingInterval:
+        description: Does not match drpolicy "dr-policy-1m" interval 1m0s
+        state: problem ❌
+        value: 5m0s
       protectedPVCs:
       - conditions:
         - description: failed to demote volume
@@ -180,6 +190,6 @@ steps:
   name: validate application
   status: failed
 summary:
-  ok: 21
-  problem: 7
+  ok: 23
+  problem: 8
   stale: 1

--- a/pkg/validate/application/testdata/problem.yaml
+++ b/pkg/validate/application/testdata/problem.yaml
@@ -24,6 +24,10 @@ applicationStatus:
       drPolicy: dr-policy-1m
       name: appset-deploy-rbd
       namespace: argocd
+      lastGroupSyncTime:
+        description: Syncing of volumes is exceeding 2x the scheduling interval
+        state: stale ⭕
+        value: "2025-07-29T17:23:00Z"
       schedulingInterval:
         state: ok ✅
         value: 1m0s
@@ -51,6 +55,9 @@ applicationStatus:
         type: NoClusterDataConflict
       deleted:
         state: ok ✅
+      lastGroupSyncTime:
+        state: ok ✅
+        value: "2025-07-29T17:24:30Z"
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
       schedulingInterval:
@@ -96,6 +103,8 @@ applicationStatus:
       - state: ok ✅
         type: NoClusterDataConflict
       deleted:
+        state: ok ✅
+      lastGroupSyncTime:
         state: ok ✅
       name: appset-deploy-rbd
       namespace: test-appset-deploy-rbd
@@ -190,6 +199,6 @@ steps:
   name: validate application
   status: failed
 summary:
-  ok: 23
+  ok: 25
   problem: 8
-  stale: 1
+  stale: 2

--- a/pkg/validate/application/testdata/problem.yaml
+++ b/pkg/validate/application/testdata/problem.yaml
@@ -25,7 +25,7 @@ applicationStatus:
       name: appset-deploy-rbd
       namespace: argocd
       lastGroupSyncTime:
-        description: Syncing of volumes is exceeding 2x the scheduling interval
+        description: Replication is exceeding 2x the scheduling interval
         state: stale ⭕
         value: "2025-07-29T17:23:00Z"
       schedulingInterval:

--- a/pkg/validate/clusters/testdata/invalid-configmap.html
+++ b/pkg/validate/clusters/testdata/invalid-configmap.html
@@ -9,7 +9,7 @@
     <header>
       <h1>Validate Clusters</h1>
       <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 3 problem</span></div>
-      <footer><span>Created 2026-03-23 18:20:41 &#43;0200</span><span>Duration 1.05s</span></footer>
+      <footer><span>Created 2026-03-23T18:20:41&#43;02:00</span><span>Duration 1.05s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -9,7 +9,7 @@
     <header>
       <h1>Validate Clusters</h1>
       <div class="result"><span class="status passed">passed</span><span class="summary">90 ok, 0 stale, 0 problem</span></div>
-      <footer><span>Created 2026-03-23 18:18:13 &#43;0200</span><span>Duration 1.13s</span></footer>
+      <footer><span>Created 2026-03-23T18:18:13&#43;02:00</span><span>Duration 1.13s</span></footer>
     </header>
     <main>
       <section>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -9,7 +9,7 @@
     <header>
       <h1>Validate Clusters</h1>
       <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 6 problem</span></div>
-      <footer><span>Created 2026-03-23 18:20:41 &#43;0200</span><span>Duration 1.05s</span></footer>
+      <footer><span>Created 2026-03-23T18:20:41&#43;02:00</span><span>Duration 1.05s</span></footer>
     </header>
     <main>
       <section>


### PR DESCRIPTION
Add cluster time, scheduling interval, and lastGroupSyncTime to the
application validation report to detect stale replication.

## New fields

- **ClusterTime**: The API server time when the resource was gathered
  (from `kubectl-gather.nirs.github.com/cluster-time` annotation).
  Displayed in the report but not validated.

- **SchedulingInterval**: The DR policy scheduling interval. Validated
  by comparing the VRG interval with the DRPolicy interval.

- **LastGroupSyncTime**: The last successful replication sync time.
  Validated by comparing with cluster time and scheduling interval.

## LastGroupSyncTime validation

Thresholds match the ramen VolumeSynchronizationDelay Prometheus alert:

| Intervals | State   | Description                                         |
|-----------|---------|-----------------------------------------------------|
| <= 2      | ok      |                                                     |
| > 2, < 3  | stale   | Replication is exceeding 2x the scheduling interval |
| >= 3      | problem | Replication is exceeding 3x the scheduling interval |

When lastGroupSyncTime is nil:

| Cluster role | State | Description                                  |
|-------------|-------|-----------------------------------------------|
| Primary     | stale | Waiting for first volume synchronization      |
| Secondary   | ok    | No replication expected on secondary cluster  |

If cluster time or scheduling interval are not available, we show the
value without validation state. This should not happen.

## Example run - replication ok

Validated right after scalling down red-mirror on the secondary cluster.

```console
$ ramenctl validate application --namespace openshift-gitops \
    --name rbd-appset-1-placement-drpc -c ocp/config.yaml -o out/ocp/rbd-mirror-down
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/rbd-mirror-down"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "amagrawa-c2"
   ✅ Gathered data from cluster "amagrawa-c1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "s3profile-amagrawa-c1-ocs-storagecluster"
   ✅ Gathered S3 profile "s3profile-amagrawa-c2-ocs-storagecluster"
   ✅ Application validated

✅ Validation completed (66 ok, 0 stale, 0 problem)
```

<img width="1762" height="832" alt="replication ok" src="https://github.com/user-attachments/assets/5191efcd-7df9-46a0-8744-db417a698e17" />

| Resource | Cluster Time | Last Group Sync Time | Age | Intervals | State |
|----------|-------------|---------------------|-----|-----------|-------|
| DRPC | 22:19:09Z | 22:14:00Z | 5m09s | 1.0 | ok ✅ |
| Primary VRG | 22:19:45Z | 22:14:00Z | 5m45s | 1.2 | ok ✅ |
| Secondary VRG | 22:19:35Z | nil | - | - | ok ✅ |

## Example run - replication exceeds 2x scheduling intervals

```console
$ ramenctl validate application --namespace openshift-gitops \
    --name rbd-appset-1-placement-drpc -c ocp/config.yaml -o out/ocp/rbd-mirror-down
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/rbd-mirror-down"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "amagrawa-c2"
   ✅ Gathered data from cluster "amagrawa-c1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "s3profile-amagrawa-c1-ocs-storagecluster"
   ✅ Gathered S3 profile "s3profile-amagrawa-c2-ocs-storagecluster"
   ❌ Issues found during validation

❌ validation failed (64 ok, 2 stale, 0 problem)
```

<img width="1762" height="832" alt="replication stale" src="https://github.com/user-attachments/assets/571779f8-6f93-4f06-9a63-bd23186e2f49" />

| Resource | Cluster Time | Last Group Sync Time | Age | Intervals | State |
|----------|-------------|---------------------|-----|-----------|-------|
| DRPC | 22:25:24Z | 22:14:00Z | 11m24s | 2.3 | stale ⭕ |
| Primary VRG | 22:25:44Z | 22:14:00Z | 11m44s | 2.3 | stale ⭕ |
| Secondary VRG | 22:25:34Z | nil | - | - | ok ✅ |

## Example run - replication exceeds 3x scheduling intervals

```console
$ ramenctl validate application --namespace openshift-gitops \
    --name rbd-appset-1-placement-drpc -c ocp/config.yaml -o out/ocp/rbd-mirror-down
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/rbd-mirror-down"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "amagrawa-c2"
   ✅ Gathered data from cluster "amagrawa-c1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "s3profile-amagrawa-c1-ocs-storagecluster"
   ✅ Gathered S3 profile "s3profile-amagrawa-c2-ocs-storagecluster"
   ❌ Issues found during validation

❌ validation failed (64 ok, 0 stale, 2 problem)
```

<img width="1762" height="832" alt="replication problem" src="https://github.com/user-attachments/assets/fb3cf6e0-0e6c-4480-bcf4-143768e59ef1" />

| Resource | Cluster Time | Last Group Sync Time | Age | Intervals | State |
|----------|-------------|---------------------|-----|-----------|-------|
| DRPC | 22:31:27Z | 22:14:00Z | 17m27s | 3.5 | problem ❌ |
| Primary VRG | 22:32:03Z | 22:14:00Z | 18m03s | 3.6 | problem ❌ |
| Secondary VRG | 22:31:33Z | nil | - | - | ok ✅ |

---
Fixes #339

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and surface cluster time, scheduling-interval, and last-group-sync-time in validation reports and templates.

* **Improvements**
  * Timestamps reformatted to ISO-8601 and nullable time fields handled in reports and HTML output.
  * Scheduling-interval parsing/validation and freshness checks added to validation logic.

* **Tests**
  * Added/updated tests and golden fixtures to cover timing, duration roundtrips, and validation scenarios.

* **Chores**
  * Bumped kubectl-gather dependency to v0.13.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramenctl/pull/442)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->