### PR TITLE
report: Rename "stale" validation state to "warning"

### DIFF
--- a/docs/test/plan.md
+++ b/docs/test/plan.md
@@ -266,7 +266,7 @@ odf dr validate clusters -o out/validate-clusters
 **Expected result:**
 - Console output shows progress with checkmarks for each cluster and S3
   profile.
-- Final line: `Validation completed (N ok, 0 stale, 0 problem)`.
+- Final line: `Validation completed (N ok, 0 warning, 0 problem)`.
 - Exits with code 0.
 
 **Output files:**
@@ -300,7 +300,7 @@ The YAML report contains common fields and command-specific data.
 - `status` - overall result (`passed` or `failed`)
 - `duration` - total duration in seconds
 - `steps` - list of steps with individual status and duration
-- `summary` - counts of ok, stale, and problem validations
+- `summary` - counts of ok, warning, and problem validations
 
 **Command-specific field** (`clustersStatus`):
 
@@ -502,7 +502,7 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/va
 **Expected result:**
 - Console output shows progress: inspected application, gathered data from
   each cluster, inspected S3 profiles.
-- Final line: `Validation completed (N ok, 0 stale, 0 problem)`.
+- Final line: `Validation completed (N ok, 0 warning, 0 problem)`.
 - Exits with code 0.
 
 **YAML report content:**
@@ -525,7 +525,7 @@ The YAML report contains common fields and command-specific data.
 - `status` - overall result (`passed` or `failed`)
 - `duration` - total duration in seconds
 - `steps` - list of steps with individual status and duration
-- `summary` - counts of ok, stale, and problem validations
+- `summary` - counts of ok, warning, and problem validations
 
 **Command-specific field** (`applicationStatus`):
 

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -78,7 +78,7 @@ $ ramenctl validate application --name appset-deploy-rbd --namespace argocd -o o
    ✅ Gathered S3 profile "minio-on-dr2"
    ✅ Application validated
 
-✅ Validation completed (24 ok, 0 stale, 0 problem)
+✅ Validation completed (24 ok, 0 warning, 0 problem)
 ```
 
 The command gathered related namespaced from all clusters, inspected the
@@ -261,7 +261,7 @@ $ ramenctl validate clusters -o out
    ✅ Checked S3 profile "minio-on-dr1"
    ✅ Clusters validated
 
-✅ Validation completed (90 ok, 0 stale, 0 problem)
+✅ Validation completed (90 ok, 0 warning, 0 problem)
 ```
 
 The command gathered cluster scoped and ramen resources from all clusters,

--- a/pkg/report/application_test.go
+++ b/pkg/report/application_test.go
@@ -90,13 +90,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("hub drpc lastGroupSyncTime", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		warningTime := time.Now().Add(-2 * stdtime.Hour)
 		a2.Hub.DRPC.LastGroupSyncTime = report.ValidatedTime{
 			Validated: report.Validated{
 				State:       report.Problem,
-				Description: "Replication is stale",
+				Description: "Replication is lagging",
 			},
-			Value: &staleTime,
+			Value: &warningTime,
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
@@ -164,13 +164,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("primary cluster vrg lastGroupSyncTime", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		warningTime := time.Now().Add(-2 * stdtime.Hour)
 		a2.PrimaryCluster.VRG.LastGroupSyncTime = report.ValidatedTime{
 			Validated: report.Validated{
 				State:       report.Problem,
-				Description: "Replication is stale",
+				Description: "Replication is lagging",
 			},
-			Value: &staleTime,
+			Value: &warningTime,
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})
@@ -301,13 +301,13 @@ func TestReportApplicationStatusNotEqual(t *testing.T) {
 	})
 	t.Run("secondary cluster vrg lastGroupSyncTime", func(t *testing.T) {
 		a2 := testApplicationStatus()
-		staleTime := time.Now().Add(-2 * stdtime.Hour)
+		warningTime := time.Now().Add(-2 * stdtime.Hour)
 		a2.SecondaryCluster.VRG.LastGroupSyncTime = report.ValidatedTime{
 			Validated: report.Validated{
 				State:       report.Problem,
-				Description: "Replication is stale",
+				Description: "Replication is lagging",
 			},
-			Value: &staleTime,
+			Value: &warningTime,
 		}
 		checkApplicationsNotEqual(t, a1, a2)
 	})

--- a/pkg/report/html.go
+++ b/pkg/report/html.go
@@ -70,8 +70,8 @@ func icon(s ValidationState) string {
 	switch s {
 	case OK:
 		return "✅"
-	case Stale:
-		return "⭕"
+	case Warning:
+		return "⚠️"
 	case Problem:
 		return "❌"
 	default:

--- a/pkg/report/state_test.go
+++ b/pkg/report/state_test.go
@@ -13,7 +13,7 @@ func TestIsIssue(t *testing.T) {
 		want  bool
 	}{
 		{OK, false},
-		{Stale, true},
+		{Warning, true},
 		{Problem, true},
 		{ValidationState(""), false},
 	}
@@ -36,13 +36,13 @@ func TestSignificantState(t *testing.T) {
 		{"empty+ok", "", OK, OK},
 		{"ok+empty", OK, "", OK},
 		{"ok+ok", OK, OK, OK},
-		{"ok+stale", OK, Stale, Stale},
-		{"stale+ok", Stale, OK, Stale},
+		{"ok+warning", OK, Warning, Warning},
+		{"warning+ok", Warning, OK, Warning},
 		{"ok+problem", OK, Problem, Problem},
 		{"problem+ok", Problem, OK, Problem},
-		{"stale+problem", Stale, Problem, Problem},
-		{"problem+stale", Problem, Stale, Problem},
-		{"stale+stale", Stale, Stale, Stale},
+		{"warning+problem", Warning, Problem, Problem},
+		{"problem+warning", Problem, Warning, Problem},
+		{"warning+warning", Warning, Warning, Warning},
 		{"problem+problem", Problem, Problem, Problem},
 	}
 	for _, tc := range cases {
@@ -57,7 +57,7 @@ func TestSignificantState(t *testing.T) {
 func TestAggregateState(t *testing.T) {
 	empty := Validated{}
 	ok := Validated{State: OK}
-	stale := Validated{State: Stale}
+	warning := Validated{State: Warning}
 	problem := Validated{State: Problem}
 
 	cases := []struct {
@@ -68,14 +68,14 @@ func TestAggregateState(t *testing.T) {
 		{"nil", nil, ""},
 		{"some empty", []StateAggregator{&empty, &empty}, ""},
 		{"empty and ok", []StateAggregator{&empty, &ok}, OK},
-		{"ok and stale", []StateAggregator{&ok, &ok, &stale}, Stale},
+		{"ok and warning", []StateAggregator{&ok, &ok, &warning}, Warning},
 		{"ok and problem", []StateAggregator{&ok, &ok, &problem}, Problem},
-		{"ok stale and problem", []StateAggregator{&ok, &stale, &problem}, Problem},
+		{"ok warning and problem", []StateAggregator{&ok, &warning, &problem}, Problem},
 		// Ensure earlier significant state is not overridden by later ok.
 		{"problem then ok", []StateAggregator{&problem, &ok}, Problem},
-		{"stale then ok", []StateAggregator{&stale, &ok}, Stale},
-		// Ensure earlier significant state is not overridden by later stale.
-		{"problem then stale", []StateAggregator{&problem, &stale}, Problem},
+		{"warning then ok", []StateAggregator{&warning, &ok}, Warning},
+		// Ensure earlier significant state is not overridden by later warning.
+		{"problem then warning", []StateAggregator{&problem, &warning}, Problem},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -97,10 +97,10 @@ func TestValidatedConditionListAggregateState(t *testing.T) {
 			{Validated: Validated{State: OK}, Type: "Ready"},
 			{Validated: Validated{State: OK}, Type: "Available"},
 		}, OK},
-		{"one stale", ValidatedConditionList{
+		{"one warning", ValidatedConditionList{
 			{Validated: Validated{State: OK}, Type: "Ready"},
-			{Validated: Validated{State: Stale}, Type: "Available"},
-		}, Stale},
+			{Validated: Validated{State: Warning}, Type: "Available"},
+		}, Warning},
 		{"one problem", ValidatedConditionList{
 			{Validated: Validated{State: OK}, Type: "Ready"},
 			{Validated: Validated{State: Problem}, Type: "Available"},

--- a/pkg/report/style.css
+++ b/pkg/report/style.css
@@ -157,7 +157,7 @@ section section > h6 {
  *   Title ... subtitle           ┌────────────────────────┐
  *                                │        passed          │
  *   Created ...  Duration ...    └────────────────────────┘
- *                                24 ok, 0 stale, 0 problem
+ *                                24 ok, 0 warning, 0 problem
  */
 
 header {

--- a/pkg/report/summary_test.go
+++ b/pkg/report/summary_test.go
@@ -38,7 +38,7 @@ func TestTestSummaryYAMLRoundtrip(t *testing.T) {
 func TestValidationSummaryYAMLRoundtrip(t *testing.T) {
 	s1 := report.Summary{
 		report.SummaryKey("ok"):      10,
-		report.SummaryKey("stale"):   1,
+		report.SummaryKey("warning"): 1,
 		report.SummaryKey("problem"): 2,
 	}
 

--- a/pkg/report/validation.go
+++ b/pkg/report/validation.go
@@ -15,16 +15,16 @@ const (
 	// OK is an expected value.
 	OK = ValidationState("ok ✅")
 
-	// Condition Generation does not match object generation.
-	Stale = ValidationState("stale ⭕")
+	// Warning indicates a potential issue that needs investigation.
+	Warning = ValidationState("warning ⚠️")
 
-	// Problem state such as missing or unexpected value.
+	// Problem indicates an unexpected state that likely needs action.
 	Problem = ValidationState("problem ❌")
 )
 
-// IsIssue returns true if the state indicates a problem or staleness.
+// IsIssue returns true if the state indicates a problem or a warning.
 func (s ValidationState) IsIssue() bool {
-	return s == Problem || s == Stale
+	return s == Problem || s == Warning
 }
 
 type Validation interface {
@@ -39,7 +39,7 @@ type StateAggregator interface {
 }
 
 type Validated struct {
-	// State is the validation state (one of OK, Stale, Error).
+	// State is the validation state (one of OK, Warning, Problem).
 	State ValidationState `json:"state"`
 	// Description explains why the value is not OK.
 	Description string `json:"description,omitempty"`
@@ -219,8 +219,8 @@ func significantState(a, b ValidationState) ValidationState {
 	switch {
 	case a == Problem || b == Problem:
 		return Problem
-	case a == Stale || b == Stale:
-		return Stale
+	case a == Warning || b == Warning:
+		return Warning
 	case a == OK || b == OK:
 		return OK
 	default:

--- a/pkg/report/validation_test.go
+++ b/pkg/report/validation_test.go
@@ -21,7 +21,7 @@ func TestEmojiRoundtrip(t *testing.T) {
 	}{
 		{"ok", report.OK},
 		{"problem", report.Problem},
-		{"stale", report.Stale},
+		{"warning", report.Warning},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -678,7 +678,7 @@ func (c *Command) validateLastGroupSyncTime(
 ) report.ValidatedTime {
 	if lastGroupSyncTime == nil {
 		if primary {
-			return c.validatedLastGroupSyncTime(nil, report.Stale,
+			return c.validatedLastGroupSyncTime(nil, report.Warning,
 				"Waiting for first volume synchronization")
 		}
 
@@ -706,7 +706,7 @@ func (c *Command) validateLastGroupSyncTime(
 	}
 
 	if intervals > 2 {
-		return c.validatedLastGroupSyncTime(&t, report.Stale,
+		return c.validatedLastGroupSyncTime(&t, report.Warning,
 			"Replication is exceeding 2x the scheduling interval")
 	}
 

--- a/pkg/validate/application/command_validated_test.go
+++ b/pkg/validate/application/command_validated_test.go
@@ -674,7 +674,7 @@ func TestValidateLastGroupSyncTime(t *testing.T) {
 	t.Run("nil on primary", func(t *testing.T) {
 		expected := report.ValidatedTime{
 			Validated: report.Validated{
-				State:       report.Stale,
+				State:       report.Warning,
 				Description: "Waiting for first volume synchronization",
 			},
 		}
@@ -736,12 +736,12 @@ func TestValidateLastGroupSyncTime(t *testing.T) {
 		}
 	})
 
-	t.Run("stale", func(t *testing.T) {
-		maxStale := 2*stdtime.Minute + 59*stdtime.Second
-		syncTime := metav1.NewTime(clusterTime.Add(-maxStale))
+	t.Run("warning", func(t *testing.T) {
+		maxWarning := 2*stdtime.Minute + 59*stdtime.Second
+		syncTime := metav1.NewTime(clusterTime.Add(-maxWarning))
 		expected := report.ValidatedTime{
 			Validated: report.Validated{
-				State:       report.Stale,
+				State:       report.Warning,
 				Description: "Replication is exceeding 2x the scheduling interval",
 			},
 			Value: &syncTime.Time,

--- a/pkg/validate/application/testdata/ok.html
+++ b/pkg/validate/application/testdata/ok.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status passed">passed</span><span class="summary">30 ok, 0 stale, 0 problem</span></div>
+      <div class="result"><span class="status passed">passed</span><span class="summary">30 ok, 0 warning, 0 problem</span></div>
       <footer><span>Created 2026-03-16T20:16:31&#43;02:00</span><span>Duration 2.21s</span></footer>
     </header>
     <main>

--- a/pkg/validate/application/testdata/problem.html
+++ b/pkg/validate/application/testdata/problem.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Application <span class="subtitle">argocd / appset-deploy-rbd</span></h1>
-      <div class="result"><span class="status failed">failed</span><span class="summary">25 ok, 2 stale, 8 problem</span></div>
+      <div class="result"><span class="status failed">failed</span><span class="summary">25 ok, 2 warning, 8 problem</span></div>
       <footer><span>Created 2026-03-16T20:19:49&#43;02:00</span><span>Duration 2.30s</span></footer>
     </header>
     <main>
@@ -34,7 +34,7 @@
                 <dd><span class="value">1m0s</span><span class="state">✅</span></dd>
                 <dt>Last Group Sync Time</dt>
                 <dd>
-                  <span class="value">2025-07-29T17:23:00Z</span><span class="state">⭕</span>
+                  <span class="value">2025-07-29T17:23:00Z</span><span class="state">⚠️</span>
                   <p class="description">Replication is exceeding 2x the scheduling interval</p>
                 </dd>
                 <dt>Action</dt>
@@ -233,7 +233,7 @@
                             </dd>
                             <dt>ClusterDataProtected</dt>
                             <dd>
-                              <span class="state">⭕</span>
+                              <span class="state">⚠️</span>
                               <p class="description">Observed generation 1 does not match object generation 2</p>
                             </dd>
                           </dl>

--- a/pkg/validate/application/testdata/problem.yaml
+++ b/pkg/validate/application/testdata/problem.yaml
@@ -26,7 +26,7 @@ applicationStatus:
       namespace: argocd
       lastGroupSyncTime:
         description: Replication is exceeding 2x the scheduling interval
-        state: stale ⭕
+        state: warning ⚠️
         value: "2025-07-29T17:23:00Z"
       schedulingInterval:
         state: ok ✅
@@ -118,7 +118,7 @@ applicationStatus:
           state: problem ❌
           type: DataReady
         - description: Observed generation 1 does not match object generation 2
-          state: stale ⭕
+          state: warning ⚠️
           type: ClusterDataProtected
         deleted:
           description: Resource was deleted
@@ -201,4 +201,4 @@ steps:
 summary:
   ok: 25
   problem: 8
-  stale: 2
+  warning: 2

--- a/pkg/validate/clusters/testdata/invalid-configmap.html
+++ b/pkg/validate/clusters/testdata/invalid-configmap.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Clusters</h1>
-      <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 3 problem</span></div>
+      <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 warning, 3 problem</span></div>
       <footer><span>Created 2026-03-23T18:20:41&#43;02:00</span><span>Duration 1.05s</span></footer>
     </header>
     <main>

--- a/pkg/validate/clusters/testdata/ok.html
+++ b/pkg/validate/clusters/testdata/ok.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Clusters</h1>
-      <div class="result"><span class="status passed">passed</span><span class="summary">90 ok, 0 stale, 0 problem</span></div>
+      <div class="result"><span class="status passed">passed</span><span class="summary">90 ok, 0 warning, 0 problem</span></div>
       <footer><span>Created 2026-03-23T18:18:13&#43;02:00</span><span>Duration 1.13s</span></footer>
     </header>
     <main>

--- a/pkg/validate/clusters/testdata/problem.html
+++ b/pkg/validate/clusters/testdata/problem.html
@@ -8,7 +8,7 @@
   <body>
     <header>
       <h1>Validate Clusters</h1>
-      <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 stale, 6 problem</span></div>
+      <div class="result"><span class="status failed">failed</span><span class="summary">18 ok, 0 warning, 6 problem</span></div>
       <footer><span>Created 2026-03-23T18:20:41&#43;02:00</span><span>Duration 1.05s</span></footer>
     </header>
     <main>

--- a/pkg/validate/command/objects.go
+++ b/pkg/validate/command/objects.go
@@ -24,7 +24,7 @@ func ValidatedCondition(
 	validated := report.ValidatedCondition{Type: condition.Type}
 
 	if condition.ObservedGeneration != obj.GetGeneration() {
-		validated.State = report.Stale
+		validated.State = report.Warning
 		validated.Description = fmt.Sprintf(
 			"Observed generation %d does not match object generation %d",
 			condition.ObservedGeneration,

--- a/pkg/validate/summary/summary.go
+++ b/pkg/validate/summary/summary.go
@@ -12,7 +12,7 @@ import (
 // Summary keys for validation reports.
 const (
 	OK      = report.SummaryKey("ok")
-	Stale   = report.SummaryKey("stale")
+	Warning = report.SummaryKey("warning")
 	Problem = report.SummaryKey("problem")
 )
 
@@ -21,20 +21,20 @@ func AddValidation(s *report.Summary, v report.Validation) {
 	switch v.GetState() {
 	case report.OK:
 		s.Add(OK)
-	case report.Stale:
-		s.Add(Stale)
+	case report.Warning:
+		s.Add(Warning)
 	case report.Problem:
 		s.Add(Problem)
 	}
 }
 
-// HasIssues returns true if there are any problems or stale results.
+// HasIssues returns true if there are any problems or warning results.
 func HasIssues(s *report.Summary) bool {
-	return s.Get(Stale) > 0 || s.Get(Problem) > 0
+	return s.Get(Warning) > 0 || s.Get(Problem) > 0
 }
 
 // String returns a string representation of a validation summary.
 func String(s *report.Summary) string {
-	return fmt.Sprintf("%d ok, %d stale, %d problem",
-		s.Get(OK), s.Get(Stale), s.Get(Problem))
+	return fmt.Sprintf("%d ok, %d warning, %d problem",
+		s.Get(OK), s.Get(Warning), s.Get(Problem))
 }

--- a/pkg/validate/summary/summary_test.go
+++ b/pkg/validate/summary/summary_test.go
@@ -14,14 +14,14 @@ func TestSummaryAdd(t *testing.T) {
 
 	AddValidation(s, &report.Validated{State: report.OK})
 	AddValidation(s, &report.Validated{State: report.OK})
-	AddValidation(s, &report.Validated{State: report.Stale})
+	AddValidation(s, &report.Validated{State: report.Warning})
 	AddValidation(s, &report.Validated{State: report.OK})
-	AddValidation(s, &report.Validated{State: report.Stale})
+	AddValidation(s, &report.Validated{State: report.Warning})
 	AddValidation(s, &report.Validated{State: report.Problem})
 
 	expected := report.Summary{
 		OK:      3,
-		Stale:   2,
+		Warning: 2,
 		Problem: 1,
 	}
 	if !s.Equal(&expected) {
@@ -37,11 +37,11 @@ func TestSummaryHasProblems(t *testing.T) {
 	}{
 		{"empty", &report.Summary{}, false},
 		{"ok", &report.Summary{OK: 5}, false},
-		{"only stale", &report.Summary{Stale: 2}, true},
+		{"only warning", &report.Summary{Warning: 2}, true},
 		{"only problem", &report.Summary{Problem: 4}, true},
 		{
-			"problem and stale",
-			&report.Summary{Stale: 2, Problem: 3},
+			"problem and warning",
+			&report.Summary{Warning: 2, Problem: 3},
 			true,
 		},
 	}
@@ -57,7 +57,7 @@ func TestSummaryString(t *testing.T) {
 		OK:      1,
 		Problem: 2,
 	}
-	expected := "1 ok, 0 stale, 2 problem"
+	expected := "1 ok, 0 warning, 2 problem"
 	if String(s) != expected {
 		t.Fatalf("expected %q, got %q", expected, String(s))
 	}


### PR DESCRIPTION
The "stale" name originated from the condition observed generation
check, but we use this state for other issues like lagging
replication. "Warning" is more generic and better describes the
intent - warn about unexpected state that may be a problem but we
are not sure about.

The stale icon (⭕) was too similar to the error icon (❌). The
warning icon (⚠️) is standard and more recognizable.

The change renames the Stale constant to Warning, updates the icon,
and updates all strings and test data.

## States

With this change we have clear indication of issues:

| state   | icon | meaning                                   |
|---------|------|-------------------------------------------|
| ok      |  ✅  | expected state                            |
| warning |  ⚠️   | potential issue that needs investigation  |
| problem |  ❌  | unexpected state that likely needs action |

## Example YAML fragment

```yaml
name: appset-deploy-rbd
namespace: argocd
lastGroupSyncTime:
  description: Replication is exceeding 2x the scheduling interval
  state: warning ⚠️
  value: "2025-07-29T17:23:00Z"
schedulingInterval:
  state: ok ✅
  value: 1m0s
phase:
  state: ok ✅
  value: FailedOver
progression:
  description: Waiting for progression "Completed"
  state: problem ❌
  value: Cleaning Up
```

## Example run - validate application with problems

<img width="1766" height="986" alt="Screenshot 2026-05-13 at 0 52 14" src="https://github.com/user-attachments/assets/27c7ddb5-bc08-4136-b595-d06d8a600a2b" />

---
Based on #445 to avoid rebase - review only the last commit.
Fixes: #383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Validation reports now use "warning" instead of "stale" and show counts as "ok, warning, problem".
  * Replication status messages now say "lagging" instead of "stale".
  * Warning indicators use the ⚠️ icon and foldable report sections may auto-expand when issues exist.

* **Documentation**
  * Command and report examples updated to reflect new terminology and summary format.

* **Tests**
  * Test fixtures and expectations updated to use "warning" semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramenctl/pull/446)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->