### PR TITLE
Add AI skills for ramenctl commands

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,152 @@
+<!-- SPDX-FileCopyrightText: The RamenDR authors -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# ramenctl AI Skills
+
+These skills teach an AI assistant how to drive **ramenctl** for disaster
+recovery on your clusters. Start with the scene below — it shows what
+this feels like in practice. **Init** (create a config) is the only step
+that must come before everything else; after that, use whichever command
+you need. Everything after the scene is detail: which skills exist, how to
+name report directories, and how to install them in your tool.
+
+## Example session
+
+The following is a short screenplay-style scene: a human and an agent
+use the ramenctl skills. (Monospace block so it reads like a script and
+renders with a distinct background on GitHub and most viewers.)
+
+```text
+INT. CURSOR CHAT — DAY
+
+USER
+        Help me set up ramenctl for my clusters. My kubeconfigs are in
+        ocp/: hub.yaml is the hub, c1.yaml and c2.yaml are the managed
+        clusters.
+
+AGENT
+        (Runs ramenctl init, fills kubeconfigs, reads ClusterClaims on c1
+        and c2, matches names on the hub, sets clusterSet.)
+        Your config is ready.
+
+USER
+        Can you check the clusters?
+
+AGENT
+        (Runs ramenctl validate clusters -o ocp/clusters.)
+        Validation completed (91 ok, 0 warning, 0 problem).
+        (Opens validate-clusters.html in the browser.)
+
+USER
+        Validate an application too.
+
+AGENT
+        (Lists DRPCs on the hub.)
+        I found two applications:
+          1. rbd4 (openshift-dr-ops) — FailedOver
+          2. appset-deploy-rbd (openshift-gitops) — Deployed
+        Which one should I validate?
+
+USER
+        rbd4.
+
+AGENT
+        (Runs ramenctl validate application --name rbd4 --namespace
+        openshift-dr-ops -o ocp/rbd4.)
+        All clear. Opening validate-application.html.
+
+USER
+        You are a very skillful agent!
+
+AGENT
+        Glad it helped.
+```
+
+## Available skills
+
+| Skill | Description |
+|-------|-------------|
+| [ramenctl-init](ramenctl-init/SKILL.md) | Create a configuration file for your clusters |
+| [ramenctl-validate-clusters](ramenctl-validate-clusters/SKILL.md) | Validate disaster recovery cluster configuration |
+| [ramenctl-validate-application](ramenctl-validate-application/SKILL.md) | Validate a DR-protected application |
+| [ramenctl-gather-application](ramenctl-gather-application/SKILL.md) | Gather diagnostic data for a protected application |
+| [ramenctl-test-run](ramenctl-test-run/SKILL.md) | Run disaster recovery flow tests |
+| [ramenctl-test-clean](ramenctl-test-clean/SKILL.md) | Clean up after test runs |
+
+## Output directory tips
+
+Most commands require an `-o <output-dir>` flag. A few tips:
+
+- Name after the environment, optionally with a date (e.g., `myenv` or
+  `myenv-2026-05-15`).
+- Multiple commands can share one directory — each creates its own files
+  (`validate-clusters.yaml`, `validate-application.yaml`, etc.) with no
+  conflicts. Running the same command again creates numbered files
+  (`validate-clusters-2.yaml`, etc.).
+- This makes it easy to attach all info to a bug report as one archive.
+- If the archive is too large for upload limits (e.g., GitHub's 25 MB),
+  use subdirectories like `myenv/clusters` and `myenv/app-name`.
+
+## Common tasks (no fixed order)
+
+The only step everyone shares: run **init** (create and edit a config file)
+before any other ramenctl command. Validate, gather, and test all need that
+configuration.
+
+After that, there is no typical sequence — pick what matches your goal.
+
+- **Cluster health**: Use validate clusters when you want to know whether
+  DR is wired correctly across the hub and managed clusters.
+- **One application**: Use validate application when you care about a
+  specific protected app (after failover, relocate, or when something looks
+  wrong). When investigating issues, the agent should suggest also running
+  validate clusters (e.g. `<env>/clusters`) so developers get both the app
+  slice and the cluster-wide DR picture for triage or bug reports.
+- **End-to-end DR**: Use test run (and test clean) when you want to exercise
+  the full flow with a small workload from the config.
+- **Snapshot for debugging**: Developers often use gather application to
+  pull a full picture of an app (namespaces, cluster resources, S3) for a bug
+  report or offline inspection — with or without running validate first.
+
+## Using with AI tools
+
+The skills are plain markdown files with workflow instructions. They work
+with any AI coding assistant that can read markdown.
+
+### Cursor
+
+Copy the `skills/` directory to `~/.cursor/skills/` for personal use, or
+to `.cursor/skills/` in your project:
+
+```console
+$ cp -r skills/ ~/.cursor/skills/
+```
+
+Cursor discovers skills automatically from the YAML frontmatter in each
+`SKILL.md` file.
+
+### Claude Code
+
+Add to your `CLAUDE.md` or reference directly. For example, to include
+all skills:
+
+```console
+$ cat skills/*/SKILL.md >> CLAUDE.md
+```
+
+Or reference individual skills when starting a conversation:
+
+```text
+Read skills/ramenctl-validate-clusters/SKILL.md and help me validate my clusters.
+```
+
+### Other tools (Codex, Aider, OpenCode, etc.)
+
+These are standard markdown files. You can:
+
+- Concatenate them into whatever instruction file your tool uses
+- Reference them directly in your prompts
+- Copy the content into your tool's configuration
+
+The YAML frontmatter at the top of each file (`---\nname: ...\n---`) is
+standard metadata that most tools ignore gracefully.

--- a/skills/ramenctl-gather-application/SKILL.md
+++ b/skills/ramenctl-gather-application/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ramenctl-gather-application
+description: >-
+  Gather diagnostic data for a DR-protected application using ramenctl gather
+  application. Use when the user wants to collect data for troubleshooting,
+  create a bug report, or inspect application resources across clusters.
+---
+
+# ramenctl gather application
+
+Gather data for a specific DR-protected application across the hub, managed
+clusters, and S3 storage. Unlike `validate application`, this command only
+collects data without validating it.
+
+## Prerequisites
+
+- `ramenctl` installed
+- A configuration file with cluster kubeconfigs (see ramenctl-init skill)
+- At least one DR-protected application in the clusters
+
+## Workflow
+
+### Step 1: Look up protected applications
+
+List DRPCs on the hub using the hub kubeconfig from the ramenctl config file:
+
+```console
+$ kubectl get drpc -A --kubeconfig <hub-kubeconfig>
+NAMESPACE   NAME                   AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
+argocd      appset-deploy-rbd      69m   dr1                dr2               Relocate       Relocated
+```
+
+Present the list and let the user choose which application to gather
+data for.
+
+### Step 2: Run gather application
+
+Use `<env>/<app-name>` for the output directory, e.g., `myenv/myapp`.
+
+```console
+$ ramenctl gather application --name <drpc-name> --namespace <namespace> -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+On success the command ends with:
+
+```console
+✅ Gather completed
+```
+
+On failure, check `<output-dir>/gather-application.log` for details.
+
+### Step 4: Inspect gathered data
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `gather-application.yaml` | Report describing the gather operation |
+| `gather-application.log` | Detailed log |
+| `gather-application.data/` | Gathered resources |
+
+#### Gathered data structure
+
+One directory per cluster plus `s3/`. Each cluster directory has
+`cluster/` for cluster-scoped resources and `namespaces/` for namespaced
+resources. Ramen operator logs are gathered under
+`namespaces/ramen-system/pods/`.
+
+```console
+$ tree -L3 <output-dir>/gather-application.data
+gather-application.data/
+├── dr1/
+│   ├── cluster/
+│   │   ├── namespaces/
+│   │   ├── persistentvolumes/
+│   │   └── storage.k8s.io/
+│   └── namespaces/
+│       ├── e2e-appset-deploy-rbd/
+│       └── ramen-system/
+├── dr2/
+│   ├── cluster/
+│   └── namespaces/
+│       ├── e2e-appset-deploy-rbd/
+│       └── ramen-system/
+├── hub/
+│   ├── cluster/
+│   └── namespaces/
+│       ├── argocd/
+│       └── ramen-system/
+└── s3/
+    ├── minio-on-dr1/
+    │   └── test-appset-deploy-rbd/
+    └── minio-on-dr2/
+        └── test-appset-deploy-rbd/
+```
+
+#### Inspecting gathered resources
+
+Check VRG protected PVC conditions:
+
+```console
+$ yq '.status.protectedPVCs[0].conditions' < <output-dir>/gather-application.data/<cluster>/namespaces/<ns>/ramendr.openshift.io/volumereplicationgroups/<name>.yaml
+```
+
+Search ramen operator logs for errors related to the app:
+
+```console
+$ grep -E 'ERROR.+<app-name>' <output-dir>/gather-application.data/<cluster>/namespaces/ramen-system/pods/*/manager/current.log
+```
+
+## Notes
+
+- Secrets in gathered data are automatically sanitized.
+- To report DR issues, archive the entire output directory and upload it
+  to the issue tracker.
+- Use `ramenctl validate application` if you need both data collection
+  and problem detection.

--- a/skills/ramenctl-init/SKILL.md
+++ b/skills/ramenctl-init/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: ramenctl-init
+description: >-
+  Create a ramenctl configuration file for disaster recovery clusters using
+  ramenctl init. Use when the user wants to initialize, configure, or set up
+  ramenctl for their clusters.
+---
+
+# ramenctl init
+
+Create a configuration file required by all other ramenctl commands.
+
+## Workflow
+
+### Step 1: Ask the user about their environment
+
+Before creating the config, ask:
+- Do they have a ramen testing environment with an envfile?
+- Where are their kubeconfig files? The user must specify which
+  kubeconfig is the hub and which are the managed clusters (c1, c2).
+- Do they want a custom config file name (default is `config.yaml`)?
+
+### Step 2: Create the configuration file
+
+**For real clusters:**
+
+```console
+$ ramenctl init
+
+✅ Created config file "config.yaml" - please modify for your clusters
+```
+
+**For a ramen testing environment with an envfile:**
+
+```console
+$ ramenctl init --envfile <path-to-envfile>
+⭐ Using envfile "<path-to-envfile>"
+
+✅ Created config file "config.yaml" - please modify for your clusters
+```
+
+**To use a custom config name:**
+
+```console
+$ ramenctl init --config myenv.yaml
+
+✅ Created config file "myenv.yaml" - please modify for your clusters
+```
+
+The command creates `config.yaml` (or the specified name) in the current
+directory. It fails if the file already exists.
+
+### Step 3: Configure clusters
+
+Open the generated file and help the user set the kubeconfig paths:
+
+```yaml
+clusters:
+  hub:
+    kubeconfig: my-hub.yaml
+  passive-hub:
+    kubeconfig: ""
+  c1:
+    kubeconfig: my-c1.yaml
+  c2:
+    kubeconfig: my-c2.yaml
+```
+
+Set `passive-hub` kubeconfig for optional passive hub cluster, or leave
+empty if not using passive hub.
+
+### Step 4: Discover and configure clusterSet
+
+The clusterSet can be discovered automatically using the kubeconfigs from
+step 3. Follow this procedure:
+
+**4a. Get the OCM cluster names for c1 and c2.**
+
+Kubernetes does not have a built-in cluster name concept. In OCM, each
+managed cluster reports its name via a `ClusterClaim` resource. Get the
+OCM name from each managed cluster:
+
+```console
+$ kubectl get clusterclaim name --kubeconfig <c1-kubeconfig> -o jsonpath='{.spec.value}'
+dr1
+```
+
+```console
+$ kubectl get clusterclaim name --kubeconfig <c2-kubeconfig> -o jsonpath='{.spec.value}'
+dr2
+```
+
+**If the ClusterClaim command fails**, stop and report the error to the
+user. ramenctl uses the same mechanism to resolve cluster names, so it
+will not work without it. Common errors:
+
+- `error: the server doesn't have a resource type "clusterclaim"` — OCM
+  klusterlet is not installed on the cluster.
+- `Error from server (NotFound)` — OCM is installed but the `name`
+  claim hasn't been created yet.
+- Connection or authentication errors — the kubeconfig is wrong, expired,
+  or lacks permissions.
+
+**4b. List managed clusters and their clusterSets on the hub.**
+
+```console
+$ kubectl get managedclusters --kubeconfig <hub-kubeconfig> \
+  -L cluster.open-cluster-management.io/clusterset
+NAME            HUB ACCEPTED   MANAGED CLUSTER URLS                 JOINED   AVAILABLE   AGE   CLUSTERSET
+my-c1           true           https://api.my-c1.example.com:6443   True     True        16d   dr-clusters
+my-c2           true           https://api.my-c2.example.com:6443   True     True        16d   dr-clusters
+local-cluster   true           https://api.my-hub.example.com:6443  True     True        16d   default
+```
+
+**4c. Find the clusterSet that contains both clusters.**
+
+Match the OCM names from step 4a against the `NAME` column, and read the
+`CLUSTERSET` column.
+
+- If both clusters are in the same clusterSet, use that value.
+- If the clusters are in different clusterSets, something is
+  misconfigured. Ask the user to verify.
+- Ignore the `global` clusterSet (it automatically includes all clusters
+  and is not suitable for DR).
+
+With the default OCM `ExclusiveClusterSetLabel` selector type, a cluster
+belongs to exactly one clusterSet (set via the
+`cluster.open-cluster-management.io/clusterset` label). If there are
+multiple non-global clusterSets, present the options and let the user
+choose.
+
+**4d. Set the clusterSet in the config file.**
+
+```yaml
+clusterSet: dr-clusters
+```
+
+### Step 5: Configure test options (optional)
+
+Ask the user if they plan to run DR tests with `ramenctl test run`. If
+they only need `validate` or `gather` commands, the configuration is
+complete — skip to step 6.
+
+If the user wants to run tests, the following additional sections need
+to be configured:
+- **repo** - Git repository URL and branch for test workloads
+- **drPolicy** - DRPolicy name in the hub cluster
+- **pvcSpecs** - Storage class names and access modes
+- **deployers** - Deployer configurations (appset, subscr, disapp)
+- **tests** - Test cases (workload + deployer + pvcSpec combinations)
+
+### Step 6: Done
+
+There is no standalone config validation command yet. The configuration
+will be validated automatically when running any ramenctl command
+(`validate clusters`, `validate application`, `test run`, etc.).
+
+## Reference
+
+- Default config file: `config.yaml` (used by all commands unless overridden
+  with `--config`)
+- Multiple config files can coexist for different environments or test sets
+- When using `--envfile`, the file is pre-populated but may still need
+  adjustments

--- a/skills/ramenctl-test-clean/SKILL.md
+++ b/skills/ramenctl-test-clean/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: ramenctl-test-clean
+description: >-
+  Clean up after ramenctl test run using ramenctl test clean. Use when the user
+  wants to clean up test resources, remove test artifacts, or reset after a
+  test run.
+---
+
+# ramenctl test clean
+
+Delete resources created by `ramenctl test run`.
+
+## Prerequisites
+
+- A previous `ramenctl test run` was executed
+- If the test failed due to an infrastructure issue (e.g., rbd-mirror
+  down), **restore the infrastructure first** before cleaning. Cleaning
+  before restoring may fail or leave leftovers.
+
+## Workflow
+
+### Step 1: Run test clean
+
+Use the same output directory and config file as the test run:
+
+```console
+$ ramenctl test clean -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command unprotects and undeploys test applications, then cleans the
+test environment (channels, namespaces).
+
+### Step 2: Check the result
+
+**On success:**
+
+```console
+✅ passed (N passed, 0 failed, 0 skipped)
+```
+
+The output directory gains additional files after clean:
+
+| File | Purpose |
+|------|---------|
+| `test-clean.yaml` | Clean operation report |
+| `test-clean.log` | Detailed log |
+
+## Notes
+
+- Always clean up after test runs to avoid leftover resources affecting
+  subsequent tests.
+- If clean fails, check the log for details. You may need to manually
+  delete stuck resources.

--- a/skills/ramenctl-test-run/SKILL.md
+++ b/skills/ramenctl-test-run/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: ramenctl-test-run
+description: >-
+  Run disaster recovery tests using ramenctl test run. Use when the user wants
+  to test DR flow, verify failover/relocate works, or run end-to-end DR tests.
+---
+
+# ramenctl test run
+
+Run a disaster recovery flow test with one or more tiny applications defined
+in the configuration file.
+
+## Prerequisites
+
+- `ramenctl` installed
+- A configuration file with both common options and test options configured
+  (see ramenctl-init skill). The test command needs `repo`, `drPolicy`,
+  `pvcSpecs`, `deployers`, and `tests` sections.
+- Clusters fully configured for DR (DRPolicy, DRClusters, S3, storage
+  replication).
+
+## Workflow
+
+### Step 1: Verify the configuration
+
+Help the user check their config file has the test sections:
+
+- **drPolicy** - Must match an actual DRPolicy in the hub cluster
+- **pvcSpecs** - Storage class names must match the managed clusters
+- **tests** - Each test specifies workload + deployer + pvcSpec
+
+Available deployer types: `appset`, `subscr`, `disapp`, `disapp-recipe`,
+`disapp-recipe-check`, `disapp-recipe-exec`, `disapp-recipe-check-exec`.
+
+### Step 2: Run the test
+
+Use `<env>/test` for the output directory, e.g., `myenv/test`.
+
+```console
+$ ramenctl test run -o <output-dir>
+```
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The test runs through the full DR flow for each test case:
+deploy, protect, failover, relocate, unprotect, undeploy.
+
+**This typically takes 15-20 minutes per test case.** Multiple test cases
+run in parallel.
+
+### Step 3: Check the result
+
+**On success:**
+
+```console
+✅ passed (N passed, 0 failed, 0 skipped)
+```
+
+**On failure** the command automatically gathers diagnostic data from all
+clusters and S3 into `test-run.data/`:
+
+```console
+❌ failed (N passed, M failed, 0 skipped)
+```
+
+### Step 4: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `test-run.yaml` | Machine-readable test report |
+| `test-run.log` | Detailed log |
+| `test-run.data/` | Gathered data (only present on failure) |
+
+Useful commands:
+
+Overall status:
+
+```console
+$ yq '.status' < <output-dir>/test-run.yaml
+```
+
+Individual step status and durations:
+
+```console
+$ yq '.steps[-1].items' < <output-dir>/test-run.yaml
+```
+
+Test events from the log:
+
+```console
+$ grep -E '(INFO|ERROR).+<app-name>' <output-dir>/test-run.log
+```
+
+The `test-run.yaml` report contains the config used, each test step with
+its status and duration, and a summary with pass/fail/skip counts.
+
+### Step 5: Handle failures
+
+If the test failed:
+
+1. Check `test-run.yaml` to see which step failed
+2. Inspect `test-run.data/` for gathered resources and logs — it has the
+   same structure as validate-application gathered data (one directory per
+   cluster plus `s3/`)
+3. Check DRPC status, VRG conditions, and operator logs
+4. Fix the underlying issue
+5. **Always clean up** before re-running (see ramenctl-test-clean skill)
+
+### Step 6: Clean up
+
+After the test (pass or fail), always clean up:
+
+```console
+$ ramenctl test clean -o <output-dir>
+```
+
+## Notes
+
+- Pressing Ctrl+C cancels gracefully. The current step may take up to
+  10 minutes to complete. Partial results are saved but data is not
+  gathered for incomplete tests.
+- To report DR issues, archive the entire output directory.

--- a/skills/ramenctl-validate-application/SKILL.md
+++ b/skills/ramenctl-validate-application/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: ramenctl-validate-application
+description: >-
+  Validate a DR-protected application using ramenctl validate application.
+  Use when the user wants to check an application is ok, check application
+  DR health, troubleshoot a protected application, or verify application
+  status after failover/relocate. When triaging or reporting bugs, also
+  suggest ramenctl validate clusters so the user has both the app report
+  and the cluster-wide DR report.
+---
+
+# ramenctl validate application
+
+Validate a specific DR-protected application by gathering related namespaces
+from all clusters and S3 data, and inspecting the gathered resources.
+
+## Prerequisites
+
+- `ramenctl` installed
+- A configuration file with cluster kubeconfigs (see ramenctl-init skill)
+- At least one DR-protected application in the clusters
+
+## Workflow
+
+### Step 1: Look up protected applications
+
+List DRPCs on the hub using the hub kubeconfig from the ramenctl config file:
+
+```console
+$ kubectl get drpc -A --kubeconfig <hub-kubeconfig>
+NAMESPACE   NAME                   AGE   PREFERREDCLUSTER   FAILOVERCLUSTER   DESIREDSTATE   CURRENTSTATE
+argocd      appset-deploy-rbd      69m   dr1                dr2               Relocate       Relocated
+```
+
+Present the list and let the user choose which application to validate.
+The `NAME` and `NAMESPACE` columns map to the `--name` and `--namespace`
+flags.
+
+### Step 2: Run validate application
+
+Use `<env>/<app-name>` for the output directory, e.g., `myenv/myapp`.
+
+```console
+$ ramenctl validate application --name <drpc-name> --namespace <namespace> -o <output-dir> --interactive=false
+```
+
+`--interactive=false` prevents ramenctl from opening a browser—you open the
+report yourself in Step 4.
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+**On success:**
+
+```console
+✅ Validation completed (N ok, 0 warning, 0 problem)
+```
+
+**On problems** the command exits with a non-zero exit code:
+
+```console
+❌ Validation completed (N ok, M warning, P problem)
+```
+
+When validation **finishes and writes a report**, a non-zero exit always means
+there are problems **in** that report. If the command **fails before** a
+report is written (early error), there may be no HTML—use the log and console
+output instead.
+
+### Step 4: Open the HTML report
+
+If `<output-dir>/validate-application.html` exists, open it as soon as `ramenctl
+validate application` has returned. Do this for **both** a fully successful run
+and a completed run that exited non-zero: in the latter case the report always
+describes problems. If the command failed **before** the HTML file was created,
+skip opening—there is nothing to show in the browser yet.
+
+Do **not** skip this step when the HTML file exists unless the user clearly
+does not want the graphical report.
+
+**How to open:** tell them the file path, or run `open` (macOS), `xdg-open`
+(Linux, when available), or open the path in Windows Explorer / `start` on
+the machine that has the file.
+
+### Step 5: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `validate-application.yaml` | Machine and human readable report |
+| `validate-application.html` | HTML report |
+| `validate-application.log` | Detailed log |
+| `validate-application.data/` | Raw resources from all clusters + S3 |
+
+Read the application status:
+
+```console
+$ yq '.applicationStatus' < <output-dir>/validate-application.yaml
+```
+
+#### What the report validates
+
+The `applicationStatus` section in the YAML report validates the
+following. Every item shows `state: ok ✅` when healthy, or a
+problem/warning state with a descriptive message.
+
+**Hub (DRPC):**
+- Exists, DR policy, action (Failover/Relocate), phase, progression
+  (should be Completed for a stable app), conditions (Available,
+  PeerReady, Protected)
+
+**Primary cluster (VRG):**
+- State is Primary, conditions (DataReady, ClusterDataReady,
+  ClusterDataProtected, KubeObjectsReady), protected PVCs with phase
+  (Bound), replication type (volrep/volsync), and PVC conditions
+
+**Secondary cluster (VRG):**
+- State is Secondary, conditions
+
+**S3 profiles:**
+- Application data gathered successfully from each profile
+
+#### Gathered data structure
+
+```console
+$ tree -L3 <output-dir>/validate-application.data
+validate-application.data/
+├── <cluster>/
+│   ├── cluster/
+│   │   ├── namespaces/
+│   │   ├── persistentvolumes/
+│   │   └── storage.k8s.io/
+│   └── namespaces/
+│       └── <app-namespace>/
+├── ...
+└── s3/
+    └── <profile-name>/
+        └── <app-namespace>/
+```
+
+### Step 6: Troubleshoot problems
+
+This section is an **initial draft** — DR troubleshooting is hard and
+needs more playbooks over time (for example a future analyze skill).
+
+If problems were found, help the user understand them:
+
+1. Read the YAML report — look for `state:` values that are not `ok ✅`
+2. Check the log file for error details
+3. Inspect raw resources in `validate-application.data/`
+4. Summarize the findings and suggest what the user should look at
+
+Useful commands for inspecting gathered data:
+
+Check VRG status:
+
+```console
+$ yq '.status' < <output-dir>/validate-application.data/<cluster>/namespaces/<ns>/ramendr.openshift.io/volumereplicationgroups/<name>.yaml
+```
+
+Search ramen operator logs for errors related to the app:
+
+```console
+$ grep -E 'ERROR.+<app-name>' <output-dir>/validate-application.data/<cluster>/namespaces/ramen-system/pods/*/manager/current.log
+```
+
+### Step 7: Suggest validate clusters
+
+After completing the application validation, suggest also running
+`ramenctl validate clusters` into a sibling output directory such as
+`<env>/clusters`. When they agree (or you run it for them), follow the
+**ramenctl-validate-clusters** skill end to end.
+
+Why this helps: the application report covers one DRPC, its namespaces, and
+S3 data (S3 reachability is already tested by the gather step). The cluster
+report adds hub and managed-cluster DR plumbing (operators, DRClusters,
+DRPolicies, ramen configmaps) that the application report does not cover.
+Having both makes it easier to see whether a problem is app-specific or
+infrastructure-wide. If the user already has a fresh cluster validation in
+the same environment, they can skip this.
+
+## Notes
+
+- Secrets in gathered data are automatically sanitized.
+- To report DR issues, archive the entire output directory.

--- a/skills/ramenctl-validate-clusters/SKILL.md
+++ b/skills/ramenctl-validate-clusters/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: ramenctl-validate-clusters
+description: >-
+  Validate disaster recovery cluster configuration using ramenctl validate
+  clusters. Use when the user wants to check clusters are ok, verify DR
+  setup, check cluster health, or troubleshoot cluster-level DR problems.
+---
+
+# ramenctl validate clusters
+
+Validate disaster recovery clusters by gathering cluster-scoped and ramen
+resources from all clusters, and checking that S3 endpoints are accessible.
+
+## Prerequisites
+
+- `ramenctl` installed
+- A configuration file with cluster kubeconfigs (see ramenctl-init skill)
+
+## Workflow
+
+### Step 1: Pick an output directory
+
+Ask the user where to store the report. Suggest `<env>/clusters` or
+`<env>-<date>/clusters`, e.g., `myenv/clusters`.
+
+### Step 2: Run validate clusters
+
+```console
+$ ramenctl validate clusters -o <output-dir> --interactive=false
+```
+
+`--interactive=false` prevents ramenctl from opening a browser—you open the
+report yourself in Step 4.
+
+Use `--config <file>` if the config file is not the default `config.yaml`.
+
+The command takes a few seconds on local clusters and about a minute on
+remote clusters.
+
+### Step 3: Check the result
+
+**On success** the last line shows:
+
+```console
+✅ Validation completed (N ok, 0 warning, 0 problem)
+```
+
+**On problems** the summary includes warning or problem counts and the
+command exits with a non-zero exit code:
+
+```console
+❌ Validation completed (N ok, M warning, P problem)
+```
+
+When validation **finishes and writes a report**, a non-zero exit always means
+there are problems **in** that report. If the command **fails before** a
+report is written (early error), there may be no HTML—use the log and console
+output instead.
+
+### Step 4: Open the HTML report
+
+If `<output-dir>/validate-clusters.html` exists, open it as soon as `ramenctl
+validate clusters` has returned. Do this for **both** a fully successful run and
+a completed run that exited non-zero: in the latter case the report always
+describes problems. If the command failed **before** the HTML file was created,
+skip opening—there is nothing to show in the browser yet.
+
+Do **not** skip this step when the HTML file exists unless the user clearly
+does not want the graphical report.
+
+**How to open:** tell them the file path, or run `open` (macOS), `xdg-open`
+(Linux, when available), or open the path in Windows Explorer / `start` on
+the machine that has the file.
+
+### Step 5: Inspect the report
+
+The output directory contains:
+
+| File | Purpose |
+|------|---------|
+| `validate-clusters.yaml` | Machine and human readable report |
+| `validate-clusters.html` | HTML report |
+| `validate-clusters.log` | Detailed log for troubleshooting |
+| `validate-clusters.data/` | Raw resources gathered from all clusters |
+
+Read the YAML report to understand the status:
+
+```console
+$ yq '.clustersStatus' < <output-dir>/validate-clusters.yaml
+```
+
+#### What the report validates
+
+The `clustersStatus` section in the YAML report validates the following.
+Every item shows `state: ok ✅` when healthy, or a problem/warning state
+with a descriptive message.
+
+**Each managed cluster:**
+- Ramen configmap: exists, controller type is `dr-cluster`, S3 store
+  profiles with bucket, endpoint, region, and secret fingerprints
+- Ramen deployment: exists, conditions (Available, Progressing), replicas
+
+**Hub cluster:**
+- DRClusters: exist, conditions (Fenced, Clean, Validated), phase
+- DRPolicies: exist, conditions (Validated), DR clusters, scheduling
+  interval
+- Ramen configmap: controller type is `dr-hub`, S3 store profiles
+- Ramen deployment: exists, conditions, replicas
+
+**S3 profiles:**
+- Each profile accessible from the machine running ramenctl
+
+Secret values are validated using sanitized fingerprints, allowing
+comparison across clusters without exposing secrets.
+
+#### Gathered data structure
+
+```console
+$ tree -L3 <output-dir>/validate-clusters.data
+validate-clusters.data/
+├── <cluster>/
+│   ├── cluster/
+│   │   ├── apiextensions.k8s.io/
+│   │   ├── namespaces/
+│   │   ├── nodes/
+│   │   ├── ramendr.openshift.io/
+│   │   ├── storage.k8s.io/
+│   │   └── ...
+│   └── namespaces/
+│       └── ramen-system/
+└── ...
+```
+
+### Step 6: Troubleshoot problems
+
+This section is an **initial draft** — DR troubleshooting is hard and
+needs more playbooks over time (for example a future analyze skill).
+
+If problems were found, help the user understand them:
+
+1. Read the YAML report — look for `state:` values that are not `ok ✅`
+2. Check the log file for error details
+3. Inspect raw resources in `validate-clusters.data/`
+4. Summarize the findings and suggest what the user should look at
+
+## Notes
+
+- To report DR issues, archive the entire output directory and upload it
+  to the issue tracker.


### PR DESCRIPTION
Ship a `skills/` tree so humans and agents know how to drive **ramenctl** for DR: init, validate clusters, validate application, gather application, test run, and test clean. Each skill is plain markdown with YAML frontmatter (Cursor discovers it); the README explains how to copy the folder into other tools too.

## Why this is fun: a scene

This is the same example that opens `skills/README.md` — a tiny screenplay so you can *feel* what we are enabling before you read any tables.

```text
INT. CURSOR CHAT — DAY

USER
        Help me set up ramenctl for my clusters. My kubeconfigs are in
        ocp/: hub.yaml is the hub, c1.yaml and c2.yaml are the managed
        clusters.

AGENT
        (Runs ramenctl init, fills kubeconfigs, reads ClusterClaims on c1
        and c2, matches names on the hub, sets clusterSet.)
        Your config is ready.

USER
        Can you check the clusters?

AGENT
        (Runs ramenctl validate clusters -o ocp/clusters.)
        Validation completed (91 ok, 0 warning, 0 problem).
        (Opens validate-clusters.html in the browser.)

USER
        Validate an application too.

AGENT
        (Lists DRPCs on the hub.)
        I found two applications:
          1. rbd4 (openshift-dr-ops) — FailedOver
          2. appset-deploy-rbd (openshift-gitops) — Deployed
        Which one should I validate?

USER
        rbd4.

AGENT
        (Runs ramenctl validate application --name rbd4 --namespace
        openshift-dr-ops -o ocp/rbd4.)
        All clear. Opening validate-application.html.

USER
        You are a very skillful agent!

AGENT
        Glad it helped.
```

## What is in the box

- **README**: install hints (Cursor, Claude Code, others), output-directory tips, common tasks, and the scene above up front.
- **Skills**: step-by-step for each command; init includes clusterSet discovery via ClusterClaims; validate-application asks the user which kubeconfig is hub vs managed, suggests **validate clusters** for triage/bugs, and calls troubleshooting an initial draft where we expect more playbooks later.

## How we checked it

Exercised init, validate clusters, validate application, and gather application against real clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ramenctl AI Skills documentation for init, validate clusters, validate application, gather application, test run, and test clean.
  * Each guide provides prerequisites, step‑by‑step workflows, expected outputs and directory conventions, troubleshooting/triage steps, artifact inspection guidance, and best practices for DR testing, cleanup, and reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramenctl/pull/452)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->