### PR TITLE
Do not create HTML report on early failures

### DIFF
--- a/pkg/command/browser.go
+++ b/pkg/command/browser.go
@@ -5,6 +5,7 @@ package command
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -18,7 +19,9 @@ import (
 func (c *Command) BrowseReport() {
 	path := c.ReportFile("html")
 	if _, err := os.Stat(path); err != nil {
-		c.log.Warnf("Skipping browse %q: %s", path, err)
+		if !errors.Is(err, os.ErrNotExist) {
+			c.log.Warnf("Skipping browse %q: %s", path, err)
+		}
 		return
 	}
 

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -167,17 +167,17 @@ func (c *Command) OpenReport(format string) (*os.File, error) {
 func (c *Command) WriteYAMLReport(r any) {
 	file, err := c.OpenReport("yaml")
 	if err != nil {
-		console.Error("failed to open report file: %s", err)
+		console.Error("Failed to open report file: %s", err)
 		return
 	}
 	defer file.Close()
 
 	if err := report.WriteYAML(file, r); err != nil {
-		console.Error("failed to write report: %s", err)
+		console.Error("Failed to write report: %s", err)
 		return
 	}
 
 	if err := file.Close(); err != nil {
-		console.Error("failed to close report file: %s", err)
+		console.Error("Failed to close report file: %s", err)
 	}
 }

--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"strings"
 	stdtime "time"
 
 	"github.com/nirs/kubectl-gather/pkg/gather"
@@ -168,9 +169,14 @@ func (c *Command) inspectApplication() ([]string, bool) {
 		if errors.Is(err, context.Canceled) {
 			console.Error("Canceled %s", step.Name)
 			step.Status = report.Canceled
+			step.Err = fmt.Sprintf("Canceled %s", step.Name)
 		} else {
 			console.Error("Failed to %s", step.Name)
 			step.Status = report.Failed
+			step.Err = fmt.Sprintf(
+				"Failed to inspect application %q in namespace %q",
+				c.opts.DRPCName, c.opts.DRPCNamespace,
+			)
 		}
 		c.Logger().Errorf("Step %q %s: %s", c.current.Name, step.Status, err)
 		c.current.AddStep(step)
@@ -196,6 +202,7 @@ func (c *Command) gatherApplication(options gathering.Options) bool {
 	c.Logger().Infof("Gathering from clusters %q with options %+v",
 		logging.ClusterNames(clusters), options)
 
+	var failedClusters []string
 	for r := range c.backend.Gather(c, clusters, options) {
 		step := &report.Step{Name: fmt.Sprintf("gather %q", r.Name), Duration: r.Duration}
 		if r.Err != nil {
@@ -203,6 +210,8 @@ func (c *Command) gatherApplication(options gathering.Options) bool {
 			console.Error(msg)
 			c.Logger().Errorf("%s: %s", msg, r.Err)
 			step.Status = report.Failed
+			step.Err = fmt.Sprintf("Failed to gather data from cluster %q", r.Name)
+			failedClusters = append(failedClusters, r.Name)
 			c.current.AddStep(step)
 		} else {
 			step.Status = report.Passed
@@ -213,7 +222,19 @@ func (c *Command) gatherApplication(options gathering.Options) bool {
 
 	c.Logger().Infof("Gathered clusters in %.2f seconds", time.Since(start).Seconds())
 
-	return c.current.Status == report.Passed
+	switch c.current.Status {
+	case report.Canceled:
+		c.current.Err = "Canceled gather data from clusters"
+		return false
+	case report.Failed:
+		c.current.Err = fmt.Sprintf(
+			"Failed to gather data from clusters %s",
+			strings.Join(failedClusters, ", "),
+		)
+		return false
+	default:
+		return true
+	}
 }
 
 func (c *Command) inspectS3Profiles() ([]*s3.Profile, string, bool) {
@@ -227,9 +248,11 @@ func (c *Command) inspectS3Profiles() ([]*s3.Profile, string, bool) {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
 			step.Status = report.Canceled
+			step.Err = fmt.Sprintf("Canceled %s", step.Name)
 			console.Error("Canceled %s", step.Name)
 		} else {
 			step.Status = report.Failed
+			step.Err = "Failed to read S3 profiles from hub"
 			console.Error("Failed to %s", step.Name)
 		}
 		c.Logger().Errorf("Step %q %s: %s", c.current.Name, step.Status, err)
@@ -256,6 +279,7 @@ func (c *Command) gatherApplicationS3Data(profiles []*s3.Profile, prefix string)
 	c.Logger().Infof("Gathering application S3 data from profiles %q with prefix %q",
 		logging.ProfileNames(profiles), prefix)
 
+	var failedProfiles []string
 	for r := range c.backend.GatherS3(c, profiles, []string{prefix}, outputDir) {
 		step := &report.Step{
 			Name:     fmt.Sprintf("gather S3 profile %q", r.ProfileName),
@@ -267,11 +291,14 @@ func (c *Command) gatherApplicationS3Data(profiles []*s3.Profile, prefix string)
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Canceled
+				step.Err = msg
 			} else {
 				msg := fmt.Sprintf("Failed to gather S3 profile %q", r.ProfileName)
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Failed
+				step.Err = fmt.Sprintf("Failed to gather S3 profile %q", r.ProfileName)
+				failedProfiles = append(failedProfiles, r.ProfileName)
 			}
 		} else {
 			step.Status = report.Passed
@@ -282,7 +309,19 @@ func (c *Command) gatherApplicationS3Data(profiles []*s3.Profile, prefix string)
 
 	c.Logger().Infof("Gathered application S3 data in %.2f seconds", time.Since(start).Seconds())
 
-	return c.current.Status == report.Passed
+	switch c.current.Status {
+	case report.Canceled:
+		c.current.Err = "Canceled gather S3 profiles"
+		return false
+	case report.Failed:
+		c.current.Err = fmt.Sprintf(
+			"Failed to gather S3 profiles %s",
+			strings.Join(failedProfiles, ", "),
+		)
+		return false
+	default:
+		return true
+	}
 }
 
 // withTimeout returns a derived command with a deadline. Call cancel to release resources
@@ -381,9 +420,11 @@ func (c *Command) failStep(err error) bool {
 	c.current.Duration = time.Since(c.currentStarted).Seconds()
 	if errors.Is(err, context.Canceled) {
 		c.current.Status = report.Canceled
+		c.current.Err = fmt.Sprintf("Canceled %s", c.current.Name)
 		console.Error("Canceled %s", c.current.Name)
 	} else {
 		c.current.Status = report.Failed
+		c.current.Err = fmt.Sprintf("Failed to %s", c.current.Name)
 		console.Error("Failed to %s", c.current.Name)
 	}
 	c.command.Logger().Errorf("Step %q %s: %s", c.current.Name, c.current.Status, err)

--- a/pkg/gather/command.go
+++ b/pkg/gather/command.go
@@ -334,7 +334,7 @@ func (c Command) withTimeout(d stdtime.Duration) (*Command, context.CancelFunc) 
 
 func (c *Command) failed() error {
 	c.command.WriteYAMLReport(c.report)
-	return fmt.Errorf("Gather %s", c.report.Status)
+	return errors.New(c.report.Error())
 }
 
 func (c *Command) passed() {

--- a/pkg/gather/command_test.go
+++ b/pkg/gather/command_test.go
@@ -75,13 +75,14 @@ func TestGatherApplicationPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkReport(t, cmd.report, report.Passed)
+	checkError(t, cmd.report, "")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Passed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{Name: "gather data", Status: report.Passed})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
@@ -101,12 +102,17 @@ func TestGatherApplicationValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report, "Failed to validate config")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Failed,
+		Err:    "Failed to validate config",
+	})
 }
 
 func TestGatherApplicationValidateCanceled(t *testing.T) {
@@ -115,12 +121,17 @@ func TestGatherApplicationValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
+	checkError(t, cmd.report, "Canceled validate config")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Canceled)
+	checkStep(t, cmd.report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Canceled,
+		Err:    "Canceled validate config",
+	})
 }
 
 func TestGatherApplicationInspectFailed(t *testing.T) {
@@ -129,16 +140,22 @@ func TestGatherApplicationInspectFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report,
+		`Failed to inspect application "appset-deploy-rbd" in namespace "argocd"`)
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{Name: "gather data", Status: report.Failed})
 
 	items := []*report.Step{
-		{Name: "inspect application", Status: report.Failed},
+		{
+			Name:   "inspect application",
+			Status: report.Failed,
+			Err:    `Failed to inspect application "appset-deploy-rbd" in namespace "argocd"`,
+		},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
 }
@@ -149,17 +166,26 @@ func TestGatherApplicationGatherClusterFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report, "Failed to gather data from clusters hub")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{
+		Name:   "gather data",
+		Status: report.Failed,
+		Err:    "Failed to gather data from clusters hub",
+	})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
-		{Name: "gather \"hub\"", Status: report.Failed},
+		{
+			Name:   "gather \"hub\"",
+			Status: report.Failed,
+			Err:    `Failed to gather data from cluster "hub"`,
+		},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
@@ -195,20 +221,25 @@ func TestGatherApplicationInspectS3ProfilesFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report, "Failed to read S3 profiles from hub")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{Name: "gather data", Status: report.Failed})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Failed},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Failed,
+			Err:    "Failed to read S3 profiles from hub",
+		},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
 }
@@ -220,20 +251,25 @@ func TestGatherApplicationInspectS3ProfilesCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
+	checkError(t, cmd.report, "Canceled inspect S3 profiles")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Canceled)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{Name: "gather data", Status: report.Canceled})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Canceled},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Canceled,
+			Err:    "Canceled inspect S3 profiles",
+		},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
 }
@@ -245,13 +281,19 @@ func TestGatherApplicationGetSecretFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report,
+		"Failed to gather S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{
+		Name:   "gather data",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns an error. The profile will have empty credentials
 	// causing S3 gather to fail.
@@ -261,8 +303,16 @@ func TestGatherApplicationGetSecretFailed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "gather S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr2"`,
+		},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
 }
@@ -274,13 +324,19 @@ func TestGatherApplicationGetSecretInvalid(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report,
+		"Failed to gather S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{
+		Name:   "gather data",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns a secret with invalid value, causing S3 gather to fail.
 	items := []*report.Step{
@@ -289,8 +345,16 @@ func TestGatherApplicationGetSecretInvalid(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "gather S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr2"`,
+		},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
 }
@@ -302,13 +366,18 @@ func TestGatherApplicationS3DataFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Failed)
+	checkError(t, cmd.report, "Failed to gather S3 profiles minio-on-dr1")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Failed)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{
+		Name:   "gather data",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1",
+	})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
@@ -316,7 +385,11 @@ func TestGatherApplicationS3DataFailed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
 		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Passed},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
@@ -329,13 +402,18 @@ func TestGatherApplicationS3DataCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, cmd.report, report.Canceled)
+	checkError(t, cmd.report, "Canceled gather S3 profiles")
 	checkApplication(t, cmd.report, testApplication)
 
 	if len(cmd.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", cmd.report.Steps)
 	}
-	checkStep(t, cmd.report.Steps[0], "validate config", report.Passed)
-	checkStep(t, cmd.report.Steps[1], "gather data", report.Canceled)
+	checkStep(t, cmd.report.Steps[0], &report.Step{Name: "validate config", Status: report.Passed})
+	checkStep(t, cmd.report.Steps[1], &report.Step{
+		Name:   "gather data",
+		Status: report.Canceled,
+		Err:    "Canceled gather S3 profiles",
+	})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
@@ -343,7 +421,11 @@ func TestGatherApplicationS3DataCanceled(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Canceled},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Canceled,
+			Err:    "Canceled gather S3 profile \"minio-on-dr1\"",
+		},
 		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Passed},
 	}
 	checkItems(t, cmd.report.Steps[1], items)
@@ -386,12 +468,22 @@ func checkApplication(t *testing.T, report *report.Report, expected *report.Appl
 	}
 }
 
-func checkStep(t *testing.T, step *report.Step, name string, status report.Status) {
-	if name != step.Name {
-		t.Fatalf("expected step %q, got %q", name, step.Name)
+// We cannot check duration since it may be zero on windows.
+func checkStep(t *testing.T, got *report.Step, expected *report.Step) {
+	if got.Name != expected.Name {
+		t.Fatalf("expected step %q, got %q", expected.Name, got.Name)
 	}
-	if status != step.Status {
-		t.Fatalf("expected status %q, got %q", status, step.Status)
+	if got.Status != expected.Status {
+		t.Fatalf("expected step %q status %q, got %q", expected.Name, expected.Status, got.Status)
+	}
+	if got.Err != expected.Err {
+		t.Fatalf("expected step %q error %q, got %q", expected.Name, expected.Err, got.Err)
+	}
+}
+
+func checkError(t *testing.T, r *report.Report, expected string) {
+	if got := r.Error(); got != expected {
+		t.Fatalf("expected error %q, got %q", expected, got)
 	}
 }
 
@@ -400,7 +492,7 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 		t.Fatalf("expected %d items, got %d", len(expected), len(step.Items))
 	}
 	for i, item := range expected {
-		checkStep(t, step.Items[i], item.Name, item.Status)
+		checkStep(t, step.Items[i], item)
 	}
 }
 

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -39,7 +39,13 @@ type Step struct {
 	Name     string  `json:"name"`
 	Status   Status  `json:"status,omitempty"`
 	Duration float64 `json:"duration,omitempty"`
-	Items    []*Step `json:"items,omitempty"`
+
+	// Err describes why the step failed. For parallel steps (e.g., gather),
+	// the parent sets Err to summarize child failures, shadowing individual
+	// item errors.
+	Err string `json:"error,omitempty"`
+
+	Items []*Step `json:"items,omitempty"`
 }
 
 // Base report for ramenctl commands report.
@@ -240,6 +246,9 @@ func (s *Step) Equal(o *Step) bool {
 		return false
 	}
 	if s.Duration != o.Duration {
+		return false
+	}
+	if s.Err != o.Err {
 		return false
 	}
 	return slices.EqualFunc(s.Items, o.Items, func(a *Step, b *Step) bool {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -48,6 +48,19 @@ type Step struct {
 	Items []*Step `json:"items,omitempty"`
 }
 
+// Error returns the error that stopped the step. A step's own Err shadows
+// its children, so parallel code can summarize child failures. If a step has
+// no Err, it drills into the last child.
+func (s *Step) Error() string {
+	if s.Err != "" {
+		return s.Err
+	}
+	if len(s.Items) > 0 {
+		return s.Items[len(s.Items)-1].Error()
+	}
+	return ""
+}
+
 // Base report for ramenctl commands report.
 type Base struct {
 	Host     Host       `json:"host"`
@@ -60,6 +73,14 @@ type Base struct {
 
 	// Summary is set by `validate` and `test` commands.
 	Summary *Summary `json:"summary,omitempty"`
+}
+
+// Error returns the error from the report by walking the step tree.
+func (r *Base) Error() string {
+	if len(r.Steps) == 0 {
+		return ""
+	}
+	return r.Steps[len(r.Steps)-1].Error()
 }
 
 // Application is application info.

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -735,6 +735,14 @@ func TestStepEqual(t *testing.T) {
 		}
 	})
 
+	t.Run("different error", func(t *testing.T) {
+		s2 := s1
+		s2.Err = "something went wrong"
+		if s1.Equal(&s2) {
+			t.Fatalf("steps with different errors should not be equal")
+		}
+	})
+
 	t.Run("equal subitems", func(t *testing.T) {
 		s1 := report.Step{
 			Name:     "parent",

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -671,6 +671,156 @@ func TestStepAddSkippedStep(t *testing.T) {
 	})
 }
 
+func TestStepError(t *testing.T) {
+	t.Run("passed", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Passed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Passed},
+				{Name: "item2", Status: report.Passed},
+				{Name: "item3", Status: report.Passed},
+			},
+		}
+		if got := step.Error(); got != "" {
+			t.Fatalf("expected empty error, got %q", got)
+		}
+	})
+
+	t.Run("leaf error", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Failed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Passed},
+				{Name: "item2", Status: report.Passed},
+				{Name: "item3", Status: report.Failed, Err: "leaf error"},
+			},
+		}
+		if got := step.Error(); got != "leaf error" {
+			t.Fatalf("expected %q, got %q", "leaf error", got)
+		}
+	})
+
+	t.Run("drills to last child", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Failed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Passed},
+				{Name: "item2", Status: report.Failed, Err: "child error"},
+			},
+		}
+		if got := step.Error(); got != "child error" {
+			t.Fatalf("expected %q, got %q", "child error", got)
+		}
+	})
+
+	t.Run("first child failed last passed", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Failed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Failed, Err: "non-fatal error"},
+				{Name: "item2", Status: report.Passed},
+				{Name: "item3", Status: report.Passed},
+			},
+		}
+		if got := step.Error(); got != "" {
+			t.Fatalf("expected empty error, got %q", got)
+		}
+	})
+
+	t.Run("parent error shadows children", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Failed,
+			Err:    "parent error",
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Failed, Err: "child error"},
+				{Name: "item2", Status: report.Passed},
+			},
+		}
+		if got := step.Error(); got != "parent error" {
+			t.Fatalf("expected %q, got %q", "parent error", got)
+		}
+	})
+
+	t.Run("drills to nested child", func(t *testing.T) {
+		step := &report.Step{
+			Name:   "step1",
+			Status: report.Failed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Passed},
+				{
+					Name:   "item2",
+					Status: report.Failed,
+					Items: []*report.Step{
+						{Name: "sub1", Status: report.Passed},
+						{Name: "sub2", Status: report.Failed, Err: "nested error"},
+					},
+				},
+			},
+		}
+		if got := step.Error(); got != "nested error" {
+			t.Fatalf("expected %q, got %q", "nested error", got)
+		}
+	})
+}
+
+func TestBaseError(t *testing.T) {
+	t.Run("no steps", func(t *testing.T) {
+		r := report.NewBase("name")
+		if got := r.Error(); got != "" {
+			t.Fatalf("expected empty error, got %q", got)
+		}
+	})
+
+	t.Run("all passed", func(t *testing.T) {
+		r := report.NewBase("name")
+		r.AddStep(&report.Step{Name: "step1", Status: report.Passed})
+		r.AddStep(&report.Step{Name: "step2", Status: report.Passed})
+		if got := r.Error(); got != "" {
+			t.Fatalf("expected empty error, got %q", got)
+		}
+	})
+
+	t.Run("last step failed", func(t *testing.T) {
+		r := report.NewBase("name")
+		r.AddStep(&report.Step{Name: "step1", Status: report.Passed})
+		r.AddStep(&report.Step{Name: "step2", Status: report.Failed, Err: "step error"})
+		if got := r.Error(); got != "step error" {
+			t.Fatalf("expected %q, got %q", "step error", got)
+		}
+	})
+
+	t.Run("drills to last step child", func(t *testing.T) {
+		r := report.NewBase("name")
+		r.AddStep(&report.Step{Name: "step1", Status: report.Passed})
+		r.AddStep(&report.Step{
+			Name:   "step2",
+			Status: report.Failed,
+			Items: []*report.Step{
+				{Name: "item1", Status: report.Passed},
+				{Name: "item2", Status: report.Failed, Err: "child error"},
+			},
+		})
+		if got := r.Error(); got != "child error" {
+			t.Fatalf("expected %q, got %q", "child error", got)
+		}
+	})
+
+	t.Run("first step failed last passed", func(t *testing.T) {
+		r := report.NewBase("name")
+		r.AddStep(&report.Step{Name: "step1", Status: report.Failed, Err: "non-fatal error"})
+		r.AddStep(&report.Step{Name: "step2", Status: report.Passed})
+		if got := r.Error(); got != "" {
+			t.Fatalf("expected empty error, got %q", got)
+		}
+	})
+
+}
+
 func TestStepMarshal(t *testing.T) {
 	step := &report.Step{
 		Name:     "test",

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -308,12 +308,12 @@ func (c *Command) displayName() string {
 
 func (c *Command) failed() error {
 	c.command.WriteYAMLReport(c.report)
-	return fmt.Errorf("%s (%s)", c.report.Status, summaryString(c.report.Summary))
+	return errors.New(c.report.Error())
 }
 
 func (c *Command) passed() {
 	c.command.WriteYAMLReport(c.report)
-	console.Completed("%s (%s)", c.report.Status, summaryString(c.report.Summary))
+	console.Completed("%s passed (%s)", c.displayName(), summaryString(c.report.Summary))
 }
 
 func (c *Command) startStep(name string) {

--- a/pkg/test/command.go
+++ b/pkg/test/command.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	stdtime "time"
 
@@ -299,6 +300,12 @@ func (c *Command) gatherS3Data() {
 	c.Logger().Infof("Gathered S3 data in %.2f seconds", time.Since(start).Seconds())
 }
 
+// displayName returns a display name from the command name (e.g., "test-run" -> "Test run").
+func (c *Command) displayName() string {
+	name := strings.ReplaceAll(c.report.Name, "-", " ")
+	return strings.ToUpper(name[:1]) + name[1:]
+}
+
 func (c *Command) failed() error {
 	c.command.WriteYAMLReport(c.report)
 	return fmt.Errorf("%s (%s)", c.report.Status, summaryString(c.report.Summary))
@@ -319,9 +326,11 @@ func (c *Command) failStep(err error) bool {
 	c.current.Duration = time.Since(c.currentStarted).Seconds()
 	if errors.Is(err, context.Canceled) {
 		c.current.Status = report.Canceled
+		c.current.Err = fmt.Sprintf("Canceled %s", c.current.Name)
 		console.Error("Canceled %s", c.current.Name)
 	} else {
 		c.current.Status = report.Failed
+		c.current.Err = fmt.Sprintf("Failed to %s", c.current.Name)
 		console.Error("Failed to %s", c.current.Name)
 	}
 	c.Logger().Errorf("Step %q %s: %s", c.current.Name, c.current.Status, err)
@@ -371,10 +380,24 @@ func (c *Command) runFlowFunc(f flowFunc) bool {
 	}
 
 	res := c.finishStep()
+
+	testsStep := c.report.Steps[len(c.report.Steps)-1]
+	switch testsStep.Status {
+	case report.Canceled:
+		testsStep.Err = fmt.Sprintf("%s canceled", c.displayName())
+	case report.Failed:
+		testsStep.Err = fmt.Sprintf(
+			"%s failed (%s)",
+			c.displayName(),
+			summaryString(c.report.Summary),
+		)
+	}
+
 	if c.report.Status == report.Failed {
 		c.gatherData()
 		c.gatherS3Data()
 	}
+
 	return res
 }
 

--- a/pkg/test/command_test.go
+++ b/pkg/test/command_test.go
@@ -162,15 +162,16 @@ func TestRunPassed(t *testing.T) {
 		report.Passed,
 		report.Summary{Passed: len(testConfig.Tests)},
 	)
+	checkError(t, test.report, "")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Passed)
+	checkStep(t, setup, &report.Step{Name: SetupStep, Status: report.Passed})
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, report.Passed)
+	checkStep(t, tests, &report.Step{Name: TestsStep, Status: report.Passed})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Passed, runFlow...)
@@ -185,11 +186,16 @@ func TestRunValidateFailed(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Failed, report.Summary{})
+	checkError(t, test.report, "Failed to validate")
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Failed)
+	checkStep(t, validate, &report.Step{
+		Name:   ValidateStep,
+		Status: report.Failed,
+		Err:    "Failed to validate",
+	})
 }
 
 func TestRunValidateCanceled(t *testing.T) {
@@ -200,11 +206,16 @@ func TestRunValidateCanceled(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Canceled, report.Summary{})
+	checkError(t, test.report, "Canceled validate")
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Canceled)
+	checkStep(t, validate, &report.Step{
+		Name:   ValidateStep,
+		Status: report.Canceled,
+		Err:    "Canceled validate",
+	})
 }
 
 func TestRunSetupFailed(t *testing.T) {
@@ -215,13 +226,18 @@ func TestRunSetupFailed(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Failed, report.Summary{})
+	checkError(t, test.report, "Failed to setup")
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Failed)
+	checkStep(t, setup, &report.Step{
+		Name:   SetupStep,
+		Status: report.Failed,
+		Err:    "Failed to setup",
+	})
 }
 
 func TestRunSetupCanceled(t *testing.T) {
@@ -232,13 +248,18 @@ func TestRunSetupCanceled(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Canceled, report.Summary{})
+	checkError(t, test.report, "Canceled setup")
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Canceled)
+	checkStep(t, setup, &report.Step{
+		Name:   SetupStep,
+		Status: report.Canceled,
+		Err:    "Canceled setup",
+	})
 }
 
 func TestRunTestsFailed(t *testing.T) {
@@ -254,15 +275,21 @@ func TestRunTestsFailed(t *testing.T) {
 		report.Failed,
 		report.Summary{Failed: len(testConfig.Tests)},
 	)
+	checkError(t, test.report,
+		"Test run failed (0 passed, 14 failed, 0 skipped, 0 canceled)")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Passed)
+	checkStep(t, setup, &report.Step{Name: SetupStep, Status: report.Passed})
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, report.Failed)
+	checkStep(t, tests, &report.Step{
+		Name:   TestsStep,
+		Status: report.Failed,
+		Err:    "Test run failed (0 passed, 14 failed, 0 skipped, 0 canceled)",
+	})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Failed, "deploy", "protect", "failover")
@@ -282,15 +309,21 @@ func TestRunDisappFailed(t *testing.T) {
 		report.Failed,
 		report.Summary{Passed: 4, Failed: 10},
 	)
+	checkError(t, test.report,
+		"Test run failed (4 passed, 10 failed, 0 skipped, 0 canceled)")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Passed)
+	checkStep(t, setup, &report.Step{Name: SetupStep, Status: report.Passed})
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, report.Failed)
+	checkStep(t, tests, &report.Step{
+		Name:   TestsStep,
+		Status: report.Failed,
+		Err:    "Test run failed (4 passed, 10 failed, 0 skipped, 0 canceled)",
+	})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		if strings.HasPrefix(tc.Deployer, "disapp") {
@@ -314,15 +347,20 @@ func TestRunTestsCanceled(t *testing.T) {
 		report.Canceled,
 		report.Summary{Canceled: len(testConfig.Tests)},
 	)
+	checkError(t, test.report, "Test run canceled")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	setup := test.report.Steps[1]
-	checkStep(t, setup, SetupStep, report.Passed)
+	checkStep(t, setup, &report.Step{Name: SetupStep, Status: report.Passed})
 	tests := test.report.Steps[2]
-	checkStep(t, tests, TestsStep, report.Canceled)
+	checkStep(t, tests, &report.Step{
+		Name:   TestsStep,
+		Status: report.Canceled,
+		Err:    "Test run canceled",
+	})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Canceled, "deploy", "protect", "failover")
@@ -337,19 +375,20 @@ func TestCleanPassed(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Passed, report.Summary{Passed: 14})
+	checkError(t, test.report, "")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, report.Passed)
+	checkStep(t, tests, &report.Step{Name: TestsStep, Status: report.Passed})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Passed, "purge")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, report.Passed)
+	checkStep(t, cleanup, &report.Step{Name: CleanupStep, Status: report.Passed})
 }
 
 func TestCleanValidateFailed(t *testing.T) {
@@ -360,11 +399,16 @@ func TestCleanValidateFailed(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Failed, report.Summary{})
+	checkError(t, test.report, "Failed to validate")
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Failed)
+	checkStep(t, validate, &report.Step{
+		Name:   ValidateStep,
+		Status: report.Failed,
+		Err:    "Failed to validate",
+	})
 }
 
 func TestCleanValidateCanceled(t *testing.T) {
@@ -375,11 +419,16 @@ func TestCleanValidateCanceled(t *testing.T) {
 	}
 
 	checkReport(t, test.report, report.Canceled, report.Summary{})
+	checkError(t, test.report, "Canceled validate")
 	if len(test.report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Canceled)
+	checkStep(t, validate, &report.Step{
+		Name:   ValidateStep,
+		Status: report.Canceled,
+		Err:    "Canceled validate",
+	})
 }
 
 func TestCleanPurgeFailed(t *testing.T) {
@@ -395,13 +444,19 @@ func TestCleanPurgeFailed(t *testing.T) {
 		report.Failed,
 		report.Summary{Failed: len(testConfig.Tests)},
 	)
+	checkError(t, test.report,
+		"Test clean failed (0 passed, 14 failed, 0 skipped, 0 canceled)")
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, report.Failed)
+	checkStep(t, tests, &report.Step{
+		Name:   TestsStep,
+		Status: report.Failed,
+		Err:    "Test clean failed (0 passed, 14 failed, 0 skipped, 0 canceled)",
+	})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Failed, "purge")
@@ -421,13 +476,18 @@ func TestCleanPurgeCanceled(t *testing.T) {
 		report.Canceled,
 		report.Summary{Canceled: len(testConfig.Tests)},
 	)
+	checkError(t, test.report, "Test clean canceled")
 	if len(test.report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, report.Canceled)
+	checkStep(t, tests, &report.Step{
+		Name:   TestsStep,
+		Status: report.Canceled,
+		Err:    "Test clean canceled",
+	})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Canceled, "purge")
@@ -447,19 +507,24 @@ func TestCleanCleanupFailed(t *testing.T) {
 		report.Failed,
 		report.Summary{Passed: len(testConfig.Tests)},
 	)
+	checkError(t, test.report, "Failed to cleanup")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, report.Passed)
+	checkStep(t, tests, &report.Step{Name: TestsStep, Status: report.Passed})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Passed, "purge")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, report.Failed)
+	checkStep(t, cleanup, &report.Step{
+		Name:   CleanupStep,
+		Status: report.Failed,
+		Err:    "Failed to cleanup",
+	})
 }
 
 func TestCleanCleanupCanceled(t *testing.T) {
@@ -475,19 +540,24 @@ func TestCleanCleanupCanceled(t *testing.T) {
 		report.Canceled,
 		report.Summary{Passed: len(testConfig.Tests)},
 	)
+	checkError(t, test.report, "Canceled cleanup")
 	if len(test.report.Steps) != 3 {
 		t.Fatalf("unexpected steps %+v", test.report.Steps)
 	}
 	validate := test.report.Steps[0]
-	checkStep(t, validate, ValidateStep, report.Passed)
+	checkStep(t, validate, &report.Step{Name: ValidateStep, Status: report.Passed})
 	tests := test.report.Steps[1]
-	checkStep(t, tests, TestsStep, report.Passed)
+	checkStep(t, tests, &report.Step{Name: TestsStep, Status: report.Passed})
 	for i, tc := range testConfig.Tests {
 		result := tests.Items[i]
 		checkTest(t, result, tc, report.Passed, "purge")
 	}
 	cleanup := test.report.Steps[2]
-	checkStep(t, cleanup, CleanupStep, report.Canceled)
+	checkStep(t, cleanup, &report.Step{
+		Name:   CleanupStep,
+		Status: report.Canceled,
+		Err:    "Canceled cleanup",
+	})
 }
 
 // Test helpers.
@@ -516,14 +586,23 @@ func checkReport(t *testing.T, r *Report, status report.Status, summary report.S
 	}
 }
 
-func checkStep(t *testing.T, step *report.Step, name string, status report.Status) {
-	if name != step.Name {
-		t.Fatalf("expected step %q, got %q", name, step.Name)
+// We cannot check duration since it may be zero on windows.
+func checkStep(t *testing.T, got *report.Step, expected *report.Step) {
+	if got.Name != expected.Name {
+		t.Fatalf("expected step %q, got %q", expected.Name, got.Name)
 	}
-	if status != step.Status {
-		t.Fatalf("expected status %q, got %q", status, step.Status)
+	if got.Status != expected.Status {
+		t.Fatalf("expected step %q status %q, got %q", expected.Name, expected.Status, got.Status)
 	}
-	// We cannot check duration since it may be zero on windows.
+	if got.Err != expected.Err {
+		t.Fatalf("expected step %q error %q, got %q", expected.Name, expected.Err, got.Err)
+	}
+}
+
+func checkError(t *testing.T, r *Report, expected string) {
+	if got := r.Error(); got != expected {
+		t.Fatalf("expected error %q, got %q", expected, got)
+	}
 }
 
 func checkTest(
@@ -538,7 +617,7 @@ func checkTest(
 		t.Fatalf("expected step %q, got %q", name, test.Name)
 	}
 	if status != test.Status {
-		t.Fatalf("expected status %q, got %q", status, test.Status)
+		t.Fatalf("expected step %q status %q, got %q", name, status, test.Status)
 	}
 	duration := totalDuration(test.Items)
 	if test.Duration != duration {
@@ -549,9 +628,16 @@ func checkTest(
 	}
 	last := len(flow) - 1
 	for i, name := range flow[:last] {
-		checkStep(t, test.Items[i], name, report.Passed)
+		checkStep(t, test.Items[i], &report.Step{Name: name, Status: report.Passed})
 	}
-	checkStep(t, test.Items[last], flow[last], test.Status)
+	lastStep := &report.Step{Name: flow[last], Status: test.Status}
+	switch test.Status {
+	case report.Failed:
+		lastStep.Err = fmt.Sprintf("Failed to %s application %q", flow[last], name)
+	case report.Canceled:
+		lastStep.Err = fmt.Sprintf("Canceled %s application %q", flow[last], name)
+	}
+	checkStep(t, test.Items[last], lastStep)
 }
 
 func totalDuration(steps []*report.Step) float64 {

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -148,9 +148,11 @@ func (t *Test) failStep(err error) bool {
 	t.Duration += step.Duration
 	if errors.Is(err, context.Canceled) {
 		step.Status = report.Canceled
+		step.Err = fmt.Sprintf("Canceled %s application %q", step.Name, t.Name())
 		console.Error("Canceled application %q %s", t.Name(), step.Name)
 	} else {
 		step.Status = report.Failed
+		step.Err = fmt.Sprintf("Failed to %s application %q", step.Name, t.Name())
 		console.Error("Failed to %s application %q", step.Name, t.Name())
 	}
 	t.Status = step.Status

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -91,14 +91,23 @@ func checkNamespaces(t *testing.T, r *Report, expected []string) {
 	}
 }
 
-func checkStep(t *testing.T, step *report.Step, name string, status report.Status) {
-	if name != step.Name {
-		t.Fatalf("expected step %q, got %q", name, step.Name)
+// We cannot check duration since it may be zero on windows.
+func checkStep(t *testing.T, got *report.Step, expected *report.Step) {
+	if got.Name != expected.Name {
+		t.Fatalf("expected step %q, got %q", expected.Name, got.Name)
 	}
-	if status != step.Status {
-		t.Fatalf("expected status %q, got %q", status, step.Status)
+	if got.Status != expected.Status {
+		t.Fatalf("expected step %q status %q, got %q", expected.Name, expected.Status, got.Status)
 	}
-	// We cannot check duration since it may be zero on windows.
+	if got.Err != expected.Err {
+		t.Fatalf("expected step %q error %q, got %q", expected.Name, expected.Err, got.Err)
+	}
+}
+
+func checkError(t *testing.T, r *Report, expected string) {
+	if got := r.Error(); got != expected {
+		t.Fatalf("expected error %q, got %q", expected, got)
+	}
 }
 
 func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
@@ -106,7 +115,7 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 		t.Fatalf("expected items %+v, got %+v", expected, step.Items)
 	}
 	for i, item := range expected {
-		checkStep(t, step.Items[i], item.Name, item.Status)
+		checkStep(t, step.Items[i], item)
 	}
 }
 

--- a/pkg/validate/application/application_test.go
+++ b/pkg/validate/application/application_test.go
@@ -137,13 +137,20 @@ func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 }
 
 func checkOutputFiles(t *testing.T, cmd *Command) {
+	if _, err := os.Stat(cmd.ReportFile("yaml")); err != nil {
+		t.Errorf("output file %q not found: %s", cmd.ReportFile("yaml"), err)
+	}
+	hasHTML := len(*cmd.Report.Summary) > 0
 	for _, path := range []string{
-		cmd.ReportFile("yaml"),
 		cmd.ReportFile("html"),
 		filepath.Join(cmd.OutputDir(), "style.css"),
 	} {
-		if _, err := os.Stat(path); err != nil {
+		_, err := os.Stat(path)
+		if hasHTML && err != nil {
 			t.Errorf("output file %q not found: %s", path, err)
+		}
+		if !hasHTML && err == nil {
+			t.Errorf("unexpected output file %q", path)
 		}
 	}
 }

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -63,7 +63,7 @@ func (c *Command) passed() {
 
 func (c *Command) failed() error {
 	c.WriteReport(c.Report)
-	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
+	return errors.New(c.Report.Error())
 }
 
 func (c *Command) Run() error {

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -10,6 +10,7 @@ import (
 	"maps"
 	"os"
 	"slices"
+	"strings"
 	stdtime "time"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
@@ -120,9 +121,14 @@ func (c *Command) inspectApplication() ([]string, bool) {
 		if errors.Is(err, context.Canceled) {
 			console.Error("Canceled %s", step.Name)
 			step.Status = report.Canceled
+			step.Err = fmt.Sprintf("Canceled %s", step.Name)
 		} else {
 			console.Error("Failed to %s", step.Name)
 			step.Status = report.Failed
+			step.Err = fmt.Sprintf(
+				"Failed to inspect application %q in namespace %q",
+				c.opts.DRPCName, c.opts.DRPCNamespace,
+			)
 		}
 		c.Logger().Errorf("Step %q %s: %s", c.Current.Name, step.Status, err)
 		c.Current.AddStep(step)
@@ -162,9 +168,11 @@ func (c *Command) inspectS3Profiles() ([]*s3.Profile, string, error) {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
 			step.Status = report.Canceled
+			step.Err = fmt.Sprintf("Canceled %s", step.Name)
 			console.Error("Canceled %s", step.Name)
 		} else {
 			step.Status = report.Failed
+			step.Err = "Failed to read S3 profiles from hub"
 			console.Error("Failed to %s", step.Name)
 		}
 		c.Logger().Errorf("Step %q %s: %s", c.Current.Name, step.Status, err)
@@ -192,6 +200,7 @@ func (c *Command) gatherS3Profiles(profiles []*s3.Profile, prefix string) bool {
 	c.Logger().Infof("Gathering application S3 data from profiles %q with prefix %q",
 		logging.ProfileNames(profiles), prefix)
 
+	var failedProfiles []string
 	for r := range c.Backend.GatherS3(c, profiles, []string{prefix}, outputDir) {
 		// Store the s3 gather result for validation.
 		c.S3Results = append(c.S3Results, r)
@@ -206,11 +215,14 @@ func (c *Command) gatherS3Profiles(profiles []*s3.Profile, prefix string) bool {
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Canceled
+				step.Err = msg
 			} else {
 				msg := fmt.Sprintf("Failed to gather S3 profile %q", r.ProfileName)
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Failed
+				step.Err = fmt.Sprintf("Failed to gather S3 profile %q", r.ProfileName)
+				failedProfiles = append(failedProfiles, r.ProfileName)
 			}
 		} else {
 			step.Status = report.Passed
@@ -221,7 +233,19 @@ func (c *Command) gatherS3Profiles(profiles []*s3.Profile, prefix string) bool {
 
 	c.Logger().Infof("Gathered application S3 data in %.2f seconds", time.Since(start).Seconds())
 
-	return c.Current.Status != report.Canceled
+	switch c.Current.Status {
+	case report.Canceled:
+		c.Current.Err = "Canceled gather S3 profiles"
+		return false
+	case report.Failed:
+		c.Current.Err = fmt.Sprintf(
+			"Failed to gather S3 profiles %s",
+			strings.Join(failedProfiles, ", "),
+		)
+		return true
+	default:
+		return true
+	}
 }
 
 func (c *Command) namespacesToGather() ([]string, error) {
@@ -296,6 +320,7 @@ func (c *Command) validateGatheredData() bool {
 	drpc, err := c.validateHub(&s.Hub)
 	if err != nil {
 		step.Status = report.Failed
+		step.Err = "Failed to validate hub"
 		msg := "Failed to validate hub"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, err)
@@ -304,6 +329,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if err := c.validatePrimaryCluster(&s.PrimaryCluster, drpc); err != nil {
 		step.Status = report.Failed
+		step.Err = fmt.Sprintf("Failed to validate primary cluster %q", s.PrimaryCluster.Name)
 		msg := "Failed to validate primary cluster"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, err)
@@ -312,6 +338,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if err := c.validateSecondaryCluster(&s.SecondaryCluster, drpc); err != nil {
 		step.Status = report.Failed
+		step.Err = fmt.Sprintf("Failed to validate secondary cluster %q", s.SecondaryCluster.Name)
 		msg := "Failed to validate secondary cluster"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, err)
@@ -322,6 +349,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if summary.HasIssues(c.Report.Summary) {
 		step.Status = report.Failed
+		step.Err = fmt.Sprintf("Validation failed (%s)", summary.String(c.Report.Summary))
 		msg := "Issues found during validation"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, summary.String(c.Report.Summary))

--- a/pkg/validate/application/command_test.go
+++ b/pkg/validate/application/command_test.go
@@ -99,13 +99,20 @@ func TestValidateApplicationPassed(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkReport(t, validate, report.Passed)
+	checkError(t, validate.Report, "")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Passed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Passed,
+	})
 
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
@@ -356,12 +363,17 @@ func TestValidateApplicationValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to validate config")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Failed,
+		Err:    "Failed to validate config",
+	})
 	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -373,12 +385,17 @@ func TestValidateApplicationValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled validate config")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Canceled,
+		Err:    "Canceled validate config",
+	})
 	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -390,17 +407,29 @@ func TestValidateApplicationInspectApplicationFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		`Failed to inspect application "appset-deploy-rbd" in namespace "argocd"`)
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+	})
 
 	// If inspecting the application has failed we skip the gather step.
 	items := []*report.Step{
-		{Name: "inspect application", Status: report.Failed},
+		{
+			Name:   "inspect application",
+			Status: report.Failed,
+			Err:    `Failed to inspect application "appset-deploy-rbd" in namespace "argocd"`,
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
@@ -414,17 +443,28 @@ func TestValidateApplicationInspectApplicationCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled inspect application")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Canceled,
+	})
 
 	// If inspecting the application has been canceled we skip the gather step.
 	items := []*report.Step{
-		{Name: "inspect application", Status: report.Canceled},
+		{
+			Name:   "inspect application",
+			Status: report.Canceled,
+			Err:    "Canceled inspect application",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkApplicationStatus(t, validate.Report, &report.ApplicationStatus{})
@@ -438,18 +478,30 @@ func TestValidateApplicationGatherClusterFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to gather data from clusters hub")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+		Err:    "Failed to gather data from clusters hub",
+	})
 
 	// If gathering data fail for some of the clusters, we skip the validation step.
 	items := []*report.Step{
 		{Name: "inspect application", Status: report.Passed},
-		{Name: "gather \"hub\"", Status: report.Failed},
+		{
+			Name:   "gather \"hub\"",
+			Status: report.Failed,
+			Err:    `Failed to gather data from cluster "hub"`,
+		},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
@@ -466,13 +518,20 @@ func TestValidateApplicationInspectS3ProfilesFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to validate hub")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+	})
 
 	// Inspect S3 profiles fails, S3 gathering is skipped.
 	// Validation runs and reports missing S3 data as problem.
@@ -481,8 +540,16 @@ func TestValidateApplicationInspectS3ProfilesFailed(t *testing.T) {
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Failed},
-		{Name: "validate data", Status: report.Failed},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Failed,
+			Err:    "Failed to read S3 profiles from hub",
+		},
+		{
+			Name:   "validate data",
+			Status: report.Failed,
+			Err:    "Failed to validate hub",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{})
@@ -496,13 +563,20 @@ func TestValidateApplicationInspectS3ProfilesCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled inspect S3 profiles")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Canceled,
+	})
 
 	// Inspect S3 profiles is canceled, gatherS3 and validation are skipped.
 	items := []*report.Step{
@@ -510,7 +584,11 @@ func TestValidateApplicationInspectS3ProfilesCanceled(t *testing.T) {
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Canceled},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Canceled,
+			Err:    "Canceled inspect S3 profiles",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{})
@@ -524,14 +602,23 @@ func TestValidateApplicationGetSecretFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		"Failed to gather S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns an error. The profile will have empty credentials
 	// causing S3 gather and validation to fail.
@@ -541,9 +628,21 @@ func TestValidateApplicationGetSecretFailed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Failed},
-		{Name: "validate data", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "gather S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr2"`,
+		},
+		{
+			Name:   "validate data",
+			Status: report.Failed,
+			Err:    "Validation failed (28 ok, 0 warning, 2 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{summary.OK: 28, summary.Problem: 2})
@@ -557,14 +656,23 @@ func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		"Failed to gather S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns a secret with invalid value, causing S3 gather and
 	// validation to fail.
@@ -574,9 +682,21 @@ func TestValidateApplicationGetSecretInvalid(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Failed},
-		{Name: "validate data", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "gather S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr2"`,
+		},
+		{
+			Name:   "validate data",
+			Status: report.Failed,
+			Err:    "Validation failed (28 ok, 0 warning, 2 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{summary.OK: 28, summary.Problem: 2})
@@ -590,13 +710,21 @@ func TestValidateApplicationGatherS3Failed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to gather S3 profiles minio-on-dr1")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Failed,
+		Err:    "Failed to gather S3 profiles minio-on-dr1",
+	})
 
 	// S3 gather fails for one profile, other profile succeeds.
 	// Validation runs and reports the failed profile as problem.
@@ -606,9 +734,17 @@ func TestValidateApplicationGatherS3Failed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Failed},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to gather S3 profile "minio-on-dr1"`,
+		},
 		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Passed},
-		{Name: "validate data", Status: report.Failed},
+		{
+			Name:   "validate data",
+			Status: report.Failed,
+			Err:    "Validation failed (29 ok, 0 warning, 1 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(
@@ -626,13 +762,21 @@ func TestValidateApplicationGatherS3Canceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled gather S3 profiles")
 	checkApplication(t, validate.Report, testApplication)
 	checkNamespaces(t, validate.Report, reportNamespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate application", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate application",
+		Status: report.Canceled,
+		Err:    "Canceled gather S3 profiles",
+	})
 
 	// S3 gather is canceled, validation is skipped.
 	items := []*report.Step{
@@ -641,7 +785,11 @@ func TestValidateApplicationGatherS3Canceled(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "gather S3 profile \"minio-on-dr1\"", Status: report.Canceled},
+		{
+			Name:   "gather S3 profile \"minio-on-dr1\"",
+			Status: report.Canceled,
+			Err:    "Canceled gather S3 profile \"minio-on-dr1\"",
+		},
 		{Name: "gather S3 profile \"minio-on-dr2\"", Status: report.Passed},
 	}
 	checkItems(t, validate.Report.Steps[1], items)

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -108,14 +108,23 @@ func checkNamespaces(t *testing.T, r *Report, expected []string) {
 	}
 }
 
-func checkStep(t *testing.T, step *report.Step, name string, status report.Status) {
-	if name != step.Name {
-		t.Fatalf("expected step %q, got %q", name, step.Name)
+// We cannot check duration since it may be zero on windows.
+func checkStep(t *testing.T, got *report.Step, expected *report.Step) {
+	if got.Name != expected.Name {
+		t.Fatalf("expected step %q, got %q", expected.Name, got.Name)
 	}
-	if status != step.Status {
-		t.Fatalf("expected status %q, got %q", status, step.Status)
+	if got.Status != expected.Status {
+		t.Fatalf("expected step %q status %q, got %q", expected.Name, expected.Status, got.Status)
 	}
-	// We cannot check duration since it may be zero on windows.
+	if got.Err != expected.Err {
+		t.Fatalf("expected step %q error %q, got %q", expected.Name, expected.Err, got.Err)
+	}
+}
+
+func checkError(t *testing.T, r *Report, expected string) {
+	if got := r.Error(); got != expected {
+		t.Fatalf("expected error %q, got %q", expected, got)
+	}
 }
 
 func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
@@ -123,7 +132,7 @@ func checkItems(t *testing.T, step *report.Step, expected []*report.Step) {
 		t.Fatalf("expected items %+v, got %+v", expected, step.Items)
 	}
 	for i, item := range expected {
-		checkStep(t, step.Items[i], item.Name, item.Status)
+		checkStep(t, step.Items[i], item)
 	}
 }
 

--- a/pkg/validate/clusters/clusters_test.go
+++ b/pkg/validate/clusters/clusters_test.go
@@ -154,13 +154,20 @@ func checkSummary(t *testing.T, r *Report, expected report.Summary) {
 }
 
 func checkOutputFiles(t *testing.T, cmd *Command) {
+	if _, err := os.Stat(cmd.ReportFile("yaml")); err != nil {
+		t.Errorf("output file %q not found: %s", cmd.ReportFile("yaml"), err)
+	}
+	hasHTML := len(*cmd.Report.Summary) > 0
 	for _, path := range []string{
-		cmd.ReportFile("yaml"),
 		cmd.ReportFile("html"),
 		filepath.Join(cmd.OutputDir(), "style.css"),
 	} {
-		if _, err := os.Stat(path); err != nil {
+		_, err := os.Stat(path)
+		if hasHTML && err != nil {
 			t.Errorf("output file %q not found: %s", path, err)
+		}
+		if !hasHTML && err == nil {
+			t.Errorf("unexpected output file %q", path)
 		}
 	}
 }

--- a/pkg/validate/clusters/command.go
+++ b/pkg/validate/clusters/command.go
@@ -62,7 +62,7 @@ func (c *Command) passed() {
 
 func (c *Command) failed() error {
 	c.WriteReport(c.Report)
-	return fmt.Errorf("validation %s (%s)", c.Report.Status, summary.String(c.Report.Summary))
+	return errors.New(c.Report.Error())
 }
 
 func (c *Command) Run() error {

--- a/pkg/validate/clusters/command.go
+++ b/pkg/validate/clusters/command.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	ramenapi "github.com/ramendr/ramen/api/v1alpha1"
 	"github.com/ramendr/ramen/e2e/types"
@@ -132,9 +133,11 @@ func (c *Command) inspectS3Profiles() ([]*s3.Profile, error) {
 		step.Duration = time.Since(start).Seconds()
 		if errors.Is(err, context.Canceled) {
 			step.Status = report.Canceled
+			step.Err = fmt.Sprintf("Canceled %s", step.Name)
 			console.Error("Canceled %s", step.Name)
 		} else {
 			step.Status = report.Failed
+			step.Err = "Failed to read S3 profiles from hub"
 			console.Error("Failed to %s", step.Name)
 		}
 		c.Logger().Errorf("Step %q %s: %s", step.Name, step.Status, err)
@@ -199,6 +202,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if err := c.validateHub(&s.Hub); err != nil {
 		step.Status = report.Failed
+		step.Err = "Failed to validate hub"
 		msg := "Failed to validate hub"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, err)
@@ -207,6 +211,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if err := c.validateManagedClusters(&s.Clusters); err != nil {
 		step.Status = report.Failed
+		step.Err = "Failed to validate managed clusters"
 		msg := "Failed to validate managed clusters"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, err)
@@ -217,6 +222,7 @@ func (c *Command) validateGatheredData() bool {
 
 	if summary.HasIssues(c.Report.Summary) {
 		step.Status = report.Failed
+		step.Err = fmt.Sprintf("Validation failed (%s)", summary.String(c.Report.Summary))
 		msg := "Issues found during validation"
 		console.Error(msg)
 		log.Errorf("%s: %s", msg, summary.String(c.Report.Summary))
@@ -1079,6 +1085,7 @@ func (c *Command) checkS3(profiles []*s3.Profile) bool {
 
 	c.Logger().Infof("Checking S3 profiles %q", logging.ProfileNames(profiles))
 
+	var failedProfiles []string
 	for r := range c.Backend.CheckS3(c, profiles) {
 		// Collect results to validate and report S3 status in validateS3Status.
 		c.S3Results = append(c.S3Results, r)
@@ -1093,11 +1100,14 @@ func (c *Command) checkS3(profiles []*s3.Profile) bool {
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Canceled
+				step.Err = msg
 			} else {
 				msg := fmt.Sprintf("Failed to check S3 profile %q", r.ProfileName)
 				console.Error(msg)
 				c.Logger().Errorf("%s: %s", msg, r.Err)
 				step.Status = report.Failed
+				step.Err = fmt.Sprintf("Failed to check S3 profile %q", r.ProfileName)
+				failedProfiles = append(failedProfiles, r.ProfileName)
 			}
 		} else {
 			step.Status = report.Passed
@@ -1108,7 +1118,19 @@ func (c *Command) checkS3(profiles []*s3.Profile) bool {
 
 	c.Logger().Infof("Checked S3 profiles in %.2f seconds", time.Since(start).Seconds())
 
-	return c.Current.Status != report.Canceled
+	switch c.Current.Status {
+	case report.Canceled:
+		c.Current.Err = "Canceled check S3 profiles"
+		return false
+	case report.Failed:
+		c.Current.Err = fmt.Sprintf(
+			"Failed to check S3 profiles %s",
+			strings.Join(failedProfiles, ", "),
+		)
+		return true
+	default:
+		return true
+	}
 }
 
 func (c *Command) validateS3Status(s *report.ClustersS3Status) {

--- a/pkg/validate/clusters/command_test.go
+++ b/pkg/validate/clusters/command_test.go
@@ -45,13 +45,20 @@ func TestValidateClustersK8s(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkReport(t, validate, report.Passed)
+	checkError(t, validate.Report, "")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Passed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Passed,
+	})
 
 	items := []*report.Step{
 		{Name: "gather \"hub\"", Status: report.Passed},
@@ -646,13 +653,20 @@ func TestValidateClustersOcp(t *testing.T) {
 		t.Fatal(err)
 	}
 	checkReport(t, validate, report.Passed)
+	checkError(t, validate.Report, "")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testOcp.namespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Passed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Passed,
+	})
 
 	items := []*report.Step{
 		{Name: "gather \"hub\"", Status: report.Passed},
@@ -1229,12 +1243,17 @@ func TestValidateClustersValidateFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to validate config")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Failed,
+		Err:    "Failed to validate config",
+	})
 	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -1246,12 +1265,17 @@ func TestValidateClustersValidateCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled validate config")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 1 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Canceled,
+		Err:    "Canceled validate config",
+	})
 	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
 	checkSummary(t, validate.Report, report.Summary{})
 }
@@ -1263,17 +1287,29 @@ func TestValidateClusterGatherClusterFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to gather data from clusters hub")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Failed,
+		Err:    "Failed to gather data from clusters hub",
+	})
 
 	// If gathering data fail for some of the clusters, we skip the validation step.
 	items := []*report.Step{
-		{Name: "gather \"hub\"", Status: report.Failed},
+		{
+			Name:   "gather \"hub\"",
+			Status: report.Failed,
+			Err:    `Failed to gather data from cluster "hub"`,
+		},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 	}
@@ -1290,12 +1326,20 @@ func TestValidateClustersInspectS3ProfilesFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		"Validation failed (0 ok, 0 warning, 12 problem)")
 	checkApplication(t, validate.Report, nil)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Failed,
+	})
 
 	// Inspect S3 profiles fails, check S3 is skipped. Validation runs and reports missing S3
 	// status as problem.
@@ -1303,8 +1347,16 @@ func TestValidateClustersInspectS3ProfilesFailed(t *testing.T) {
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Failed},
-		{Name: "validate clusters data", Status: report.Failed},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Failed,
+			Err:    "Failed to read S3 profiles from hub",
+		},
+		{
+			Name:   "validate clusters data",
+			Status: report.Failed,
+			Err:    "Validation failed (0 ok, 0 warning, 12 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	empty := &report.ClustersStatus{}
@@ -1322,21 +1374,32 @@ func TestValidateClustersInspectS3ProfilesCanceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled inspect S3 profiles")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Canceled,
+	})
 
 	// Inspect S3 profiles is canceled, checkS3 and validation are skipped.
 	items := []*report.Step{
 		{Name: "gather \"hub\"", Status: report.Passed},
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
-		{Name: "inspect S3 profiles", Status: report.Canceled},
+		{
+			Name:   "inspect S3 profiles",
+			Status: report.Canceled,
+			Err:    "Canceled inspect S3 profiles",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})
@@ -1351,14 +1414,23 @@ func TestValidateClustersGetSecretFailed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		"Failed to check S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Failed,
+		Err:    "Failed to check S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns an error. The profile will have empty credentials
 	// causing checkS3 and validation to fail.
@@ -1367,9 +1439,21 @@ func TestValidateClustersGetSecretFailed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "check S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "check S3 profile \"minio-on-dr2\"", Status: report.Failed},
-		{Name: "validate clusters data", Status: report.Failed},
+		{
+			Name:   "check S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to check S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "check S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to check S3 profile "minio-on-dr2"`,
+		},
+		{
+			Name:   "validate clusters data",
+			Status: report.Failed,
+			Err:    "Validation failed (91 ok, 0 warning, 2 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{summary.OK: 91, summary.Problem: 2})
@@ -1383,14 +1467,23 @@ func TestValidateClustersGetSecretInvalid(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report,
+		"Failed to check S3 profiles minio-on-dr1, minio-on-dr2")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Failed,
+		Err:    "Failed to check S3 profiles minio-on-dr1, minio-on-dr2",
+	})
 
 	// When GetSecret returns a secret with invalid value, causing checkS3 and
 	// validation to fail.
@@ -1399,9 +1492,21 @@ func TestValidateClustersGetSecretInvalid(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "check S3 profile \"minio-on-dr1\"", Status: report.Failed},
-		{Name: "check S3 profile \"minio-on-dr2\"", Status: report.Failed},
-		{Name: "validate clusters data", Status: report.Failed},
+		{
+			Name:   "check S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to check S3 profile "minio-on-dr1"`,
+		},
+		{
+			Name:   "check S3 profile \"minio-on-dr2\"",
+			Status: report.Failed,
+			Err:    `Failed to check S3 profile "minio-on-dr2"`,
+		},
+		{
+			Name:   "validate clusters data",
+			Status: report.Failed,
+			Err:    "Validation failed (91 ok, 0 warning, 2 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkSummary(t, validate.Report, report.Summary{summary.OK: 91, summary.Problem: 2})
@@ -1415,13 +1520,21 @@ func TestValidateClustersCheckS3Failed(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Failed)
+	checkError(t, validate.Report, "Failed to check S3 profiles minio-on-dr1")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Failed)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Failed,
+		Err:    "Failed to check S3 profiles minio-on-dr1",
+	})
 
 	// Check s3 fails for one profile, other profile succeeds. Validation runs and reports the
 	// failed profile as problem.
@@ -1430,9 +1543,17 @@ func TestValidateClustersCheckS3Failed(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "check S3 profile \"minio-on-dr1\"", Status: report.Failed},
+		{
+			Name:   "check S3 profile \"minio-on-dr1\"",
+			Status: report.Failed,
+			Err:    `Failed to check S3 profile "minio-on-dr1"`,
+		},
 		{Name: "check S3 profile \"minio-on-dr2\"", Status: report.Passed},
-		{Name: "validate clusters data", Status: report.Failed},
+		{
+			Name:   "validate clusters data",
+			Status: report.Failed,
+			Err:    "Validation failed (92 ok, 0 warning, 1 problem)",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	empty := &report.ClustersStatus{}
@@ -1454,13 +1575,21 @@ func TestValidateClustersCheckS3Canceled(t *testing.T) {
 		t.Fatal("command did not fail")
 	}
 	checkReport(t, validate, report.Canceled)
+	checkError(t, validate.Report, "Canceled check S3 profiles")
 	checkApplication(t, validate.Report, nil)
 	checkNamespaces(t, validate.Report, testK8s.namespaces)
 	if len(validate.Report.Steps) != 2 {
 		t.Fatalf("unexpected steps %+v", validate.Report.Steps)
 	}
-	checkStep(t, validate.Report.Steps[0], "validate config", report.Passed)
-	checkStep(t, validate.Report.Steps[1], "validate clusters", report.Canceled)
+	checkStep(t, validate.Report.Steps[0], &report.Step{
+		Name:   "validate config",
+		Status: report.Passed,
+	})
+	checkStep(t, validate.Report.Steps[1], &report.Step{
+		Name:   "validate clusters",
+		Status: report.Canceled,
+		Err:    "Canceled check S3 profiles",
+	})
 
 	// Check S3 is canceled, validation is skipped.
 	items := []*report.Step{
@@ -1468,8 +1597,16 @@ func TestValidateClustersCheckS3Canceled(t *testing.T) {
 		{Name: "gather \"dr1\"", Status: report.Passed},
 		{Name: "gather \"dr2\"", Status: report.Passed},
 		{Name: "inspect S3 profiles", Status: report.Passed},
-		{Name: "check S3 profile \"minio-on-dr1\"", Status: report.Canceled},
-		{Name: "check S3 profile \"minio-on-dr2\"", Status: report.Canceled},
+		{
+			Name:   "check S3 profile \"minio-on-dr1\"",
+			Status: report.Canceled,
+			Err:    "Canceled check S3 profile \"minio-on-dr1\"",
+		},
+		{
+			Name:   "check S3 profile \"minio-on-dr2\"",
+			Status: report.Canceled,
+			Err:    "Canceled check S3 profile \"minio-on-dr2\"",
+		},
 	}
 	checkItems(t, validate.Report.Steps[1], items)
 	checkClusterStatus(t, validate.Report, &report.ClustersStatus{})

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	stdtime "time"
 
 	"github.com/nirs/kubectl-gather/pkg/gather"
@@ -159,6 +160,7 @@ func (c *Command) GatherNamespaces(options gathering.Options) bool {
 	c.Logger().Infof("Gathering from clusters %q with options %+v",
 		logging.ClusterNames(clusters), options)
 
+	var failedClusters []string
 	for r := range c.Backend.Gather(c, clusters, options) {
 		step := &report.Step{Name: fmt.Sprintf("gather %q", r.Name), Duration: r.Duration}
 		if r.Err != nil {
@@ -166,6 +168,8 @@ func (c *Command) GatherNamespaces(options gathering.Options) bool {
 			console.Error(msg)
 			c.Logger().Errorf("%s: %s", msg, r.Err)
 			step.Status = report.Failed
+			step.Err = fmt.Sprintf("Failed to gather data from cluster %q", r.Name)
+			failedClusters = append(failedClusters, r.Name)
 		} else {
 			console.Pass("Gathered data from cluster %q", r.Name)
 			step.Status = report.Passed
@@ -175,7 +179,19 @@ func (c *Command) GatherNamespaces(options gathering.Options) bool {
 
 	c.Logger().Infof("Gathered clusters in %.2f seconds", time.Since(start).Seconds())
 
-	return c.Current.Status == report.Passed
+	switch c.Current.Status {
+	case report.Canceled:
+		c.Current.Err = "Canceled gather data from clusters"
+		return false
+	case report.Failed:
+		c.Current.Err = fmt.Sprintf(
+			"Failed to gather data from clusters %s",
+			strings.Join(failedClusters, ", "),
+		)
+		return false
+	default:
+		return true
+	}
 }
 
 func (c *Command) OutputReader(cluster string) gathering.OutputReader {
@@ -238,9 +254,11 @@ func (c *Command) FailStep(err error) bool {
 	c.Current.Duration = time.Since(c.currentStarted).Seconds()
 	if errors.Is(err, context.Canceled) {
 		c.Current.Status = report.Canceled
+		c.Current.Err = fmt.Sprintf("Canceled %s", c.Current.Name)
 		console.Error("Canceled %s", c.Current.Name)
 	} else {
 		c.Current.Status = report.Failed
+		c.Current.Err = fmt.Sprintf("Failed to %s", c.Current.Name)
 		console.Error("Failed to %s", c.Current.Name)
 	}
 	c.Logger().Errorf("Step %q %s: %s", c.Current.Name, c.Current.Status, err)

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -217,19 +217,19 @@ func (c *Command) WriteReport(r HTMLWriter) {
 
 	file, err := c.cmd.OpenReport("html")
 	if err != nil {
-		console.Error("failed to open HTML report: %s", err)
+		console.Error("Failed to open HTML report: %s", err)
 		return
 	}
 	defer file.Close()
 	if err := r.WriteHTML(file); err != nil {
-		console.Error("failed to write HTML report: %s", err)
+		console.Error("Failed to write HTML report: %s", err)
 	}
 	if err := file.Close(); err != nil {
-		console.Error("failed to close HTML report: %s", err)
+		console.Error("Failed to close HTML report: %s", err)
 	}
 
 	if err := report.WriteCSS(c.cmd.OutputDir()); err != nil {
-		console.Error("failed to write report CSS: %s", err)
+		console.Error("Failed to write report CSS: %s", err)
 	}
 }
 

--- a/pkg/validate/command/command.go
+++ b/pkg/validate/command/command.go
@@ -211,10 +211,15 @@ func (c *Command) ReportFile(format string) string {
 	return c.cmd.ReportFile(format)
 }
 
-// WriteReport writes YAML, HTML, and CSS reports to the command output directory.
+// WriteReport writes YAML report, and HTML + CSS reports when validation ran.
 func (c *Command) WriteReport(r HTMLWriter) {
 	c.cmd.WriteYAMLReport(r)
+	if len(*c.Report.Summary) > 0 {
+		c.writeHTMLReport(r)
+	}
+}
 
+func (c *Command) writeHTMLReport(r HTMLWriter) {
 	file, err := c.cmd.OpenReport("html")
 	if err != nil {
 		console.Error("Failed to open HTML report: %s", err)


### PR DESCRIPTION
## Summary

When validation fails early (e.g., DRPC not found, config validation
fails, or the user cancels), we show an empty HTML report with no
useful information and a generic error message like "validation failed
(0 ok, 0 warning, 0 problem)".

This PR adds step-level error tracking so failed runs report
meaningful errors and skip writing useless HTML reports.

## Changes

### Step 1: Keep errors in Step

Add `Step.Err` field to record why a step failed, and `Step.Error()`
/ `Base.Error()` methods to walk the step tree and extract the error
that stopped a run. The error semantics follow the step structure:
the last child is the one that stopped a sequential flow, and parent
errors shadow children for parallel steps.

### Step 2: Set errors on failures

Set user-friendly `Err` on every failing or canceled step across all
commands (validate, gather, test). All error messages use sentence
case for consistency with console output. The error patterns vary by
step type:

* Simple steps: `FailStep()`/`failStep()` generates the error from
  the step name. Steps needing more context set `Err` directly.
* Parallel operations: parent summarizes child failures
* Canceled operations: distinct cancellation message
* Validation/test steps: include summary counts

All tests updated to verify `Report.Error()` and `step.Err`.

### Step 3: Use Report.Error() in all commands

All commands now use `Report.Error()` in `failed()` instead of
generic messages. This gives the user a specific description of what
went wrong:

* validate: "Validation failed (0 ok, 0 warning, 0 problem)" ->
  actual step error
* gather: "Gather failed" -> actual step error
* test: "failed (0 passed, 0 failed, ...)" -> actual step error.
  Also fixes misleading zero summary when validate/setup failed
  before any tests ran.

Skip writing HTML report and CSS when no validation checks ran
(empty summary). `BrowseReport` silently skips when the HTML file
does not exist.

Console error messages for file I/O normalized to sentence case.

## Example run - broken clusters

Validating no regression in positive flows.

```console
% ramenctl validate clusters -c ocp/config.yaml -o out/ocp/clusters-wrong-secret                  
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/clusters-wrong-secret"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate clusters ...
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "prsurve-c1-ibm2"
   ✅ Gathered data from cluster "prsurve-c2-ibm3"
   ✅ Inspected S3 profiles
   ✅ Checked S3 profile "s3profile-prsurve-c1-ibm2-ocs-storagecluster"
   ✅ Checked S3 profile "s3profile-prsurve-c2-ibm3-ocs-storagecluster"
   ❌ Issues found during validation

❌ Validation failed (92 ok, 0 warning, 3 problem)
```

### HTML report

<img width="1907" height="1257" alt="bad secret" src="https://github.com/user-attachments/assets/7de6bc73-8a0d-4095-9706-ee8ef4d40bbb" />

### YAML report

The failing step ("validate clusters data") shows the error (new feature).

```yaml
steps:
- duration: 1.579763458
  name: validate config
  status: passed
- duration: 31.707401666
  items:
  - duration: 15.599037792
    name: gather "hub"
    status: passed
  - duration: 25.178876334
    name: gather "prsurve-c1-ibm2"
    status: passed
  - duration: 30.790871458
    name: gather "prsurve-c2-ibm3"
    status: passed
  - duration: 0.299749333
    name: inspect S3 profiles
    status: passed
  - duration: 0.586134542
    name: check S3 profile "s3profile-prsurve-c1-ibm2-ocs-storagecluster"
    status: passed
  - duration: 0.602765917
    name: check S3 profile "s3profile-prsurve-c2-ibm3-ocs-storagecluster"
    status: passed
  - duration: 0.012232167
    error: Validation failed (92 ok, 0 warning, 3 problem)
    name: validate clusters data
    status: failed
```

## Example run - validate application ok

Validating no regression in positive flows.

```console
% ramenctl validate application --namespace openshift-dr-ops --name dis-rbd-alert2 -c ocp/config.yaml -o out/ocp/application-ok
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/application-ok"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "prsurve-c1-ibm2"
   ✅ Gathered data from cluster "prsurve-c2-ibm3"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "s3profile-prsurve-c1-ibm2-ocs-storagecluster"
   ✅ Gathered S3 profile "s3profile-prsurve-c2-ibm3-ocs-storagecluster"
   ✅ Application validated

✅ Validation completed (66 ok, 0 warning, 0 problem)
```

### HTML report

<img width="1907" height="1257" alt="Screenshot 2026-05-20 at 21 16 09" src="https://github.com/user-attachments/assets/ce166bae-e936-4712-baaa-9334017b1af1" />

## Example run - validate config failed (fix)

Validating fix for https://redhat.atlassian.net/browse/DFBUGS-6902 by using the wrong clusterset name. This cause validate config step to fail. We fail early without generating empty HTML report.

```
% ramenctl validate application --namespace openshift-dr-ops --name dis-rbd-alert2 -c ocp/config.yaml -o out/ocp/application-validation-failed
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/application-validation-failed"

🔎 Validate config ...
   ❌ Failed to validate config

❌ Failed to validate config
```

### HTML report not generated

```console
% tree out/ocp/application-validation-failed 
out/ocp/application-validation-failed
├── validate-application.log
└── validate-application.yaml
```

### YAML report shows the failed step error

```yaml
steps:
- duration: 1.614549542
  error: Failed to validate config
  name: validate config
  status: failed
```

## Example run - wrong application name (fix)

Validating fix for #448 - we get expected output with detailed error and do not create empty HTML report.

```console
% ramenctl validate application --namespace openshift-dr-ops --name no-such-app -c ocp/config.yaml -o out/ocp/application-missing
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/application-missing"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ❌ Failed to inspect application

❌ Failed to inspect application "no-such-app" in namespace "openshift-dr-ops"
```

### HTML report not generated

```console
% tree out/ocp/application-missing 
out/ocp/application-missing
├── validate-application.log
└── validate-application.yaml
```

### YAML report shows the error

```yaml
steps:
- duration: 1.776395166
  name: validate config
  status: passed
- duration: 0.154845459
  items:
  - duration: 0.154098
    error: Failed to inspect application "no-such-app" in namespace "openshift-dr-ops"
    name: inspect application
    status: failed
  name: validate application
  status: failed
```

## Example run with cancellation (fix)

Validating fix for #449 - don't generate html report for canceled run.

Pressing Cntl+C while gathering cluster data. We don't handle cancellation during gather, so we fail when trying to get the secret from hub in inspect s3 profiles step.

```console
% ramenctl validate application --namespace openshift-dr-ops --name dis-rbd-alert2 -c ocp/config.yaml -o out/ocp/application-canceled
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/application-canceled"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
^C   ✅ Gathered data from cluster "prsurve-c2-ibm3"
   ✅ Gathered data from cluster "prsurve-c1-ibm2"
   ❌ Canceled inspect S3 profiles

❌ Canceled inspect S3 profiles
```

### HTML report not generated

```console
% tree -L1 out/ocp/application-canceled
out/ocp/application-canceled
├── validate-application.data
├── validate-application.log
└── validate-application.yaml
```

### YAML report shows the step error

```yaml
steps:
- duration: 1.5748328329999999
  name: validate config
  status: passed
- duration: 39.152094542
  items:
  - duration: 0.152303208
    name: inspect application
    status: passed
  - duration: 17.632291875
    name: gather "hub"
    status: passed
  - duration: 38.521963917
    name: gather "prsurve-c2-ibm3"
    status: passed
  - duration: 38.995539375
    name: gather "prsurve-c1-ibm2"
    status: passed
  - duration: 0.0018715
    error: Canceled inspect S3 profiles
    name: inspect S3 profiles
    status: canceled
```

## Example run - failed and canceled tests

Testing that canceled and failed test steps report the error and the final failure message doe snot report partial results.

```console
% ramenctl test run -c ocp/config.yaml -o out/ocp/test-canceled
⭐ Using config "ocp/config.yaml"
⭐ Using report "out/ocp/test-canceled"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "disapp-deploy-cephfs" deployed
   ✅ Application "disapp-deploy-rbd" deployed
   ✅ Application "appset-deploy-rbd" deployed
   ✅ Application "appset-deploy-cephfs" deployed
   ✅ Application "subscr-deploy-cephfs" deployed
   ✅ Application "subscr-deploy-rbd" deployed
   ✅ Application "disapp-deploy-rbd" protected
   ✅ Application "appset-deploy-rbd" protected
   ✅ Application "subscr-deploy-rbd" protected
   ❌ Failed to protect application "disapp-deploy-cephfs"
   ❌ Failed to protect application "appset-deploy-cephfs"
   ❌ Failed to protect application "subscr-deploy-cephfs"
   ✅ Application "disapp-deploy-rbd" failed over
   ✅ Application "subscr-deploy-rbd" failed over
   ✅ Application "appset-deploy-rbd" failed over
   ✅ Application "subscr-deploy-rbd" relocated
^C   ❌ Canceled application "appset-deploy-rbd" relocate
   ❌ Canceled application "subscr-deploy-rbd" unprotect
   ❌ Canceled application "disapp-deploy-rbd" relocate

❌ Test run canceled
``` 

### YAML report show test errors and cancellations

```yaml
steps:
- duration: 2.619539833
  name: validate
  status: passed
- duration: 0.3243645
  name: setup
  status: passed
- duration: 641.839608958
  error: Test run canceled
  items:
  - duration: 641.835622332
    items:
    - duration: 21.793301083
      name: deploy
      status: passed
    - duration: 63.022719041
      name: protect
      status: passed
    - duration: 424.206857208
      name: failover
      status: passed
    - duration: 132.812745
      error: Canceled relocate application "appset-deploy-rbd"
      name: relocate
      status: canceled
    name: appset-deploy-rbd
    status: canceled
  - duration: 321.84178825000004
    items:
    - duration: 21.841355458
      name: deploy
      status: passed
    - duration: 300.000432792
      error: Failed to protect application "appset-deploy-cephfs"
      name: protect
      status: failed
    name: appset-deploy-cephfs
    status: failed
  - duration: 641.83564379
    items:
    - duration: 22.05738875
      name: deploy
      status: passed
    - duration: 62.905179041
      name: protect
      status: passed
    - duration: 424.056761792
      name: failover
      status: passed
    - duration: 130.811438291
      name: relocate
      status: passed
    - duration: 2.004875916
      error: Canceled unprotect application "subscr-deploy-rbd"
      name: unprotect
      status: canceled
    name: subscr-deploy-rbd
    status: canceled
  - duration: 322.05402270800005
    items:
    - duration: 22.053148833
      name: deploy
      status: passed
    - duration: 300.000873875
      error: Failed to protect application "subscr-deploy-cephfs"
      name: protect
      status: failed
    name: subscr-deploy-cephfs
    status: failed
  - duration: 641.839405207
    items:
    - duration: 11.214865041
      name: deploy
      status: passed
    - duration: 63.306014583
      name: protect
      status: passed
    - duration: 274.7403885
      name: failover
      status: passed
    - duration: 292.578137083
      error: Canceled relocate application "disapp-deploy-rbd"
      name: relocate
      status: canceled
    name: disapp-deploy-rbd
    status: canceled
  - duration: 311.186481999
    items:
    - duration: 11.184096833
      name: deploy
      status: passed
    - duration: 300.002385166
      error: Failed to protect application "disapp-deploy-cephfs"
      name: protect
      status: failed
    name: disapp-deploy-cephfs
    status: failed
  name: tests
  status: canceled
```

---
Fixes #448
Fixes #449

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suppress misleading warning when HTML report is absent; clearer YAML write/close error messages.

* **New Features**
  * Step-level error messages now show precise failure/cancellation reasons and aggregate failed clusters/profiles/apps.
  * Report-level error now reflects the most relevant failing step for clearer command-level errors.

* **Refactor**
  * YAML always written; HTML/CSS only produced when report content warrants it and HTML writing is centralized.

* **Tests**
  * Expanded tests to assert report- and per-step error messages and equality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramenctl/pull/456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->