### PR TITLE
command: Test more cases for gap in sequence numbers

### DIFF
--- a/pkg/command/suffix_test.go
+++ b/pkg/command/suffix_test.go
@@ -70,12 +70,20 @@ func TestFindNextSuffix(t *testing.T) {
 			suffix: "-2",
 		},
 		{
-			name: "gap in sequence numbers",
+			name: "gap in middle",
 			files: []string{
 				"validate-clusters.log",
 				"validate-clusters-3.log",
 			},
 			suffix: "-4",
+		},
+		{
+			name: "gap in front",
+			files: []string{
+				"validate-clusters-4.yaml",
+				"validate-clusters-5.log",
+			},
+			suffix: "-6",
 		},
 	}
 


### PR DESCRIPTION
Keerthana reported an issue when files for 4,5 exists, and the next report was 3 instead of 6. Add test for this case, showing the we handle this case correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for suffix sequence gap detection with additional edge case scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RamenDR/ramenctl/pull/457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->