### PR TITLE
test: Add mdformat to make fmt and CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,17 @@ jobs:
           make htmlfmt
           git diff --exit-code
 
+  mdformat:
+    name: Markdown Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v6
+      - name: Install mdformat
+        run: pip3 install -r requirements.txt
+      - name: Check markdown formatting
+        run: git ls-files -z '*.md' | xargs -0 mdformat --check
+
   build-matrix:
     name: Build
     runs-on: ubuntu-latest

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: The RamenDR authors
+# SPDX-License-Identifier: Apache-2.0
+
+# mdformat configuration
+# https://mdformat.readthedocs.io/en/stable/users/configuration_file.html
+
+# Line length - keep at 80 to match Ramen configuration.
+wrap = 80

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # ramenctl contribution guide
 
-We accept contributions via GitHub pull requests. This document outlines
-some of the conventions related to development workflow to make it
-easier to get your contribution accepted.
+We accept contributions via GitHub pull requests. This document outlines some of
+the conventions related to development workflow to make it easier to get your
+contribution accepted.
 
 ## Getting Started
 
@@ -21,8 +21,7 @@ easier to get your contribution accepted.
 This is a rough outline of what a contributor's workflow looks like:
 
 1. Create a branch from where you want to base your work (usually main).
-1. Make your changes, keeping every commit focused on one logical
-   change.
+1. Make your changes, keeping every commit focused on one logical change.
 1. Make sure your commit messages are in the proper format (see below).
 1. Push your changes to the branch in your fork of the repository.
 1. Make sure all tests pass, and add any new tests as appropriate.
@@ -31,9 +30,9 @@ This is a rough outline of what a contributor's workflow looks like:
 
 ## Commit message
 
-We follow a rough convention for commit messages that is designed to
-answer two questions: what changed and why. The subject line should
-feature the what and the body of the commit should describe the why.
+We follow a rough convention for commit messages that is designed to answer two
+questions: what changed and why. The subject line should feature the what and
+the body of the commit should describe the why.
 
 ```
 commands/test: Initial implementation
@@ -46,17 +45,17 @@ cluster is working properly.
 [1] https://github.com/RamenDR/ramen/tree/main/e2e
 ```
 
-The first line is the subject and should be no longer than 70
-characters, the second line is always blank, and other lines should be
-wrapped at 80 characters.  This allows the message to be easier to read
-on GitHub as well as in various git tools.
+The first line is the subject and should be no longer than 70 characters, the
+second line is always blank, and other lines should be wrapped at 80 characters.
+This allows the message to be easier to read on GitHub as well as in various git
+tools.
 
 ## Certificate of Origin
 
-By contributing to this project you agree to the Developer Certificate
-of Origin (DCO). This document was created by the Linux Kernel community
-and is a simple statement that you, as a contributor, have the legal
-right to make the contribution. See the [DCO](DCO) file for details.
+By contributing to this project you agree to the Developer Certificate of Origin
+(DCO). This document was created by the Linux Kernel community and is a simple
+statement that you, as a contributor, have the legal right to make the
+contribution. See the [DCO](DCO) file for details.
 
 Contributors sign-off that they adhere to these requirements by adding a
 Signed-off-by line to commit messages. For example:
@@ -73,8 +72,8 @@ You can append this automatically to the commit message using:
 git commit -s
 ```
 
-If you have already made a commit and forgot to include the sign-off,
-you can amend your last commit to add the sign-off using:
+If you have already made a commit and forgot to include the sign-off, you can
+amend your last commit to add the sign-off using:
 
 ```console
 git commit --amend -s
@@ -99,5 +98,6 @@ make fmt
 
 The `tools/git` directory contains git hooks that you may want to install. See
 the hook documentation for more info:
+
 - pre-commit - automatically run `make pre-commit`
 - commit-msg - automatically add Signed-off-by footer

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ pre-commit: fmt htmlfmt spell lint
 
 fmt:
 	golangci-lint fmt
+	git ls-files -z '*.md' | xargs -0 mdformat
 
 htmlfmt:
 	find pkg -path '*/testdata/*.html' -exec $(GO) run ./tools/htmlfmt {} \;

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Command line tool and Go module for managing and troubleshooting Ramen.
 
 ## Overview
 
-Working with a complicated Kubernetes cluster is not easy.  In a typical
-disaster recovery environment we have at least 3 connected Kubernetes
-clusters with many components. The *ramenctl* project aims to make it
-easier to manage and troubleshoot this challenging environment.
+Working with a complicated Kubernetes cluster is not easy. In a typical disaster
+recovery environment we have at least 3 connected Kubernetes clusters with many
+components. The *ramenctl* project aims to make it easier to manage and
+troubleshoot this challenging environment.
 
 ## Features
 
@@ -27,7 +27,8 @@ The project provides:
 - The *ramenctl* command line tool, managing and troubleshooting ramen.
 - The *ramenctl* Go module for integrating the ramenctl commands in other
   projects. This module is used to implement the
-  [odf dr](https://github.com/red-hat-storage/odf-cli/blob/main/docs/dr.md) command.
+  [odf dr](https://github.com/red-hat-storage/odf-cli/blob/main/docs/dr.md)
+  command.
 
 ## Installing
 
@@ -98,9 +99,8 @@ Check the guides below to learn more:
 
 ## Contributing
 
-- For reporting bugs, suggesting improvements, or requesting new
-  features, please open an
-  [issue](https://github.com/RamenDR/ramenctl/issues).
+- For reporting bugs, suggesting improvements, or requesting new features,
+  please open an [issue](https://github.com/RamenDR/ramenctl/issues).
 - For implementing features or fixing bugs, please see the
   [ramenctl contribution guide](CONTRIBUTING.md)
 

--- a/docs/gather.md
+++ b/docs/gather.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # ramenctl gather
 
@@ -28,8 +30,8 @@ Use "ramenctl gather [command] --help" for more information about a command.
 
 > [!IMPORTANT]
 > The gather command requires a configuration file. See
-> [Configuring common options](docs/init.md#configuring-common-options)
-> to learn how to create one.
+> [Configuring common options](docs/init.md#configuring-common-options) to learn
+> how to create one.
 
 ## gather application
 
@@ -39,8 +41,8 @@ protected application across the hub and the managed clusters.
 
 ### Looking up applications
 
-To run the gather application command, we need to find the protected
-application name and namespace. Run the following command:
+To run the gather application command, we need to find the protected application
+name and namespace. Run the following command:
 
 ```console
 $ kubectl get drpc -A --context hub
@@ -50,8 +52,8 @@ argocd      appset-deploy-rbd   6m16s   dr1                                     
 
 ### Gathering application data
 
-To gather data for the application `appset-deploy-rbd` in namespace `argocd`
-run the following command:
+To gather data for the application `appset-deploy-rbd` in namespace `argocd` run
+the following command:
 
 ```console
 $ ramenctl gather application --name appset-deploy-rbd --namespace argocd -o out
@@ -120,9 +122,9 @@ out/gather-application.data
         └── test-appset-deploy-rbd
 ```
 
-Secrets in the gathered data are automatically sanitized. See [Secret
-sanitization](https://github.com/nirs/kubectl-gather#secret-sanitization) for
-more info.
+Secrets in the gathered data are automatically sanitized. See
+[Secret sanitization](https://github.com/nirs/kubectl-gather#secret-sanitization)
+for more info.
 
 You can use standard tools to inspect the resources:
 

--- a/docs/html.md
+++ b/docs/html.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # HTML Report Generation
 
@@ -15,21 +17,21 @@ reports that are human-readable and shareable.
 ## Requirements
 
 1. Each command has its own report structure with specific data
-2. HTML reports share common styling and layout
-3. External tools can unmarshal YAML reports without custom parsing
-4. Templates should be standard Go templates for maintainability
-5. HTML reports are self-contained (embedded CSS)
+1. HTML reports share common styling and layout
+1. External tools can unmarshal YAML reports without custom parsing
+1. Templates should be standard Go templates for maintainability
+1. HTML reports are self-contained (embedded CSS)
 
 ## Report Types
 
 Each command has its own report type with clear structure:
 
-| Command | Report Type | Specific Data |
-|---------|-------------|---------------|
+| Command              | Report Type          | Specific Data                  |
+| -------------------- | -------------------- | ------------------------------ |
 | validate-application | `application.Report` | Application, ApplicationStatus |
-| validate-clusters | `clusters.Report` | ClustersStatus |
-| test-run | `test.Report` | Config, TestResults |
-| gather-application | `gather.Report` | Application, GatherResults |
+| validate-clusters    | `clusters.Report`    | ClustersStatus                 |
+| test-run             | `test.Report`        | Config, TestResults            |
+| gather-application   | `gather.Report`      | Application, GatherResults     |
 
 All reports embed `report.Report` (for validate/gather) or `report.Base` (for
 test) which contains common fields.
@@ -54,7 +56,7 @@ Kubernetes `kind`). We may rename it to `Kind` in the future.
 External tools can unmarshal reports by:
 
 1. Using the specific report type directly if known
-2. Using a helper function that detects the type from the `Name` field
+1. Using a helper function that detects the type from the `Name` field
 
 ## HTML Template Structure
 
@@ -79,8 +81,8 @@ pkg/validate/application/
 
 ### Main Report Template
 
-The shared `report.tmpl` defines the complete HTML structure. Each command
-only needs to define its `content` template:
+The shared `report.tmpl` defines the complete HTML structure. Each command only
+needs to define its `content` template:
 
 ```html
 <!DOCTYPE html>
@@ -175,8 +177,8 @@ func Template() (*template.Template, error) {
 
 ### Command HTML writing
 
-Command report provides the `WriteHTML()` function using the command template
-to write report HTML.
+Command report provides the `WriteHTML()` function using the command template to
+write report HTML.
 
 ```go
 func (r *Report) WriteHTML(w io.Writer) error {
@@ -193,8 +195,8 @@ func (r *Report) WriteHTML(w io.Writer) error {
 To add HTML support for a new command (e.g., `gather-application`):
 
 1. Create `templates/content.tmpl` defining the `content` template
-2. Create `html.go` with `templateData` type and `Template()` function
-3. Add `WriteHTML()` method to the report type
+1. Create `html.go` with `templateData` type and `Template()` function
+1. Add `WriteHTML()` method to the report type
 
 ## Testing HTML output
 

--- a/docs/init.md
+++ b/docs/init.md
@@ -1,10 +1,12 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # ramenctl init
 
-The init command crates a configuration file required for other
-*ramenctl* commands.
+The init command crates a configuration file required for other *ramenctl*
+commands.
 
 ```console
 % ramenctl init -h
@@ -23,8 +25,8 @@ Global Flags:
 
 ## Creating a configuration file
 
-The init command creates a configuration file named "config.yaml" in the
-current directory:
+The init command creates a configuration file named "config.yaml" in the current
+directory:
 
 ```console
 $ ramenctl init
@@ -33,8 +35,8 @@ $ ramenctl init
 ```
 
 > [!IMPORTANT]
-> Before using the configuration file you need to edit it to match your
-> clusters and storage.
+> Before using the configuration file you need to edit it to match your clusters
+> and storage.
 
 Other *ramenctl* commands use "config.yaml" by default.
 
@@ -54,9 +56,9 @@ You can edit the configuration file to change the default tests.
 
 ## Using multiple configuration files
 
-When working with multiple environments or when you want to run
-different sets of tests with the same environment, you can create
-multiple configuration files and use them with the `--config` option.
+When working with multiple environments or when you want to run different sets
+of tests with the same environment, you can create multiple configuration files
+and use them with the `--config` option.
 
 Create a configuration file named "myenv.yaml":
 
@@ -78,8 +80,8 @@ $ ramenctl test run --config myenv.yaml -o test
 
 ## Configuring common options
 
-All *ramenctl* commands require the `clusters` and `clusterSet` options.
-For the validate and gather commands, these are the only options needed.
+All *ramenctl* commands require the `clusters` and `clusterSet` options. For the
+validate and gather commands, these are the only options needed.
 
 > [!TIP]
 > When using a ramen testing environment, the `--envfile` option configures
@@ -88,9 +90,9 @@ For the validate and gather commands, these are the only options needed.
 
 ### Configuring clusters
 
-Modify the `clusters` section to match your hub and managed clusters
-kubeconfig files. Set `passive-hub` kubeconfig for optional passive hub
-cluster, or leave it empty if not using passive hub.
+Modify the `clusters` section to match your hub and managed clusters kubeconfig
+files. Set `passive-hub` kubeconfig for optional passive hub cluster, or leave
+it empty if not using passive hub.
 
 ```yaml
 clusters:
@@ -109,8 +111,7 @@ clusters:
 The `clusterSet` option specifies the Open Cluster Management
 `ManagedClusterSet` that contains the managed clusters.
 
-To find the clusterSet for your managed clusters, run the following
-command:
+To find the clusterSet for your managed clusters, run the following command:
 
 ```console
 $ kubectl get managedclusters --kubeconfig my-hub.yaml -L cluster.open-cluster-management.io/clusterset
@@ -120,8 +121,8 @@ my-c2           true           https://api.my-c2.example.com:6443   True     Tru
 local-cluster   true           https://api.my-hub.example.com:6443  True     True        16d   default
 ```
 
-The `CLUSTERSET` column shows which clusterSet each managed cluster
-belongs to. Use this value in the configuration file:
+The `CLUSTERSET` column shows which clusterSet each managed cluster belongs to.
+Use this value in the configuration file:
 
 ```yaml
 clusterSet: dr-clusters
@@ -147,10 +148,9 @@ clusterSet: dr-clusters
 
 ## Configuration for the test command
 
-The test command requires the [common options](#configuring-common-options)
-and additional test options. The following is a sample configuration
-file showing the default values. You must modify it to match your
-clusters and storage.
+The test command requires the [common options](#configuring-common-options) and
+additional test options. The following is a sample configuration file showing
+the default values. You must modify it to match your clusters and storage.
 
 ```yaml
 ## ramenctl configuration file

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # ramenctl test
 
@@ -30,8 +32,8 @@ Use "ramenctl test [command] --help" for more information about a command.
 
 The command supports the following sub-commands:
 
-* [run](#test-run)
-* [clean](#test-clean)
+- [run](#test-run)
+- [clean](#test-clean)
 
 > [!IMPORTANT]
 > The test command requires a configuration file. See [init](docs/init.md) to

--- a/docs/test/plan.md
+++ b/docs/test/plan.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # `odf dr` test plan
 
@@ -52,13 +54,14 @@
 
 ## Overview
 
-This test plan covers functional validation of the `odf dr` command in a
-real ODF + Ramen Regional DR environment. The `odf dr` command is delivered
-as part of the odf-cli project and is based on the upstream ramenctl project.
-The goal is to verify that all commands produce correct output, detect real
-problems, and generate usable reports.
+This test plan covers functional validation of the `odf dr` command in a real
+ODF + Ramen Regional DR environment. The `odf dr` command is delivered as part
+of the odf-cli project and is based on the upstream ramenctl project. The goal
+is to verify that all commands produce correct output, detect real problems, and
+generate usable reports.
 
 Each test case includes:
+
 - **Preconditions**: what must be true before the test
 - **Steps**: exact user actions
 - **Expected result**: what the user should observe
@@ -74,46 +77,46 @@ the `ramenctl` command.
 
 Regional DR environment with 3 clusters:
 
-| Cluster | Description |
-|---------|-------------|
-| Hub | ACM hub cluster |
-| c1 | Managed cluster |
-| c2 | Managed cluster |
+| Cluster | Description     |
+| ------- | --------------- |
+| Hub     | ACM hub cluster |
+| c1      | Managed cluster |
+| c2      | Managed cluster |
 
-Different tests require different cluster configuration levels. Each test
-case specifies its own preconditions. The main levels are:
+Different tests require different cluster configuration levels. Each test case
+specifies its own preconditions. The main levels are:
 
-| Level | Description |
-|-------|-------------|
-| Base clusters | Hub with ACM/OCM, managed clusters joined, no Ramen or DR configuration |
-| Ramen deployed | Ramen hub and DR cluster operators deployed, not configured |
-| DR configured | DRPolicy, DRClusters, S3 profiles, and storage replication configured |
-| Application protected | A DR-protected application deployed and in a stable state |
+| Level                   | Description                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------------- |
+| Base clusters           | Hub with ACM/OCM, managed clusters joined, no Ramen or DR configuration                       |
+| Ramen deployed          | Ramen hub and DR cluster operators deployed, not configured                                   |
+| DR configured           | DRPolicy, DRClusters, S3 profiles, and storage replication configured                         |
+| Application protected   | A DR-protected application deployed and in a stable state                                     |
 | Application in-progress | A DR action (failover or relocate) is in progress; the application is moving between clusters |
-| Application degraded | Application is protected but a component is unhealthy (e.g., rbd-mirror daemon is down) |
+| Application degraded    | Application is protected but a component is unhealthy (e.g., rbd-mirror daemon is down)       |
 
 Some tests (e.g., validate clusters on unconfigured clusters) specifically
 require clusters that are NOT fully configured, to verify that `odf dr`
 correctly detects and reports missing components. Other tests require the
 application to be in a transient or degraded state to verify that `odf dr`
-correctly reports problems during DR operations or when replication
-components are unhealthy.
+correctly reports problems during DR operations or when replication components
+are unhealthy.
 
 ### Software
 
-| Component | Notes |
-|-----------|-------|
-| odf-cli | Built from the version under test, provides the `odf dr` command |
-| ramenctl | For testing upstream only features |
-| oc | For verifying cluster state before and after tests (not a dependency of odf dr) |
-| yq | For inspecting YAML reports |
+| Component | Notes                                                                           |
+| --------- | ------------------------------------------------------------------------------- |
+| odf-cli   | Built from the version under test, provides the `odf dr` command                |
+| ramenctl  | For testing upstream only features                                              |
+| oc        | For verifying cluster state before and after tests (not a dependency of odf dr) |
+| yq        | For inspecting YAML reports                                                     |
 
 ### Storage
 
 ODF creates storage classes during installation. The default names used by
 `odf dr init` may differ from the actual names in your clusters. Check the
-available storage classes and update the `pvcSpecs` section in the
-configuration file accordingly:
+available storage classes and update the `pvcSpecs` section in the configuration
+file accordingly:
 
 ```bash
 oc get storageclass
@@ -121,10 +124,10 @@ oc get storageclass
 
 Common storage types used for DR testing:
 
-| Type | Access Mode | Example Storage Class |
-|------|-------------|-----------------------|
-| RBD | ReadWriteOnce | `ocs-storagecluster-ceph-rbd` |
-| CephFS | ReadWriteMany | `ocs-storagecluster-cephfs` |
+| Type   | Access Mode   | Example Storage Class         |
+| ------ | ------------- | ----------------------------- |
+| RBD    | ReadWriteOnce | `ocs-storagecluster-ceph-rbd` |
+| CephFS | ReadWriteMany | `ocs-storagecluster-cephfs`   |
 
 ## Test cases
 
@@ -138,8 +141,8 @@ Common storage types used for DR testing:
 ramenctl --version
 ```
 
-**Expected result:** Prints the version string (e.g., `v0.17.0`) and exits
-with code 0.
+**Expected result:** Prints the version string (e.g., `v0.17.0`) and exits with
+code 0.
 
 #### Help
 
@@ -171,8 +174,8 @@ odf dr test --help
 odf dr validate clusters
 ```
 
-**Expected result:** Error message indicating `--output` flag is required.
-Exits with non-zero code.
+**Expected result:** Error message indicating `--output` flag is required. Exits
+with non-zero code.
 
 #### Missing config file
 
@@ -184,7 +187,6 @@ odf dr validate clusters -c nonexistent.yaml -o out/invalid-config
 
 **Expected result:** Error message about missing config file. Exits with
 non-zero code.
-
 
 ### Init command
 
@@ -199,6 +201,7 @@ odf dr init
 ```
 
 **Expected result:**
+
 - Prints `Created config file "config.yaml" - please modify for your clusters`.
 - File `config.yaml` is created with documented sections: `clusters`, `repo`,
   `drPolicy`, `clusterSet`, `pvcSpecs`, `deployers`, `tests`.
@@ -216,6 +219,7 @@ odf dr init --config myenv.yaml
 ```
 
 **Expected result:**
+
 - Prints `Created config file "myenv.yaml" - please modify for your clusters`.
 - File `myenv.yaml` is created.
 
@@ -230,8 +234,10 @@ ramenctl init --envfile ../ramen/test/envs/regional-dr.yaml
 ```
 
 **Expected result:**
+
 - Prints the envfile path and success message.
-- `config.yaml` is populated with cluster names, storage class names and distro relevant to ramen testing environment.
+- `config.yaml` is populated with cluster names, storage class names and distro
+  relevant to ramen testing environment.
 
 #### Config already exists
 
@@ -246,15 +252,16 @@ odf dr init
 **Expected result:** Error indicating the file already exists. Does not
 overwrite the existing file.
 
-
 ### Validate clusters command
 
 **Preconditions for all tests in this section:**
+
 - `config.yaml` is configured with correct kubeconfig paths.
 
 #### Validate fully configured clusters
 
 **Preconditions:**
+
 - Cluster level: DR configured.
 
 **Steps:**
@@ -264,8 +271,8 @@ odf dr validate clusters -o out/validate-clusters
 ```
 
 **Expected result:**
-- Console output shows progress with checkmarks for each cluster and S3
-  profile.
+
+- Console output shows progress with checkmarks for each cluster and S3 profile.
 - Final line: `Validation completed (N ok, 0 warning, 0 problem)`.
 - Exits with code 0.
 
@@ -276,6 +283,7 @@ ls out/validate-clusters/
 ```
 
 Expected directory contents:
+
 - `validate-clusters.yaml` - machine-readable report
 - `validate-clusters.log` - detailed log
 - `validate-clusters.data/` - gathered resources
@@ -304,9 +312,9 @@ The YAML report contains common fields and command-specific data.
 
 **Command-specific field** (`clustersStatus`):
 
-The `clustersStatus` section contains validations for the hub, managed
-clusters, and S3 profiles. Every validated item shows `state: ok ✅` on a
-healthy cluster. The report validates the following:
+The `clustersStatus` section contains validations for the hub, managed clusters,
+and S3 profiles. Every validated item shows `state: ok ✅` on a healthy cluster.
+The report validates the following:
 
 **For each managed cluster:**
 
@@ -334,8 +342,7 @@ healthy cluster. The report validates the following:
   - Condition: `Validated`
   - Associated DR clusters
   - Scheduling interval
-- Ramen configmap (same checks as managed clusters, controller type is
-  `dr-hub`)
+- Ramen configmap (same checks as managed clusters, controller type is `dr-hub`)
 - Ramen deployment (same checks as managed clusters)
 
 **S3 profiles:**
@@ -348,9 +355,8 @@ healthy cluster. The report validates the following:
 tree out/validate-clusters/validate-clusters.data/
 ```
 
-One directory per cluster. Each contains `cluster/` for cluster-scoped
-resources and `namespaces/` for namespaced resources. The general structure
-is:
+One directory per cluster. Each contains `cluster/` for cluster-scoped resources
+and `namespaces/` for namespaced resources. The general structure is:
 
 ```
 <cluster-name>/
@@ -381,13 +387,14 @@ For the validate clusters command:
 
 Open `out/validate-clusters/validate-clusters.html` in a browser.
 
-- Shows the same information in the yaml in a more compact and easier to
-  read form.
+- Shows the same information in the yaml in a more compact and easier to read
+  form.
 - All items show green/ok status.
 
 #### Validate clusters ramen not deployed
 
 **Preconditions:**
+
 - Cluster level: Base clusters (ACM/OCM configured, managed clusters joined).
 - Ramen operators are NOT deployed on any cluster.
 
@@ -398,6 +405,7 @@ odf dr validate clusters -o out/no-ramen
 ```
 
 **Expected result:**
+
 - Command completes without crashing.
 - Report shows problems for missing ramen deployments and configmaps on all
   clusters.
@@ -406,6 +414,7 @@ odf dr validate clusters -o out/no-ramen
 #### Validate clusters ramen not configured
 
 **Preconditions:**
+
 - Cluster level: Ramen deployed.
 - No DRPolicy, DRClusters, or S3 profiles configured on the hub.
 - No S3 store profiles in ramen configmaps on managed clusters.
@@ -417,6 +426,7 @@ odf dr validate clusters -o out/no-config
 ```
 
 **Expected result:**
+
 - Report shows ramen deployments as ok.
 - Report shows problems for missing DRPolicy, DRClusters on the hub.
 - Report shows problems for missing or empty S3 store profiles.
@@ -424,6 +434,7 @@ odf dr validate clusters -o out/no-config
 #### Validate clusters S3 endpoint unreachable
 
 **Preconditions:**
+
 - Cluster level: DR configured.
 - Scale down the S3 endpoint controller (minio in upstream).
 
@@ -434,6 +445,7 @@ odf dr validate clusters -o out/s3-down
 ```
 
 **Expected result:**
+
 - S3 profile check reports a problem.
 - The report shows the S3 profile as not accessible.
 
@@ -442,6 +454,7 @@ odf dr validate clusters -o out/s3-down
 #### Validate clusters missing S3 secret
 
 **Preconditions:**
+
 - Cluster level: DR configured.
 - Delete or rename the S3 secret in one managed cluster's openshift-dr-system
   namespace.
@@ -453,6 +466,7 @@ odf dr validate clusters -o out/secret-problem
 ```
 
 **Expected result:**
+
 - Report shows a problem for the affected S3 profile's secret.
 
 **Cleanup:** Restore the secret.
@@ -460,6 +474,7 @@ odf dr validate clusters -o out/secret-problem
 #### Validate clusters ramen deployment is down
 
 **Preconditions:**
+
 - Cluster level: DR configured.
 - Scale down the ramen-dr-cluster-operator deployment on one managed cluster:
 
@@ -474,6 +489,7 @@ odf dr validate clusters -o out/operator-down
 ```
 
 **Expected result:**
+
 - Console output completes but final summary shows problem count > 0.
 - `validate-clusters.yaml` report shows a non-ok state for the affected
   cluster's deployment.
@@ -489,6 +505,7 @@ oc scale deployment ramen-dr-cluster-operator -n openshift-dr-system --replicas=
 #### Validate healthy application
 
 **Preconditions:**
+
 - Cluster level: Application protected.
 - The application is in a healthy stable state (progression `Completed`).
 
@@ -500,8 +517,9 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/va
 ```
 
 **Expected result:**
-- Console output shows progress: inspected application, gathered data from
-  each cluster, inspected S3 profiles.
+
+- Console output shows progress: inspected application, gathered data from each
+  cluster, inspected S3 profiles.
 - Final line: `Validation completed (N ok, 0 warning, 0 problem)`.
 - Exits with code 0.
 
@@ -531,8 +549,7 @@ The YAML report contains common fields and command-specific data.
 
 The `applicationStatus` section contains validations for the hub, primary
 cluster, secondary cluster, and S3 profiles. Every validated item shows
-`state: ok ✅` on a healthy application. The report validates the
-following:
+`state: ok ✅` on a healthy application. The report validates the following:
 
 **Hub (DRPC):**
 
@@ -574,8 +591,8 @@ following:
 tree out/validate-app/validate-application.data/
 ```
 
-One directory per cluster plus an `s3/` directory. Each cluster directory
-has the same structure as validate clusters. The general structure is:
+One directory per cluster plus an `s3/` directory. Each cluster directory has
+the same structure as validate clusters. The general structure is:
 
 ```
 <cluster-name>/
@@ -612,6 +629,7 @@ For the validate application command:
 #### Validate application during failover
 
 **Preconditions:**
+
 - Cluster level: Application in-progress.
 - Application is during failover; run the validate command about one minute
   after starting the failover.
@@ -624,6 +642,7 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/ap
 ```
 
 **Expected result:**
+
 - Report shows problems in DRPC progression (not `Completed`).
 - VRG conditions may show issues.
 - Problem count > 0 in the summary.
@@ -631,10 +650,11 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/ap
 #### Validate degraded application
 
 **Preconditions:**
+
 - Cluster level: DR configured.
-- Scale down the rbd-mirror daemon on the secondary cluster before
-  protecting the application. Then deploy and protect the application. The
-  protection will get stuck because replication cannot progress.
+- Scale down the rbd-mirror daemon on the secondary cluster before protecting
+  the application. Then deploy and protect the application. The protection will
+  get stuck because replication cannot progress.
 
 **Steps:**
 
@@ -644,8 +664,9 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/ap
 ```
 
 **Expected result:**
-- Report shows problems in protected PVC conditions (protection condition
-  is not true).
+
+- Report shows problems in protected PVC conditions (protection condition is not
+  true).
 - Problem count > 0 in the summary.
 
 **Cleanup:** Restore the rbd-mirror daemon and wait for the application to
@@ -654,6 +675,7 @@ become fully protected.
 #### Validate application missing S3 secret
 
 **Preconditions:**
+
 - Cluster level: Application protected.
 - Delete or rename the S3 secret on one managed cluster.
 
@@ -665,6 +687,7 @@ odf dr validate application --name <drpc-name> --namespace <namespace> -o out/ap
 ```
 
 **Expected result:**
+
 - Gathering S3 application data from the affected profile fails.
 - Report shows a problem for the affected S3 profile's `gathered` field.
 - Problem count > 0 in the summary.
@@ -690,14 +713,15 @@ required.
 odf dr validate application --name nonexistent --namespace default -o out/app-noexist
 ```
 
-**Expected result:** Error indicating the application was not found. Exits
-with non-zero code.
+**Expected result:** Error indicating the application was not found. Exits with
+non-zero code.
 
 ### Gather command
 
 #### Gather application data
 
 **Preconditions:**
+
 - Cluster level: Application protected.
 
 **Steps:**
@@ -708,29 +732,30 @@ odf dr gather application --name <drpc-name> --namespace <namespace> -o out/gath
 ```
 
 **Expected result:**
-- Console shows progress: inspected application, gathered data from each
-  cluster and S3 profiles.
+
+- Console shows progress: inspected application, gathered data from each cluster
+  and S3 profiles.
 - Prints `Gather completed`.
 - Exits with code 0.
 - Output directory contains:
   - `gather-application.yaml` - report
   - `gather-application.log` - detailed log
   - `gather-application.data/` - gathered resources
-- `gather-application.data/` contains directories for hub, each managed
-  cluster, and `s3/`.
+- `gather-application.data/` contains directories for hub, each managed cluster,
+  and `s3/`.
 - Each cluster directory contains the application namespace and
-  `openshift-operators`/`openshift-dr-system`. Ramen operator logs are
-  gathered in `<namespace>/pods/<operator-pod>/manager/`.
-- `s3/` contains one directory per S3 profile with the application's S3
-  data.
+  `openshift-operators`/`openshift-dr-system`. Ramen operator logs are gathered
+  in `<namespace>/pods/<operator-pod>/manager/`.
+- `s3/` contains one directory per S3 profile with the application's S3 data.
 
 #### Gather degraded application
 
 **Preconditions:**
+
 - Cluster level: DR configured.
-- Scale down the rbd-mirror daemon on the secondary cluster before
-  protecting the application. Then deploy and protect the application. The
-  protection will get stuck because replication cannot progress.
+- Scale down the rbd-mirror daemon on the secondary cluster before protecting
+  the application. Then deploy and protect the application. The protection will
+  get stuck because replication cannot progress.
 
 **Steps:**
 
@@ -740,9 +765,10 @@ odf dr gather application --name <drpc-name> --namespace <namespace> -o out/gath
 ```
 
 **Expected result:**
+
 - Gather completes successfully.
-- Gathered data includes ramen operator logs that contain errors related
-  to the replication failure.
+- Gathered data includes ramen operator logs that contain errors related to the
+  replication failure.
 
 **Cleanup:** Restore the rbd-mirror daemon and wait for the application to
 become fully protected.
@@ -768,17 +794,17 @@ odf dr gather application --name nonexistent --namespace default -o out/gather-n
 
 **Expected result:** Error indicating the application was not found.
 
-
 ### Test command
 
 **Preconditions for all tests in this section:**
+
 - Cluster level: DR configured.
 - `config.yaml` configured with correct kubeconfigs, drPolicy, clusterSet,
   storage classes, and test definitions.
 
-> **Important:** Every test must run both `test run` and `test clean`.
-> Skipping `test clean` may leave resources in the clusters and cause false
-> results for subsequent tests.
+> **Important:** Every test must run both `test run` and `test clean`. Skipping
+> `test clean` may leave resources in the clusters and cause false results for
+> subsequent tests.
 
 #### Default application (appset + rbd)
 
@@ -790,6 +816,7 @@ odf dr test clean -o out/test-rbd
 ```
 
 **Expected result:**
+
 - Console shows progress through all DR phases: deployed, protected, failed
   over, relocated, unprotected, undeployed.
 - Final line: `passed (1 passed, 0 failed, 0 skipped)`.
@@ -803,6 +830,7 @@ ls out/test-rbd/
 ```
 
 Expected directory contents:
+
 - `test-run.yaml` - machine-readable test report
 - `test-run.log` - detailed log
 - `test-clean.yaml` - clean report
@@ -821,8 +849,8 @@ Expected: `passed`
 yq '.steps[-1].items.items[].name' < out/test-rbd/test-run.yaml
 ```
 
-Expected: lists the DR phases: `deploy`, `protect`, `failover`,
-`relocate`, `unprotect`, `undeploy`.
+Expected: lists the DR phases: `deploy`, `protect`, `failover`, `relocate`,
+`unprotect`, `undeploy`.
 
 ```bash
 yq '.summary' < out/test-rbd/test-run.yaml
@@ -858,8 +886,8 @@ odf dr test clean -o out/test-disapp
 
 #### Multiple applications
 
-**Preconditions:** Config file has multiple test entries (e.g., appset+rbd
-and subscr+rbd).
+**Preconditions:** Config file has multiple test entries (e.g., appset+rbd and
+subscr+rbd).
 
 **Steps:**
 
@@ -869,12 +897,14 @@ odf dr test clean -o out/test-multi
 ```
 
 **Expected result:**
+
 - Both tests run (may run in parallel).
 - Final line: `passed (2 passed, 0 failed, 0 skipped)`.
 
 #### Failing test
 
 **Preconditions:**
+
 - Config ready. Plan to break rbd-mirror after the `protected` step.
 
 **Steps:**
@@ -886,6 +916,7 @@ odf dr test run -o out/test-fail
 ```
 
 **Expected result:**
+
 - Console shows `❌` for the failing step.
 - Command gathers data from all clusters and S3.
 - Final line: `failed (0 passed, 1 failed, 0 skipped)`.
@@ -898,6 +929,7 @@ ls out/test-fail/
 ```
 
 Expected:
+
 - `test-run.yaml` - report with `status: failed`
 - `test-run.log` - detailed log
 - `test-run.data/` - gathered resources from all clusters and S3
@@ -906,8 +938,8 @@ Expected:
 ls out/test-fail/test-run.data/
 ```
 
-Expected: directories for hub, both managed clusters, and `s3/`
-with data for each S3 profile.
+Expected: directories for hub, both managed clusters, and `s3/` with data for
+each S3 profile.
 
 **YAML report shows failure details:**
 
@@ -916,12 +948,11 @@ yq '.status' < out/test-fail/test-run.yaml
 yq '.steps[-1].items.items[].status' < out/test-fail/test-run.yaml
 ```
 
-Overall status is `failed`. Individual step statuses show which step
-failed.
+Overall status is `failed`. Individual step statuses show which step failed.
 
-**Cleanup:** Restore rbd-mirror first, then clean up test resources.
-Cleaning up before restoring rbd-mirror may fail or time out and leave
-leftovers in the clusters.
+**Cleanup:** Restore rbd-mirror first, then clean up test resources. Cleaning up
+before restoring rbd-mirror may fail or time out and leave leftovers in the
+clusters.
 
 ```bash
 # Restore rbd-mirror on c1:
@@ -939,6 +970,7 @@ odf dr test run -o out/test-cancel
 ```
 
 **Expected result:**
+
 - Command stops gracefully after completing or timing out the current step.
 - `test-run.yaml` is written with partial results.
 - Does NOT gather data for incomplete tests.
@@ -966,10 +998,10 @@ oc get ns test-gitops --context hub
 ```
 
 **Expected result:**
+
 - Console shows applications being unprotected and undeployed.
 - Environment cleaned.
 - Final line: `passed (1 passed, 0 failed, 0 skipped)`.
 - No test-related DRPC resources or namespaces remain in any cluster.
-- The channel `https-github-com-ramendr-ocm-ramen-samples-git` and
-  namespace `test-gitops` are deleted from the hub.
-
+- The channel `https-github-com-ramendr-ocm-ramen-samples-git` and namespace
+  `test-gitops` are deleted from the hub.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # Testing disaster recovery with ramenctl
 
@@ -33,7 +35,8 @@ simple application and test real disaster recovery flow. The *ramenctl* command
 makes this task easy.
 
 > [!TIP]
-> When working with ODF clusters, use the `odf dr` command instead of `ramenctl`.
+> When working with ODF clusters, use the `odf dr` command instead of
+> `ramenctl`.
 
 ## Environment
 
@@ -45,8 +48,8 @@ configured for Regional DR.
 
 ## Preparing a configuration file
 
-This section describes how to prepare a configuration file for your clusters
-and run a disaster recovery test.
+This section describes how to prepare a configuration file for your clusters and
+run a disaster recovery test.
 
 `ramenctl` uses a configuration file to access the clusters and the related
 resources needed for testing. To create the configuration file run:
@@ -110,8 +113,8 @@ pvcSpecs:
 ```
 
 > [!TIP]
-> You can add more pvcSpecs for testing other storage classes as needed.
-> Modify the test to refer to your own pvcSpec names.
+> You can add more pvcSpecs for testing other storage classes as needed. Modify
+> the test to refer to your own pvcSpec names.
 
 ### Configuring tests
 
@@ -131,13 +134,13 @@ The available options are:
   - `subscr`: OCM managed application deployed using *Subscription*.
   - `disapp`: OCM discovered application deployed by the test command.
   - `disapp-recipe`: OCM discovered application deployed using recipe without
-   any hooks by the test command.
-  - `disapp-recipe-check`: OCM discovered application deployed using recipe
-   with check hooks by the test command.
-  - `disapp-recipe-exec`: OCM discovered application deployed using recipe
-   with exec hooks by the test command.
-  - `disapp-recipe-check-exec`: OCM discovered application deployed using
-   recipe with check and exec hooks by the test command.
+    any hooks by the test command.
+  - `disapp-recipe-check`: OCM discovered application deployed using recipe with
+    check hooks by the test command.
+  - `disapp-recipe-exec`: OCM discovered application deployed using recipe with
+    exec hooks by the test command.
+  - `disapp-recipe-check-exec`: OCM discovered application deployed using recipe
+    with check and exec hooks by the test command.
 - pvcSpecs:
   - `rbd`: *Ceph* *RBD* storage
   - `cephfs`: *CephFS* storage
@@ -185,13 +188,13 @@ ramenctl-test
 ```
 
 > [!IMPORTANT]
-> When reporting DR related issues, please create an archive with the
-> output directory and upload it to the issue tracker.
+> When reporting DR related issues, please create an archive with the output
+> directory and upload it to the issue tracker.
 
 ### The test-run.yaml
 
-The test-run.yaml is a machine and human readable description of the the
-test run:
+The test-run.yaml is a machine and human readable description of the the test
+run:
 
 ```yaml
 build:
@@ -334,8 +337,8 @@ $ ramenctl test clean -o ramenctl-test
 ✅ passed (1 passed, 0 failed, 0 skipped)
 ```
 
-The clean command adds `test-clean.log` and `test-clean.yaml` to the
-output directory:
+The clean command adds `test-clean.log` and `test-clean.yaml` to the output
+directory:
 
 ```console
 $ tree ramenctl-test
@@ -349,8 +352,8 @@ ramenctl-test
 ## Failed tests
 
 When a test fails, the test command gathers data related to the failed tests in
-the output directory. The gathered data can help you or developers to diagnose the
-issue.
+the output directory. The gathered data can help you or developers to diagnose
+the issue.
 
 The following example shows a test run with a failed test, and how to inspect
 the failure.
@@ -410,8 +413,8 @@ example-failure
 ### Inspecting gathered data
 
 The command gathers all the namespaces related to the failed test, related
-cluster scope resources such as storage classes and persistent volumes, and
-S3 data stored by ramen for the failed applications.
+cluster scope resources such as storage classes and persistent volumes, and S3
+data stored by ramen for the failed applications.
 
 ```console
 $ tree -L3 example-failure/test-run.data

--- a/docs/user-interface.md
+++ b/docs/user-interface.md
@@ -76,8 +76,8 @@ resources.
 - *ApplicationSet based application*: All DRPCs are located in the GitOps
   namespace on the hub, and must be unique. We only need the DRPC name.
 
-- *OCM discovered application*: All DRPCs are located in the Ramen Ops
-  namespace and must be unique. We need only the DRPC name.
+- *OCM discovered application*: All DRPCs are located in the Ramen Ops namespace
+  and must be unique. We need only the DRPC name.
 
 ### test
 

--- a/docs/validate.md
+++ b/docs/validate.md
@@ -1,5 +1,7 @@
-<!-- SPDX-FileCopyrightText: The RamenDR authors -->
-<!-- SPDX-License-Identifier: Apache-2.0 -->
+<!--
+SPDX-FileCopyrightText: The RamenDR authors
+SPDX-License-Identifier: Apache-2.0
+-->
 
 # ramenctl validate
 
@@ -30,13 +32,13 @@ Use "ramenctl validate [command] --help" for more information about a command.
 
 The command supports the following sub-commands:
 
-* [application](#validate-application)
-* [clusters](#validate-clusters)
+- [application](#validate-application)
+- [clusters](#validate-clusters)
 
 > [!IMPORTANT]
 > The validate command requires a configuration file. See
-> [Configuring common options](docs/init.md#configuring-common-options)
-> to learn how to create one.
+> [Configuring common options](docs/init.md#configuring-common-options) to learn
+> how to create one.
 
 ## validate application
 
@@ -199,7 +201,8 @@ applicationStatus:
 This directory contains all data gathered during validation. The data depend on
 the application deployment type. Use the gathered data to investigate the
 problems reported in the `validate-application.yaml` report. Secrets in the
-gathered data are automatically [sanitized](https://github.com/nirs/kubectl-gather#secret-sanitization).
+gathered data are automatically
+[sanitized](https://github.com/nirs/kubectl-gather#secret-sanitization).
 
 ```console
 $ tree -L3 out/validate-application.data
@@ -662,5 +665,5 @@ out/validate-clusters.data
 ### The validate-clusters.log
 
 This log includes detailed information that may help to troubleshoot the
-validate clusters command. If the command failed, check the error details in
-the log.
+validate clusters command. If the command failed, check the error details in the
+log.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+mdformat
+mdformat-gfm
+mdformat-gfm-alerts


### PR DESCRIPTION
## Summary

Add automatic markdown formatting with mdformat, matching the setup merged in
RamenDR/ramen#2546.

- Add `mdformat` and `mdformat-gfm` via `requirements.txt`
- Add `.mdformat.toml` with `wrap = 80`
- Extend `make fmt` to format tracked `*.md` files
- Add a `Markdown Format` CI job that runs `mdformat --check`
- Format all existing markdown files

Fixes #462

## Test plan

- [x] `make fmt` formats markdown without errors
- [x] CI `Markdown Format` job passes
- [x] Introduce bad formatting in a `.md` file and confirm CI fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reformatted all project documentation with standardized Markdown formatting to improve consistency and readability across guides.

* **Chores**
  * Enhanced build process with automated documentation formatting checks and updated tooling dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->