### PR TITLE
deps: Update ramendr/ramen/e2e to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.13.0
 	github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30
-	github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780
+	github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.19.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf5Kg+u05Q/0klUEDTVT27kKc2/9LeLI=
 github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
-github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780 h1:6TJ2D6N8sfFYWXXTyzkLQg7nBFu0yNYZdGmnRkhcOOU=
-github.com/ramendr/ramen/e2e v0.0.0-20260303090636-b77204c8e780/go.mod h1:BhAPwG+WRu/nJ3Qr9BM+pEMNu6N4QYGftCczD8QWsHk=
+github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd h1:hvmEEqELXO8+EP5QzqmYhokIbN6axKuF/K0DfShS0fk=
+github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd/go.mod h1:S/3Q5edMqSZtE09pbGIh5SoOqY4EoAZAswKmhgA7Jsc=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=

--- a/pkg/test/context.go
+++ b/pkg/test/context.go
@@ -5,7 +5,6 @@ package test
 
 import (
 	"context"
-	"fmt"
 	stdtime "time"
 
 	e2econfig "github.com/ramendr/ramen/e2e/config"
@@ -25,8 +24,12 @@ type Context struct {
 
 var _ types.TestContext = &Context{}
 
-func newContext(parent types.Context, workload types.Workload, deployer types.Deployer) *Context {
-	name := fmt.Sprintf("%s-%s", deployer.GetName(), workload.GetName())
+func newContext(
+	parent types.Context,
+	name string,
+	workload types.Workload,
+	deployer types.Deployer,
+) *Context {
 	return &Context{
 		parent:   parent,
 		context:  parent.Context(),

--- a/pkg/test/test.go
+++ b/pkg/test/test.go
@@ -52,7 +52,7 @@ func newTest(tc e2econfig.Test, cmd *Command) *Test {
 	}
 
 	return &Test{
-		Context: newContext(cmd, workload, deployer),
+		Context: newContext(cmd, tc.ContextName(), workload, deployer),
 		Backend: cmd.backend,
 		Status:  report.Passed,
 	}


### PR DESCRIPTION
To consume https://github.com/RamenDR/ramen/pull/2635, fixing validation for applications created by ramenctl test.

This version also supports running multiple instances of the same
workload https://github.com/RamenDR/ramen/pull/2542.

To use this version we must modify the test package to use the test
ContextName() for the test.Context. Otherwise multiple instances will be
allowed but they use the same application name.

With this change we can run multiple instances of the same workload by
specifying the name of the workload.

## Example config

```yaml
tests:
- name: multi-1
  workload: deploy
  deployer: appset
  pvcSpec: rbd
- name: multi-2
  workload: deploy
  deployer: appset
  pvcSpec: rbd
```

## Example run

```console
% ramenctl test run -c demo/config.yaml -o out/multi     
⭐ Using config "demo/config.yaml"
⭐ Using report "out/multi"

🔎 Validate config ...
   ✅ Config validated

🔎 Setup environment ...
   ✅ Environment setup

🔎 Run tests ...
   ✅ Application "multi-2" deployed
   ✅ Application "multi-1" deployed
   ✅ Application "multi-1" protected
   ✅ Application "multi-2" protected
   ✅ Application "multi-2" failed over
   ✅ Application "multi-1" failed over
   ✅ Application "multi-1" relocated
   ✅ Application "multi-2" relocated
   ✅ Application "multi-1" unprotected
   ✅ Application "multi-1" undeployed
   ✅ Application "multi-2" unprotected
   ✅ Application "multi-2" undeployed

✅ Test run passed (2 passed, 0 failed, 0 skipped, 0 canceled)
```

## Issues

- Multiple instances support is not documented yet, we need to improve this later.

Fixes: #473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a project dependency to a newer version.
* **Refactor**
  * Improved how internal test contexts are named, making context creation more explicit and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->