### PR TITLE
deps: Updated ramendr/ramen/{e2e,api} to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,8 +15,8 @@ require (
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/go-logr/zapr v1.3.0
 	github.com/nirs/kubectl-gather v0.13.0
-	github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30
-	github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd
+	github.com/ramendr/ramen/api v0.0.0-20260708142616-0e17c0d9913e
+	github.com/ramendr/ramen/e2e v0.0.0-20260708142616-0e17c0d9913e
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.19.0
 	github.com/yosssi/gohtml v0.0.0-20201013000340-ee4748c638f4

--- a/go.sum
+++ b/go.sum
@@ -235,10 +235,10 @@ github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ
 github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
-github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30 h1:q6ci5ht39oiDf5Kg+u05Q/0klUEDTVT27kKc2/9LeLI=
-github.com/ramendr/ramen/api v0.0.0-20260302102746-0080ff0b2f30/go.mod h1:G3q4wmHUdOVefjCKSacg3McDodLwtfFe84wSrGxQ69w=
-github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd h1:hvmEEqELXO8+EP5QzqmYhokIbN6axKuF/K0DfShS0fk=
-github.com/ramendr/ramen/e2e v0.0.0-20260701090316-2fa150b226dd/go.mod h1:S/3Q5edMqSZtE09pbGIh5SoOqY4EoAZAswKmhgA7Jsc=
+github.com/ramendr/ramen/api v0.0.0-20260708142616-0e17c0d9913e h1:FZoq+A+9bjPYBvE30LlpNB6Z0EIMDf/5zQw3ZfoAxvk=
+github.com/ramendr/ramen/api v0.0.0-20260708142616-0e17c0d9913e/go.mod h1:OcpEzl0uLzjiZ4WiYEhWND5oCqxekFfbLZ2MRlodLMI=
+github.com/ramendr/ramen/e2e v0.0.0-20260708142616-0e17c0d9913e h1:6Ltp1S+cFmVltBk66Bl23X+dyCeFSrLyvcLTupYZZ8s=
+github.com/ramendr/ramen/e2e v0.0.0-20260708142616-0e17c0d9913e/go.mod h1:S/3Q5edMqSZtE09pbGIh5SoOqY4EoAZAswKmhgA7Jsc=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567 h1:QRcHe6GTJAgLK7zgF6ivwZ6B0SFe1tONbA7VMQMWjMM=
 github.com/ramendr/recipe v0.0.0-20250507125257-0295a01da567/go.mod h1:dGXrk743fq6VG8u6lflEce7ITM7d/9xSBeAbI2RXl9s=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=


### PR DESCRIPTION
Updating the e2e module for fixing the way we delete namespace during purge. Updating the api module for consistency, so we depend on the same version of the ramen modules.

With this change, when running with fixed ramen version, `test clean` will not time out waiting for deleted namespaces recreated by ocm.

With broken ramen that does not delete the namespace manifestwork, `test clean` may still time out.

Fixes: #478