### PR TITLE
validate: filter unknown VRG conditions

### DIFF
--- a/pkg/ramen/ramen.go
+++ b/pkg/ramen/ramen.go
@@ -23,6 +23,14 @@ import (
 )
 
 const (
+	// Known VRG condition types that ramenctl validates.
+	// https://github.com/RamenDR/ramen/blob/ca0d1e2ab23a86a9706893b5635ed83c6bc4ecc2/internal/controller/status.go
+	VRGConditionTypeDataReady             = "DataReady"
+	VRGConditionTypeClusterDataReady      = "ClusterDataReady"
+	VRGConditionTypeKubeObjectsReady      = "KubeObjectsReady"
+	VRGConditionTypeClusterDataProtected  = "ClusterDataProtected"
+	VRGConditionTypeNoClusterDataConflict = "NoClusterDataConflict"
+
 	// PV data is protected. This means that, the PV data from the storage
 	// is in complete sync with its remote peer.
 	// https://github.com/RamenDR/ramen/blob/eebc5c0cb46af2eea145e7d40feef09681f6b110/internal/controller/status.go#L25
@@ -93,6 +101,17 @@ const (
 // Actions are the valid DRPC and VRG actions.
 // NOTE: ramen uses different type for vrg actions with the same values.
 var Actions = []string{"", string(ramenapi.ActionFailover), string(ramenapi.ActionRelocate)}
+
+// knownVRGConditionTypes are VRG conditions that ramenctl knows how to
+// validate. Unknown conditions are filtered out to avoid breaking validation
+// when ramen adds new conditions.
+var knownVRGConditionTypes = map[string]struct{}{
+	VRGConditionTypeDataReady:             {},
+	VRGConditionTypeClusterDataReady:      {},
+	VRGConditionTypeKubeObjectsReady:      {},
+	VRGConditionTypeClusterDataProtected:  {},
+	VRGConditionTypeNoClusterDataConflict: {},
+}
 
 type Context interface {
 	Env() *e2etypes.Env
@@ -378,6 +397,12 @@ func ParseRamenConfig(configMap *corev1.ConfigMap) (*ramenapi.RamenConfig, error
 		return nil, fmt.Errorf("failed to parse %q: %w", ConfigMapRamenConfigKeyName, err)
 	}
 	return config, nil
+}
+
+// IsKnownVRGCondition returns true if the condition type is known to ramenctl.
+func IsKnownVRGCondition(conditionType string) bool {
+	_, known := knownVRGConditionTypes[conditionType]
+	return known
 }
 
 // getRamenConfigMapData reads and parses the ramen operator configmap data.

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -813,7 +813,7 @@ func (c *Command) validatedVRGConditions(
 			continue
 		}
 		// DataProtected behaves differently for volrep and volsync. Since a workload can have both
-		// volsync protected pvcs and volrep protected pvcs we seem to have now way to validate this
+		// volsync protected pvcs and volrep protected pvcs we seem to have no way to validate this
 		// condition.
 		if condition.Type == ramen.VRGConditionTypeDataProtected {
 			continue

--- a/pkg/validate/application/command.go
+++ b/pkg/validate/application/command.go
@@ -818,6 +818,10 @@ func (c *Command) validatedVRGConditions(
 		if condition.Type == ramen.VRGConditionTypeDataProtected {
 			continue
 		}
+		if !ramen.IsKnownVRGCondition(condition.Type) {
+			c.Logger().Warnf("Skipping validation for unknown VRG condition: %+v", *condition)
+			continue
+		}
 		validated := validatecmd.ValidatedCondition(vrg, condition, metav1.ConditionTrue)
 		summary.AddValidation(c.Report.Summary, &validated)
 		conditions = append(conditions, validated)

--- a/pkg/validate/application/command_validated_test.go
+++ b/pkg/validate/application/command_validated_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	stdtime "time"
 
@@ -767,6 +768,146 @@ func TestValidateLastGroupSyncTime(t *testing.T) {
 			&syncTime, &clusterTime, schedulingInterval, true)
 		if !validated.Equal(&expected) {
 			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+}
+
+func TestValidatedVRGConditions(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status: ramenapi.VolumeReplicationGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "DataReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Ready",
+					},
+					{
+						Type:               "ClusterDataReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Restored",
+					},
+					{
+						Type:               "KubeObjectsReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "KubeObjectsRestored",
+					},
+					{
+						Type:               "ClusterDataProtected",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Uploaded",
+					},
+					{
+						Type:               "NoClusterDataConflict",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "NoConflictDetected",
+					},
+				},
+			},
+		}
+
+		expected := []report.ValidatedCondition{
+			{Validated: report.Validated{State: report.OK}, Type: "DataReady"},
+			{Validated: report.Validated{State: report.OK}, Type: "ClusterDataReady"},
+			{Validated: report.Validated{State: report.OK}, Type: "KubeObjectsReady"},
+			{Validated: report.Validated{State: report.OK}, Type: "ClusterDataProtected"},
+			{Validated: report.Validated{State: report.OK}, Type: "NoClusterDataConflict"},
+		}
+		validated := cmd.validatedVRGConditions(vrg)
+		if !slices.Equal(validated, expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("skip unknown conditions", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status: ramenapi.VolumeReplicationGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "DataReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Ready",
+					},
+					{
+						Type:               "HooksReady",
+						Status:             metav1.ConditionUnknown,
+						ObservedGeneration: 1,
+						Reason:             "Initializing",
+					},
+				},
+			},
+		}
+
+		expected := []report.ValidatedCondition{
+			{Validated: report.Validated{State: report.OK}, Type: "DataReady"},
+		}
+		validated := cmd.validatedVRGConditions(vrg)
+		if !slices.Equal(validated, expected) {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, expected, validated))
+		}
+	})
+
+	t.Run("skip unused conditions", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status: ramenapi.VolumeReplicationGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "DataReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Unused",
+					},
+					{
+						Type:               "ClusterDataReady",
+						Status:             metav1.ConditionTrue,
+						ObservedGeneration: 1,
+						Reason:             "Unused",
+					},
+				},
+			},
+		}
+
+		validated := cmd.validatedVRGConditions(vrg)
+		if len(validated) != 0 {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, nil, validated))
+		}
+	})
+
+	t.Run("skip data protected", func(t *testing.T) {
+		cmd := testCommand(t, &helpers.ValidationMock{}, testK8s)
+
+		vrg := &ramenapi.VolumeReplicationGroup{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+			Status: ramenapi.VolumeReplicationGroupStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               "DataProtected",
+						Status:             metav1.ConditionFalse,
+						ObservedGeneration: 1,
+						Reason:             "Replicating",
+					},
+				},
+			},
+		}
+
+		validated := cmd.validatedVRGConditions(vrg)
+		if len(validated) != 0 {
+			t.Fatalf("unexpected result\n%s", helpers.UnifiedDiff(t, nil, validated))
 		}
 	})
 }


### PR DESCRIPTION
Ramen can add new VRG conditions (e.g. HooksReady) that ramenctl does not know how to validate. Previously, all conditions were validated and expected to be True, causing validation to fail when ramen adds a new condition with unexpected status.

Change VRG condition validation from opt-out to opt-in. Only conditions that ramenctl knows how to validate are checked: DataReady, ClusterDataReady, KubeObjectsReady,
ClusterDataProtected, and NoClusterDataConflict. Unknown conditions are logged.

Testing:

Tested validate application on all types of application:
```
./ramenctl validate application --namespace ramen-ops --name disapp-deploy-rbd --output out/v_app_filter1
⭐ Using config "config.yaml"
⭐ Using report "out/v_app_filter1"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (30 ok, 0 warning, 0 problem)

./ramenctl validate application --namespace argocd --name appset-deploy-rbd --output out/v_app_filter2
⭐ Using config "config.yaml"
⭐ Using report "out/v_app_filter2"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (30 ok, 0 warning, 0 problem)

 ./ramenctl validate application --namespace test-subscr-deploy-rbd --name subscr-deploy-rbd --output out/v_app_fil3
⭐ Using config "config.yaml"
⭐ Using report "out/v_app_fil3"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr1"
   ✅ Gathered data from cluster "dr2"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (30 ok, 0 warning, 0 problem)

./ramenctl validate application --namespace ramen-ops --name disapp-recipe-check-exec-deploy-rbd --output out/v_app_fil4
⭐ Using config "config.yaml"
⭐ Using report "out/v_app_fil4"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (30 ok, 0 warning, 0 problem)
```

Report:
```
  primaryCluster:
    name: dr1
    vrg:
      clusterTime: "2026-07-15T07:45:51Z"
      conditions:
      - state: ok ✅
        type: DataReady
      - state: ok ✅
        type: ClusterDataReady
      - state: ok ✅
        type: KubeObjectsReady
      - state: ok ✅
        type: ClusterDataProtected
      - state: ok ✅
        type: NoClusterDataConflict
      deleted:
        state: ok ✅
      lastGroupSyncTime:
        state: ok ✅
        value: "2026-07-15T07:44:00Z"
      name: disapp-deploy-rbd
      namespace: ramen-ops
      protectedPVCs:
      - conditions:
        - state: ok ✅
          type: DataReady
        - state: ok ✅
          type: ClusterDataProtected
        deleted:
          state: ok ✅
        name: busybox-pvc
        namespace: test-disapp-deploy-rbd
        phase:
          state: ok ✅
          value: Bound
        replication: volrep
      schedulingInterval:
        state: ok ✅
        value: 1m0s
      state:
        state: ok ✅
        value: Primary
```

warn log:
```
2026-07-15T13:15:53.690+0530	DEBUG	application/command.go:502	Read vrg "ramen-ops/disapp-deploy-rbd" from cluster "dr1"
2026-07-15T13:15:53.690+0530	WARN	application/command.go:822	Skipping validation for unknown VRG condition: {Type:HooksReady Status:Unknown ObservedGeneration:1 LastTransitionTime:2026-07-15 13:06:03 +0530 IST Reason:Initializing Message:Initializing VolumeReplicationGroup}
2026-07-15T13:15:53.691+0530	DEBUG	application/command.go:502	Read vrg "ramen-ops/disapp-deploy-rbd" from cluster "dr2"
2026-07-15T13:15:53.691+0530	WARN	application/command.go:822	Skipping validation for unknown VRG condition: {Type:HooksReady Status:Unknown ObservedGeneration:1 LastTransitionTime:2026-07-15 13:06:32 +0530 IST Reason:Initializing Message:Initializing VolumeReplicationGroup}
```
[val_app_fil.tar.gz](https://github.com/user-attachments/files/30043775/val_app_fil.tar.gz)


Fixes #475 
