### PR TITLE
ci: add go-compatibility job to enforce minimum go version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -109,6 +109,31 @@ jobs:
           retention-days: 15
           compression-level: 9
 
+  go-compatibility:
+    name: Go compatibility
+    runs-on: ubuntu-24.04
+    env:
+      GOTOOLCHAIN: local
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Extract go version
+        id: go-version
+        run: |
+          version=$(awk '/^go [0-9]/ {print $2}' go.mod)
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - name: Setup go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          # We cannot use go-version-file since in v6 it picks the toolchain
+          # version instead of go version, ignoring GOTOOLCHAIN=local.
+          go-version: ${{ steps.go-version.outputs.version }}
+          cache: false
+      - name: Build ramenctl
+        run: make
+
   test-matrix:
     name: Test
     strategy:


### PR DESCRIPTION
## Problem

The current CI uses `actions/setup-go@v6` with `go-version-file`, which
automatically picks the version from the `toolchain` directive in `go.mod`
instead of the `go` directive.

While this provides a modern development environment, it can mask
"standard library leakage" — cases where code uses features from a
newer Go version that are not actually available in the minimum
supported `go` version declared in `go.mod`. Since CI silently builds
with the newer toolchain version, this kind of incompatibility goes
undetected until a downstream consumer builds the project with only
the minimum supported Go version installed.

## Solution

Added a dedicated `go-compatibility` job to the test workflow that:

- Extracts the minimum required Go version from the `go` directive in
  `go.mod` (not the `toolchain` directive).
- Sets `GOTOOLCHAIN=local` so Go cannot silently download/switch to a
  newer toolchain during the build.
- Installs that exact minimum version via `actions/setup-go@v6`.
- Builds the project against it, so the build fails if any code
  references symbols or language features not available in the
  declared minimum Go version.

This mirrors the same approach already added in the `ramen` repo:
https://github.com/RamenDR/ramen/pull/2499

Fixes #411