### PR TITLE
go: Update toolchain to go1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ module github.com/ramendr/ramenctl
 go 1.25.0
 
 // Recommended version: latest go release.
-toolchain go1.26.2
+toolchain go1.26.5
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5


### PR DESCRIPTION
Created using:

    go get toolchain@1.26.5