### PR TITLE
s3: paginate and download objects together

### DIFF
--- a/pkg/s3/s3.go
+++ b/pkg/s3/s3.go
@@ -235,46 +235,11 @@ func newObjectStore(
 func (s *objectStore) downloadObjects(ctx context.Context, prefix, outputDir string) error {
 	start := time.Now()
 
-	keys, err := s.listObjects(ctx, prefix)
-	if err != nil {
-		return err
-	}
-
-	if len(keys) == 0 {
-		return fmt.Errorf("no objects found in bucket %q for prefix %q",
-			s.profile.Bucket, prefix)
-	}
-
 	profileDir := filepath.Join(outputDir, dirName, s.profile.Name)
 	if err := os.MkdirAll(profileDir, dirPerm); err != nil {
 		return fmt.Errorf("failed to create directory %q for prefix %q: %w",
 			profileDir, prefix, err)
 	}
-
-	var failed int
-	for _, key := range keys {
-		if err := s.downloadObject(ctx, key, profileDir); err != nil {
-			s.log.Warnf("Failed to download object %q from bucket %q: %v",
-				key, s.profile.Bucket, err)
-			failed++
-			continue
-		}
-	}
-
-	if failed > 0 {
-		return fmt.Errorf("failed to download %d of %d objects from bucket %q",
-			failed, len(keys), s.profile.Bucket)
-	}
-
-	s.log.Debugf("Downloaded %d objects from bucket %q in %.3f seconds",
-		len(keys), s.profile.Bucket, time.Since(start).Seconds())
-
-	return nil
-}
-
-// listObjects returns all object keys under the given prefix.
-func (s *objectStore) listObjects(ctx context.Context, prefix string) ([]string, error) {
-	start := time.Now()
 
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.profile.Bucket),
@@ -287,24 +252,40 @@ func (s *objectStore) listObjects(ctx context.Context, prefix string) ([]string,
 
 	paginator := s3.NewListObjectsV2Paginator(s.client, input)
 
-	var keys []string
+	var total, failed int
 	for paginator.HasMorePages() {
 		page, err := paginator.NextPage(ctx)
 		if err != nil {
 			s.log.Warnf("Failed to list objects in bucket %q with prefix %q: %v",
 				s.profile.Bucket, prefix, err)
-			return nil, fmt.Errorf("failed to list objects in bucket %q with prefix %q",
+			return fmt.Errorf("failed to list objects in bucket %q with prefix %q",
 				s.profile.Bucket, prefix)
 		}
 		for _, obj := range page.Contents {
-			keys = append(keys, *obj.Key)
+			total++
+			if err := s.downloadObject(ctx, *obj.Key, profileDir); err != nil {
+				s.log.Warnf("Failed to download object %q from bucket %q: %v",
+					*obj.Key, s.profile.Bucket, err)
+				failed++
+				continue
+			}
 		}
 	}
 
-	s.log.Debugf("Listed %d objects in bucket %q with prefix %q in %.3f seconds",
-		len(keys), s.profile.Bucket, prefix, time.Since(start).Seconds())
+	if total == 0 {
+		return fmt.Errorf("no objects found in bucket %q for prefix %q",
+			s.profile.Bucket, prefix)
+	}
 
-	return keys, nil
+	if failed > 0 {
+		return fmt.Errorf("failed to download %d of %d objects from bucket %q",
+			failed, total, s.profile.Bucket)
+	}
+
+	s.log.Debugf("Downloaded %d objects from bucket %q in %.3f seconds",
+		total, s.profile.Bucket, time.Since(start).Seconds())
+
+	return nil
 }
 
 // downloadObject downloads and decompresses an object from S3 store.


### PR DESCRIPTION
Previously, downloadObjects called listObjects which collected all object keys into a slice across all pages, then iterated the slice to download each object. For large applications with many S3 objects, this used unnecessary memory and delayed downloading until all keys were listed.
Merge the pagination into downloadObjects directly list a page, download those objects, move to the next page. This eliminates the listObjects function, reduces memory usage, and starts downloading sooner.

Testing:

gather application:
```
./ramenctl gather application --name appset-deploy-rbd --namespace argocd -o out/gather_app
⭐ Using config "config.yaml"
⭐ Using report "out/gather_app"

🔎 Validate config ...
   ✅ Config validated

🔎 Gather application data ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"

✅ Gather completed

tree -L6 out/gather_app/gather-application.data/s3
out/gather_app/gather-application.data/s3
├── minio-on-dr1
│   └── test-appset-deploy-rbd
│       └── appset-deploy-rbd
│           ├── v1.PersistentVolume
│           │   └── pvc-87863165-982d-468e-a717-3b8bd98f0e59
│           ├── v1.PersistentVolumeClaim
│           │   └── test-appset-deploy-rbd
│           │       └── busybox-pvc
│           └── v1alpha1.VolumeReplicationGroup
│               └── a
└── minio-on-dr2
    └── test-appset-deploy-rbd
        └── appset-deploy-rbd
            ├── v1.PersistentVolume
            │   └── pvc-87863165-982d-468e-a717-3b8bd98f0e59
            ├── v1.PersistentVolumeClaim
            │   └── test-appset-deploy-rbd
            │       └── busybox-pvc
            └── v1alpha1.VolumeReplicationGroup
                └── a

15 directories, 6 files
```
validate application:
```
./ramenctl validate application --namespace ramen-ops --name disapp-deploy-rbd --output out/v_app
⭐ Using config "config.yaml"
⭐ Using report "out/v_app"

🔎 Validate config ...
   ✅ Config validated

🔎 Validate application ...
   ✅ Inspected application
   ✅ Gathered data from cluster "hub"
   ✅ Gathered data from cluster "dr2"
   ✅ Gathered data from cluster "dr1"
   ✅ Inspected S3 profiles
   ✅ Gathered S3 profile "minio-on-dr1"
   ✅ Gathered S3 profile "minio-on-dr2"
   ✅ Application validated

✅ Validation completed (30 ok, 0 warning, 0 problem)

tree -L6 out/v_app/validate-application.data/s
3
out/v_app/validate-application.data/s3
├── minio-on-dr1
│   └── ramen-ops
│       └── disapp-deploy-rbd
│           ├── kube-objects
│           │   └── 1
│           │       └── velero
│           ├── v1.PersistentVolume
│           │   └── pvc-4cbf89b7-b31a-4f3b-8d30-b3075e6468fa
│           ├── v1.PersistentVolumeClaim
│           │   └── test-disapp-deploy-rbd
│           │       └── busybox-pvc
│           └── v1alpha1.VolumeReplicationGroup
│               └── a
└── minio-on-dr2
    └── ramen-ops
        └── disapp-deploy-rbd
            ├── kube-objects
            │   └── 1
            │       └── velero
            ├── v1.PersistentVolume
            │   └── pvc-4cbf89b7-b31a-4f3b-8d30-b3075e6468fa
            ├── v1.PersistentVolumeClaim
            │   └── test-disapp-deploy-rbd
            │       └── busybox-pvc
            └── v1alpha1.VolumeReplicationGroup
                └── a

21 directories, 6 files
```

Fixes #489 