### PR TITLE
ci: Fail the build when go.mod is not tidy

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,24 @@ jobs:
       - name: Check markdown formatting
         run: git ls-files -z '*.md' | xargs -0 mdformat --check
 
+  tidy:
+    name: Go Mod Tidy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Setup go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version-file: go.mod
+          cache: false
+      - name: Check go modules are tidy
+        run: |
+          go mod tidy
+          git --no-pager diff --exit-code
+
   build-matrix:
     name: Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add a CI job that runs `go mod tidy` and fails if `go.mod` or `go.sum` would change. The diff is shown in the job log so module drift is easy to spot before it lands.

This keeps the module files tidy on every change and avoids unrelated tidy churn showing up in later PRs.

Fixes #412