### PR TITLE
ci: run lint on all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # CRLF conversion).
 *.tmpl text eol=lf
 *.html text eol=lf
+*.go text eol=lf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,11 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
Fixes #191

Runs the lint job on Linux, Windows, and macOS. The Windows run on #498 confirmed that Git's native checkout converts all Go sources to CRLF; `golangci-lint` showed only three files because its default `max-same-issues` limit is 3. The Go attribute keeps formatter input consistent while still exercising the Windows toolchain.

Recovery note: #498 was auto-closed after I accidentally amended from shallow history and briefly force-pushed an unrelated root commit. I restored the branch to the correct single commit and two-file diff. Sorry for the churn.

Tests:

- `golangci-lint run` (0 issues)
- `go test ./...`
- CRLF checkout simulation followed by `golangci-lint fmt --diff` (clean)
- `git diff --check`
