### PR TITLE
ci: run lint on all platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 # CRLF conversion).
 *.tmpl text eol=lf
 *.html text eol=lf
+*.go text eol=lf

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,11 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.runner }}
     steps:
       - name: Checkout source
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3


### PR DESCRIPTION
- run the Go lint job on Ubuntu, Windows, and macOS
- use the -latest runner aliases on every platform

Fixes #191